### PR TITLE
drop unnecessary coerce

### DIFF
--- a/src/components/MessageSimple.js
+++ b/src/components/MessageSimple.js
@@ -496,7 +496,7 @@ export class MessageSimple extends PureComponent {
               <React.Fragment>
                 {this.renderOptions()}
                 {/* if reactions show them */}
-                {hasReactions > 0 && !this.state.showDetailedReactions && (
+                {hasReactions && !this.state.showDetailedReactions && (
                   <ReactionsList
                     reactions={message.latest_reactions}
                     reaction_counts={message.reaction_counts}
@@ -570,7 +570,7 @@ export class MessageSimple extends PureComponent {
                   )}
 
                   {/* if reactions show them */}
-                  {hasReactions > 0 && !this.state.showDetailedReactions && (
+                  {hasReactions && !this.state.showDetailedReactions && (
                     <ReactionsList
                       reactions={message.latest_reactions}
                       reaction_counts={message.reaction_counts}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Variable(`hasReactions`) is already a boolean
there is no need to coerce into number to compare.