### PR TITLE
detect react version to silence eslint warning for react

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,11 @@
       "modules": true
     }
   },
-
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
   "overrides": [
     {
       "files": ["*.md"],


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
`eslint-plugin-react` requires `react` version for some rules. Right now, it shows a warning since its version isn't set in the config. By setting `detect` in `eslint`, version info can be maintained in one place and there is no suspicious warning.