### PR TITLE
refactor(message-commerce): Drop unnecessary coerce

### DIFF
--- a/src/components/MessageCommerce.js
+++ b/src/components/MessageCommerce.js
@@ -270,7 +270,7 @@ export class MessageCommerce extends PureComponent {
               <React.Fragment>
                 {this.renderOptions()}
                 {/* if reactions show them */}
-                {hasReactions > 0 && !this.state.showDetailedReactions && (
+                {hasReactions && !this.state.showDetailedReactions && (
                   <ReactionsList
                     reactions={message.latest_reactions}
                     reaction_counts={message.reaction_counts}
@@ -329,7 +329,7 @@ export class MessageCommerce extends PureComponent {
                   )}
 
                   {/* if reactions show them */}
-                  {hasReactions > 0 && !this.state.showDetailedReactions && (
+                  {hasReactions && !this.state.showDetailedReactions && (
                     <ReactionsList
                       reverse
                       reactions={message.latest_reactions}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Boolean (`hasReactions`) was compared to number unnecessarily where boolean could be used directly.
