### PR TITLE
fix in MessageList: use EmptyStateIndicator from props

### DIFF
--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -754,7 +754,7 @@ class MessageList extends PureComponent {
           ref={this.messageList}
         >
           {!elements.length ? (
-            <EmptyStateIndicator listType="message" />
+            <this.props.EmptyStateIndicator listType="message" />
           ) : (
             <ReverseInfiniteScroll
               loadMore={this._loadMore}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

`MessageList` component always uses the default `EmptyStateIndicator`

View more on [GitDuck](https://gitduck.com/watch/5da7041a951a390d74f21c42)


