### PR TITLE
override sendMessage request in Channel props

### DIFF
--- a/src/components/Channel.js
+++ b/src/components/Channel.js
@@ -88,6 +88,12 @@ class Channel extends PureComponent {
     acceptedFiles: PropTypes.array,
     /** Maximum number of attachments allowed per message */
     maxNumberOfFiles: PropTypes.number,
+    /** Override send message request (Advanced usage only)
+     *
+     * @param {String} channelId full channel ID in format of `type:id`
+     * @param {Object} message
+     */
+    doSendMessageRequest: PropTypes.func,
   };
 
   static defaultProps = {
@@ -356,7 +362,16 @@ class ChannelInner extends PureComponent {
     };
 
     try {
-      const messageResponse = await this.props.channel.sendMessage(messageData);
+      let messageResponse;
+      if (this.props.doSendMessageRequest) {
+        messageResponse = await this.props.doSendMessageRequest(
+          this.props.channel.cid,
+          messageData,
+        );
+      } else {
+        messageResponse = await this.props.channel.sendMessage(messageData);
+      }
+
       // replace it after send is completed
       if (messageResponse.message) {
         messageResponse.message.status = 'received';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -108,6 +108,11 @@ export interface ChannelProps extends ChatContextValue {
   onMentionsClick?(e: React.MouseEvent, user: Client.UserResponse): void;
   /** Function to be called when hovering over a @mention. Function has access to the DOM event and the target user object */
   onMentionsHover?(e: React.MouseEvent, user: Client.UserResponse): void;
+  /** Override send message request (Advanced usage only) */
+  doSendMessageRequest?(
+    channelId: string,
+    message: Client.Message,
+  ): Promise<Client.MessageResponse> | void;
 }
 
 export interface ChannelListProps extends ChatContextValue {


### PR DESCRIPTION
This prop allow users to pass a custom function to catch network request for sending a new message. This can be used to reroute the new messages to custom API and send the message after some validation. 
