### PR TITLE
override doEditMessageRequest

### DIFF
--- a/src/components/Channel.js
+++ b/src/components/Channel.js
@@ -88,6 +88,12 @@ class Channel extends PureComponent {
     acceptedFiles: PropTypes.array,
     /** Maximum number of attachments allowed per message */
     maxNumberOfFiles: PropTypes.number,
+    /** Override update(edit) message request (Advanced usage only)
+     *
+     * @param {String} channelId full channel ID in format of `type:id`
+     * @param {Object} updatedMessage
+     */
+    doUpdateMessageRequest: PropTypes.func,
   };
 
   static defaultProps = {
@@ -345,6 +351,19 @@ class ChannelInner extends PureComponent {
     return message;
   };
 
+  editMessage = (updatedMessage) => {
+    if (this.props.doUpdateMessageRequest) {
+      return Promise.resolve(
+        this.props.doUpdateMessageRequest(
+          this.props.channel.cid,
+          updatedMessage,
+        ),
+      );
+    }
+
+    return this.props.client.updateMessage(updatedMessage);
+  };
+
   _sendMessage = async (message) => {
     const { text, attachments, id, parent_id, mentioned_users } = message;
     const messageData = {
@@ -597,6 +616,7 @@ class ChannelInner extends PureComponent {
     updateMessage: this.updateMessage,
     removeMessage: this.removeMessage,
     sendMessage: this.sendMessage,
+    editMessage: this.editMessage,
     retrySendMessage: this.retrySendMessage,
     loadMore: this.loadMore,
 

--- a/src/components/MessageInput.js
+++ b/src/components/MessageInput.js
@@ -315,11 +315,10 @@ class MessageInput extends PureComponent {
       // TODO: Remove this line and show an error when submit fails
       this.props.clearEditingState();
 
-      const updateMessagePromise = this.props.client
-        .updateMessage(updatedMessage)
-        .then(() => {
-          this.props.clearEditingState();
-        });
+      const updateMessagePromise = this.props
+        .editMessage(updatedMessage)
+        .then(this.props.clearEditingState);
+
       logChatPromiseExecution(updateMessagePromise, 'update message');
     } else {
       const sendMessagePromise = this.props.sendMessage({

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -314,7 +314,7 @@ class MessageList extends PureComponent {
   };
 
   clearEditingState = (e) => {
-    if (e) {
+    if (e && e.preventDefault) {
       e.preventDefault();
     }
     this.setState({

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,6 +51,7 @@ export interface ChannelContextValue extends ChatContextValue {
   acceptedFiles?: string[];
   maxNumberOfFiles?: number;
   sendMessage?(message: Client.Message): void;
+  editMessage?(updatedMessage: Client.Message): void;
   /** Via Context: The function to update a message, handled by the Channel component */
   updateMessage?(
     updatedMessage: Client.MessageResponse,
@@ -108,6 +109,11 @@ export interface ChannelProps extends ChatContextValue {
   onMentionsClick?(e: React.MouseEvent, user: Client.UserResponse): void;
   /** Function to be called when hovering over a @mention. Function has access to the DOM event and the target user object */
   onMentionsHover?(e: React.MouseEvent, user: Client.UserResponse): void;
+  /** Override update(edit) message request (Advanced usage only) */
+  doUpdateMessageRequest?(
+    channelId: string,
+    updatedMessage: Client.Message,
+  ): Promise<Client.MessageResponse> | void;
 }
 
 export interface ChannelListProps extends ChatContextValue {


### PR DESCRIPTION
Allow users to override the Edit messages network requests, similar to https://github.com/GetStream/stream-chat-react/pull/102