### PR TITLE
CRNS-48: Support props for thread customization

### DIFF
--- a/src/components/Thread.js
+++ b/src/components/Thread.js
@@ -180,6 +180,8 @@ class ThreadInner extends React.PureComponent {
             initialMessage
             threadList
             Message={this.props.Message}
+            // TODO: remove the following line in next release, since we already have additionalParentMessageProps now.
+            {...this.props}
             {...this.props.additionalParentMessageProps}
           />
           <div className="str-chat__thread-start">Start of a new thread</div>

--- a/src/components/Thread.js
+++ b/src/components/Thread.js
@@ -11,6 +11,10 @@ import { MessageInputSmall } from './MessageInputSmall';
 /**
  * Thread - The Thread renders a parent message with a list of replies. Use the standard message list of the main channel's messages.
  * The thread is only used for the list of replies to a message.
+ * Underlying MessageList, MessageInput and Message components can be customized using props:
+ * - additionalParentMessageProps
+ * - additionalMessageListProps
+ * - additionalMessageInputProps
  *
  * @example ./docs/Thread.md
  * @extends Component
@@ -49,6 +53,21 @@ class Thread extends React.PureComponent {
      * **Available from [channel context](https://getstream.github.io/stream-chat-react/#channel)**
      * If the thread is currently loading more messages. This is helpful to display a loading indicator on threadlist */
     threadLoadingMore: PropTypes.bool,
+    /**
+     * Additional props for underlying Message component of parent message at the top.
+     * Available props - https://getstream.github.io/stream-chat-react/#message
+     * */
+    additionalParentMessageProps: PropTypes.object,
+    /**
+     * Additional props for underlying MessageList component.
+     * Available props - https://getstream.github.io/stream-chat-react/#messagelist
+     * */
+    additionalMessageListProps: PropTypes.object,
+    /**
+     * Additional props for underlying MessageInput component.
+     * Available props - https://getstream.github.io/stream-chat-react/#messageinput
+     * */
+    additionalMessageInputProps: PropTypes.object,
   };
 
   static defaultProps = {
@@ -161,7 +180,7 @@ class ThreadInner extends React.PureComponent {
             initialMessage
             threadList
             Message={this.props.Message}
-            {...this.props}
+            {...this.props.additionalParentMessageProps}
           />
           <div className="str-chat__thread-start">Start of a new thread</div>
           <MessageList
@@ -172,11 +191,13 @@ class ThreadInner extends React.PureComponent {
             hasMore={this.props.threadHasMore}
             loadingMore={this.props.threadLoadingMore}
             Message={this.props.Message}
+            {...this.props.additionalMessageListProps}
           />
           <MessageInput
             Input={MessageInputSmall}
             parent={this.props.thread}
             focus={this.props.autoFocus}
+            {...this.props.additionalMessageInputProps}
           />
         </div>
       </div>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -458,6 +458,9 @@ export interface ThreadProps extends ChannelContextValue {
   fullWidth?: boolean;
   /** Make input focus on mounting thread */
   autoFocus?: boolean;
+  additionalParentMessageProps?: object;
+  additionalMessageListProps?: object;
+  additionalMessageInputProps?: object;
 }
 
 export interface TypingIndicatorProps {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Fix for issue: https://github.com/GetStream/stream-chat-react/issues/101

Currently there is no way to customise the underlying components of `Thread` component. Props added in this PR will give the client power to customise or add more props to them as he wishes.