### PR TITLE
sync ChannelPreview latest message on edit/delete

### DIFF
--- a/src/components/ChannelPreview.js
+++ b/src/components/ChannelPreview.js
@@ -49,11 +49,15 @@ export class ChannelPreview extends PureComponent {
 
     this.setState({ unread });
     channel.on('message.new', this.handleEvent);
+    channel.on('message.updated', this.handleEvent);
+    channel.on('message.deleted', this.handleEvent);
   }
 
   componentWillUnmount() {
     const channel = this.props.channel;
     channel.off('message.new', this.handleEvent);
+    channel.off('message.updated', this.handleEvent);
+    channel.off('message.deleted', this.handleEvent);
   }
 
   handleEvent = (event) => {


### PR DESCRIPTION
fix ChannelPreview in ChannelList not getting updated on message delete or updates

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
