### PR TITLE
add strikethrough to text renderer

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -146,6 +146,7 @@ export const renderText = (message) => {
     'code',
     'inlineCode',
     'blockquote',
+    'delete',
   ];
 
   const urls = anchorme(text, {


### PR DESCRIPTION
# Submit a pull request

Add the strikethrough option to the markdown renderer so the `~~text~~` doesn;t return an empty message

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
