### PR TITLE
CRS-22: Optimistic reaction updates to UI

### DIFF
--- a/src/components/Channel.js
+++ b/src/components/Channel.js
@@ -208,6 +208,7 @@ class ChannelInner extends PureComponent {
     }
     this.originalTitle = document.title;
     this.lastRead = new Date();
+    this.props.client.on('connection.changed', this.connectionChanged);
     if (!errored) {
       this.copyChannelState();
       this.listenToChanges();
@@ -231,6 +232,7 @@ class ChannelInner extends PureComponent {
 
   componentWillUnmount() {
     this.props.client.off('connection.recovered', this.handleEvent);
+    this.props.client.off('connection.changed', this.connectionChanged);
     this.props.channel.off(this.handleEvent);
     this._loadMoreFinishedDebounced.cancel();
     this._loadMoreThreadFinishedDebounced.cancel();
@@ -239,6 +241,11 @@ class ChannelInner extends PureComponent {
       Visibility.unbind(this.visibilityListener);
     }
   }
+  connectionChanged = (event) => {
+    if (this.state.online !== event.online) {
+      this.setState({ online: event.online });
+    }
+  };
 
   openThread = (message, e) => {
     if (e && e.preventDefault) {
@@ -312,6 +319,94 @@ class ChannelInner extends PureComponent {
 
     if (channel.countUnread() > 0) channel.markRead();
   }
+
+  copyChannelMessages() {
+    const { channel } = this.props;
+    let threadMessages = [];
+
+    if (this.state.thread) {
+      threadMessages = channel.state.threads[this.state.thread.id] || [];
+    }
+    this._setStateThrottled({
+      messages: channel.state.messages,
+      threadMessages,
+    });
+  }
+
+  handleReaction = async (message, reactionType, event) => {
+    if (!this.state.online) return;
+
+    if (event !== undefined && event.preventDefault) {
+      event.preventDefault();
+    }
+    const { channel, client } = this.props;
+
+    let userExistingReaction = null;
+
+    for (const reaction of message.own_reactions) {
+      // own user should only ever contain the current user id
+      // just in case we check to prevent bugs with message updates from breaking reactions
+      if (
+        client.userID === reaction.user.id &&
+        reaction.type === reactionType
+      ) {
+        userExistingReaction = reaction;
+      } else if (client.userID !== reaction.user.id) {
+        console.warn(
+          `message.own_reactions contained reactions from a different user, this indicates a bug`,
+        );
+      }
+    }
+
+    let reactionChangePromise;
+    let resetReaction;
+    const tmpReaction = {
+      type: reactionType,
+      user_id: client.userID,
+      message_id: message.id,
+      user: client.user,
+    };
+
+    /*
+     * - Add the reaction to the local state
+     * - Make the API call in the background
+     * - If it fails, revert to the old message...
+     */
+    if (userExistingReaction) {
+      channel.state.removeReaction(tmpReaction, message);
+      this.copyChannelMessages();
+      resetReaction = () => {
+        channel.state.addReaction(tmpReaction, message);
+      };
+
+      reactionChangePromise = channel.deleteReaction(
+        message.id,
+        userExistingReaction.type,
+      );
+    } else {
+      // add the reaction
+      const messageID = message.id;
+
+      channel.state.addReaction(tmpReaction, message);
+      this.copyChannelMessages();
+
+      resetReaction = () => {
+        channel.state.removeReaction(tmpReaction, message);
+      };
+
+      reactionChangePromise = channel.sendReaction(messageID, {
+        type: reactionType,
+      });
+    }
+
+    try {
+      // only wait for the API call after the state is updated
+      await reactionChangePromise;
+    } catch (e) {
+      resetReaction();
+      this.copyChannelMessages();
+    }
+  };
 
   updateMessage = (updatedMessage, extraState) => {
     const channel = this.props.channel;
@@ -650,6 +745,7 @@ class ChannelInner extends PureComponent {
     sendMessage: this.sendMessage,
     editMessage: this.editMessage,
     retrySendMessage: this.retrySendMessage,
+    handleReaction: this.handleReaction,
     loadMore: this.loadMore,
 
     // thread related

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -29,7 +29,6 @@ class MessageList extends PureComponent {
     this.state = {
       newMessagesNotification: false,
       editing: '',
-      online: true,
       notifications: [],
     };
 
@@ -166,12 +165,6 @@ class MessageList extends PureComponent {
     messageActions: Object.keys(MESSAGE_ACTIONS),
   };
 
-  connectionChanged = (event) => {
-    if (this.state.online !== event.online) {
-      this.setState({ online: event.online });
-    }
-  };
-
   componentDidMount() {
     // start at the bottom
     this.scrollToBottom();
@@ -181,14 +174,10 @@ class MessageList extends PureComponent {
       messageListRect,
     });
 
-    this.props.client.on('connection.changed', this.connectionChanged);
-
     document.addEventListener('keydown', this.keypress);
   }
 
   componentWillUnmount() {
-    this.props.client.off('connection.changed', this.connectionChanged);
-
     document.removeEventListener('keydown', this.keypress);
     this.notificationTimeouts.forEach((ct) => {
       clearTimeout(ct);
@@ -730,6 +719,7 @@ class MessageList extends PureComponent {
               addNotification={this.addNotification}
               updateMessage={this.props.updateMessage}
               removeMessage={this.props.removeMessage}
+              handleReaction={this.props.handleReaction}
               Message={this.props.Message}
               unsafeHTML={this.props.unsafeHTML}
               Attachment={this.props.Attachment}
@@ -801,7 +791,7 @@ class MessageList extends PureComponent {
               {notification.text}
             </Notification>
           ))}
-          <Notification active={!this.state.online} type="error">
+          <Notification active={!this.props.online} type="error">
             {t('Connection failure, reconnecting now...')}
           </Notification>
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -470,6 +470,11 @@ export interface MessageProps extends TranslationContextValue {
   /** Function executed when user clicks on link to open thread */
   retrySendMessage?(message: Client.Message): void;
   removeMessage?(updatedMessage: Client.MessageResponse): void;
+  handleReaction?(
+    message: Client.MessageResponse,
+    reactionType: string,
+    event?: React.BaseSyntheticEvent,
+  ): Promise<void>;
   /** Function to be called when a @mention is clicked. Function has access to the DOM event and the target user object */
   onMentionsClick?(e: React.MouseEvent, user: Client.UserResponse): void;
   /** Function to be called when hovering over a @mention. Function has access to the DOM event and the target user object */


### PR DESCRIPTION
# Submit a pull request

## Purpose
 - Update the reactions (add/remove) in UI without waiting for api calls.
 - In case of failure, reset the added/removed reactions.

## Changes

- Lifting `handleReaction` function up from `Message` (HOC) to `Channel` component.
- Lifting network status (state variable `online`) from `MessageList` to `Channel` component
- Updating channel state before calling sendReaction/removeReaction api.
- If promise gets rejected or api fails, then we reset the state update.

**NOTE** This PR is dependent on changes of following PR in js client - https://github.com/GetStream/stream-chat-js/pull/280

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
