### PR TITLE
fix race condition for channel update event

### DIFF
--- a/src/components/ChannelList.js
+++ b/src/components/ChannelList.js
@@ -373,18 +373,20 @@ class ChannelList extends PureComponent {
 
     // Update the channel with data
     if (e.type === 'channel.updated') {
-      const channels = this.state.channels;
-      const channelIndex = channels.findIndex(
-        (channel) => channel.cid === e.channel.cid,
-      );
+      // quick check to avoid calling setState in case channel does not exist
+      if (!this.state.channels.find(({ cid }) => cid === e.channel.cid)) return;
 
-      if (channelIndex < 0) return;
+      this.setState(({ channels, channelUpdateCount }) => {
+        const channelIndex = channels.findIndex(
+          (channel) => channel.cid === e.channel.cid,
+        );
+        if (channelIndex < 0) return null;
 
-      channels[channelIndex].data = Immutable(e.channel);
-
-      this.setState({
-        channels: [...channels],
-        channelUpdateCount: this.state.channelUpdateCount + 1,
+        channels[channelIndex].data = Immutable(e.channel);
+        return {
+          channels: [...channels],
+          channelUpdateCount: channelUpdateCount + 1,
+        };
       });
 
       if (


### PR DESCRIPTION
`notification.removed_from_channel` event will remove the channel from the list while at the same time `channel.updated` event tries to update the removed channel

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
