### PR TITLE
Disabling message input for frozen channel

### DIFF
--- a/src/components/Channel.js
+++ b/src/components/Channel.js
@@ -111,6 +111,10 @@ class Channel extends PureComponent {
      * @param {Object} updatedMessage
      */
     doUpdateMessageRequest: PropTypes.func,
+    /** Hides the child MessageInput component if channel is frozen */
+    hideMessageInputIfFrozenChannel: PropTypes.bool,
+    /** Disables the child MessageInput component if channel is frozen */
+    disableMessageInputIfFrozenChannel: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -119,6 +123,8 @@ class Channel extends PureComponent {
     LoadingErrorIndicator,
     Message: MessageSimple,
     Attachment,
+    hideMessageInputIfFrozenChannel: false,
+    disableMessageInputIfFrozenChannel: true,
   };
 
   render() {
@@ -658,6 +664,9 @@ class ChannelInner extends PureComponent {
     loadMoreThread: this.loadMoreThread,
     onMentionsClick: this._onMentionsHoverOrClick,
     onMentionsHover: this._onMentionsHoverOrClick,
+    hideMessageInputIfFrozenChannel: this.props.hideMessageInputIfFrozenChannel,
+    disableMessageInputIfFrozenChannel: this.props
+      .disableMessageInputIfFrozenChannel,
   });
 
   renderComponent = () => this.props.children;

--- a/src/components/MessageInput.js
+++ b/src/components/MessageInput.js
@@ -130,6 +130,10 @@ class MessageInput extends PureComponent {
      * Defaults to and accepts same props as: [SendButton](https://getstream.github.io/stream-chat-react/#sendbutton)
      * */
     SendButton: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+    /** Hides the child MessageInput component if channel is frozen */
+    hideMessageInputIfFrozenChannel: PropTypes.bool,
+    /** Disables the child MessageInput component if channel is frozen */
+    disableMessageInputIfFrozenChannel: PropTypes.bool,
     /**
      * Any additional attrubutes that you may want to add for underlying HTML textarea element.
      * e.g.
@@ -154,7 +158,7 @@ class MessageInput extends PureComponent {
 
   componentDidMount() {
     if (this.props.focus) {
-      this.textareaRef.current.focus();
+      this.textareaRef.current && this.textareaRef.current.focus();
     }
   }
 
@@ -620,7 +624,25 @@ class MessageInput extends PureComponent {
   };
 
   render() {
-    const { Input } = this.props;
+    const {
+      Input,
+      channel: { data: channelData },
+      disableMessageInputIfFrozenChannel,
+      hideMessageInputIfFrozenChannel,
+    } = this.props;
+    const isFrozen = channelData ? channelData.frozen : false;
+
+    if (isFrozen && hideMessageInputIfFrozenChannel) return null;
+
+    let additionalTextareaProps = this.props.additionalTextareaProps || {};
+
+    if (isFrozen && disableMessageInputIfFrozenChannel) {
+      additionalTextareaProps = {
+        disabled: true,
+        ...additionalTextareaProps,
+      };
+    }
+
     const handlers = {
       uploadNewFiles: this._uploadNewFiles,
       removeImage: this._removeImage,
@@ -639,7 +661,14 @@ class MessageInput extends PureComponent {
       onSelectItem: this._onSelectItem,
       openEmojiPicker: this.openEmojiPicker,
     };
-    return <Input {...this.props} {...this.state} {...handlers} />;
+    return (
+      <Input
+        {...this.props}
+        {...this.state}
+        {...handlers}
+        additionalTextareaProps={additionalTextareaProps}
+      />
+    );
   }
 }
 

--- a/src/components/Thread.js
+++ b/src/components/Thread.js
@@ -76,6 +76,10 @@ class Thread extends React.PureComponent {
         ```
     */
     MessageInput: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+    /** Hides the child MessageInput component if channel is frozen */
+    hideMessageInputIfFrozenChannel: PropTypes.bool,
+    /** Disables the child MessageInput component if channel is frozen */
+    disableMessageInputIfFrozenChannel: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -83,6 +87,8 @@ class Thread extends React.PureComponent {
     threadLoadingMore: true,
     fullWidth: false,
     autoFocus: true,
+    hideMessageInputIfFrozenChannel: false,
+    disableMessageInputIfFrozenChannel: true,
     MessageInput,
   };
 
@@ -216,6 +222,10 @@ class ThreadInner extends React.PureComponent {
             MessageInputSmall,
             parent: this.props.thread,
             focus: this.props.autoFocus,
+            hideMessageInputIfFrozenChannel: this.props
+              .hideMessageInputIfFrozenChannel,
+            disableMessageInputIfFrozenChannel: this.props
+              .disableMessageInputIfFrozenChannel,
             ...this.props.additionalMessageInputProps,
           })}
         </div>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -78,6 +78,10 @@ export interface ChannelContextValue extends ChatContextValue {
 
   /** Via Context: The function is called when the list scrolls */
   listenToScroll?(offset: number): void;
+  /** Hides the child MessageInput component if channel is frozen */
+  hideMessageInputIfFrozenChannel: boolean;
+  /** Disables the child MessageInput component if channel is frozen */
+  disableMessageInputIfFrozenChannel: boolean;
 }
 
 export interface ChatProps {
@@ -125,6 +129,10 @@ export interface ChannelProps
     channelId: string,
     updatedMessage: Client.Message,
   ): Promise<Client.MessageResponse> | void;
+  /** Hides the child MessageInput component if channel is frozen */
+  hideMessageInputIfFrozenChannel: boolean;
+  /** Disables the child MessageInput component if channel is frozen */
+  disableMessageInputIfFrozenChannel: boolean;
 }
 
 export interface ChannelListProps extends ChatContextValue {


### PR DESCRIPTION
# Submit a pull request

Introducing two new props on Channel component:

1. hideMessageInputIfFrozenChannel
2. disableMessageInputIfFrozenChannel (default)

This will either hide or disable the message input component, if channel is frozen.

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
