### PR TITLE
Fix dateseparator on same day of week

### DIFF
--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -335,10 +335,10 @@ class MessageList extends PureComponent {
         newMessages.push(message);
         continue;
       }
-      const messageDate = message.created_at.getDay();
+      const messageDate = message.created_at.toDateString();
       let prevMessageDate = messageDate;
       if (i > 0) {
-        prevMessageDate = messages[i - 1].created_at.getDay();
+        prevMessageDate = messages[i - 1].created_at.toDateString();
       }
 
       if (i === 0 || messageDate !== prevMessageDate) {


### PR DESCRIPTION
# Submit a pull request
Fixes the following issue: if two messages are for example two thursdays apart, the dateseparator is hidden


## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
