### PR TITLE
only get readstates for messages submitted by the user themselves, so…

### DIFF
--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -649,8 +649,8 @@ class MessageList extends PureComponent {
     // sort by date
     allMessages.sort((a, b) => a.created_at - b.created_at);
 
-    // get the readData
-    const readData = this.getReadStates(allMessages);
+    // get the readData, but only for messages submitted by the user themselves
+    const readData = this.getReadStates(allMessages.filter(({ user }) => user && user.id === this.props.client.userID));
 
     const lastReceivedId = this.getLastReceived(allMessages);
     const elements = [];


### PR DESCRIPTION
… messages from other users don't influence userLastReadMsgId

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Read indicators were disappearing if the current user's message wasn't the last in the thread, because we were updating read states for all messages, not just the ones submitted by the current user. This fixes that by first filtering the messages down to the user's own messages.