### PR TITLE
Add MessageDeleted prop

### DIFF
--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -126,7 +126,7 @@ class Message extends Component {
      * The component that will be rendered if the message has been deleted.
      * All props are passed into this component.
      */
-    MessageDeleted: PropTypes.func,
+    MessageDeleted: PropTypes.elementType,
   };
 
   static defaultProps = {

--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -122,6 +122,11 @@ class Message extends Component {
      * Available props - https://getstream.github.io/stream-chat-react/#messageinput
      * */
     additionalMessageInputProps: PropTypes.object,
+    /**
+     * The component that will be rendered if the message has been deleted.
+     * All props are passed into this component.
+     */
+    MessageDeleted: PropTypes.func,
   };
 
   static defaultProps = {

--- a/src/components/MessageCommerce.js
+++ b/src/components/MessageCommerce.js
@@ -8,7 +8,7 @@ import { MessageRepliesCountButton } from './MessageRepliesCountButton';
 
 import PropTypes from 'prop-types';
 
-import { isOnlyEmojis, renderText } from '../utils';
+import { isOnlyEmojis, renderText, smartRender } from '../utils';
 import { withTranslationContext } from '../context';
 
 /**
@@ -95,23 +95,6 @@ class MessageCommerce extends PureComponent {
 
   static defaultProps = {
     Attachment,
-    MessageDeleted: ({ message, t, isMyMessage }) => {
-      const messageClasses = isMyMessage(message)
-        ? 'str-chat__message-commerce str-chat__message-commerce--left'
-        : 'str-chat__message-commerce str-chat__message-commerce--right';
-
-      return (
-        <React.Fragment>
-          <span
-            key={message.id}
-            className={`${messageClasses} str-chat__message--deleted`}
-          >
-            {t('This message was deleted...')}
-          </span>
-          <div className="clearfix" />
-        </React.Fragment>
-      );
-    },
   };
 
   state = {
@@ -244,7 +227,7 @@ class MessageCommerce extends PureComponent {
     );
 
     if (message.deleted_at) {
-      return <MessageDeleted {...this.props} />; // MessageDeleted is always defined because it has a default value
+      return smartRender(MessageDeleted, this.props, null);
     }
 
     if (message.type === 'message.read' || message.type === 'message.date') {

--- a/src/components/MessageCommerce.js
+++ b/src/components/MessageCommerce.js
@@ -90,7 +90,7 @@ class MessageCommerce extends PureComponent {
      * The component that will be rendered if the message has been deleted.
      * All of Message's props are passed into this component.
      */
-    MessageDeleted: PropTypes.func,
+    MessageDeleted: PropTypes.elementType,
   };
 
   static defaultProps = {

--- a/src/components/MessageCommerce.js
+++ b/src/components/MessageCommerce.js
@@ -86,10 +86,32 @@ class MessageCommerce extends PureComponent {
     onMentionsClickMessage: PropTypes.func,
     /** Position of message in group. Possible values: top, bottom, middle, single */
     groupStyles: PropTypes.array,
+    /**
+     * The component that will be rendered if the message has been deleted.
+     * All of Message's props are passed into this component.
+     */
+    MessageDeleted: PropTypes.func,
   };
 
   static defaultProps = {
     Attachment,
+    MessageDeleted: ({ message, t, isMyMessage }) => {
+      const messageClasses = isMyMessage(message)
+        ? 'str-chat__message-commerce str-chat__message-commerce--left'
+        : 'str-chat__message-commerce str-chat__message-commerce--right';
+
+      return (
+        <React.Fragment>
+          <span
+            key={message.id}
+            className={`${messageClasses} str-chat__message--deleted`}
+          >
+            {t('This message was deleted...')}
+          </span>
+          <div className="clearfix" />
+        </React.Fragment>
+      );
+    },
   };
 
   state = {
@@ -202,6 +224,7 @@ class MessageCommerce extends PureComponent {
       handleOpenThread,
       t,
       tDateTimeParser,
+      MessageDeleted,
     } = this.props;
 
     const when = tDateTimeParser(message.created_at).format('LT');
@@ -220,27 +243,14 @@ class MessageCommerce extends PureComponent {
       message.latest_reactions && message.latest_reactions.length,
     );
 
-    if (
-      message.type === 'message.read' ||
-      message.deleted_at ||
-      message.type === 'message.date'
-    ) {
+    if (message.deleted_at) {
+      return <MessageDeleted {...this.props} />; // MessageDeleted is always defined because it has a default value
+    }
+
+    if (message.type === 'message.read' || message.type === 'message.date') {
       return null;
     }
 
-    if (message.deleted_at) {
-      return (
-        <React.Fragment>
-          <span
-            key={message.id}
-            className={`${messageClasses} str-chat__message--deleted`}
-          >
-            {t('This message was deleted...')}
-          </span>
-          <div className="clearfix" />
-        </React.Fragment>
-      );
-    }
     return (
       <React.Fragment>
         <div

--- a/src/components/MessageDeleted.js
+++ b/src/components/MessageDeleted.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { withTranslationContext } from '../context';
 
 class MessageDeleted extends React.PureComponent {
   static propTypes = {
@@ -27,5 +28,7 @@ class MessageDeleted extends React.PureComponent {
     );
   }
 }
+
+MessageDeleted = withTranslationContext(MessageDeleted);
 
 export { MessageDeleted };

--- a/src/components/MessageDeleted.js
+++ b/src/components/MessageDeleted.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class MessageDeleted extends React.PureComponent {
+  static propTypes = {
+    /** The [message object](https://getstream.io/chat/docs/#message_format) */
+    message: PropTypes.object,
+    /** Returns true if message belongs to current user */
+    isMyMessage: PropTypes.func,
+  };
+
+  render() {
+    const { isMyMessage, message, t } = this.props;
+    const messageClasses = isMyMessage(message)
+      ? 'str-chat__message str-chat__message--me str-chat__message-simple str-chat__message-simple--me'
+      : 'str-chat__message str-chat__message-simple';
+
+    return (
+      <div
+        key={message.id}
+        className={`${messageClasses} str-chat__message--deleted ${message.type} `}
+      >
+        <div className="str-chat__message--deleted-inner">
+          {t('This message was deleted...')}
+        </div>
+      </div>
+    );
+  }
+}
+
+export { MessageDeleted };

--- a/src/components/MessageLivestream.js
+++ b/src/components/MessageLivestream.js
@@ -115,6 +115,11 @@ class MessageLivestream extends React.PureComponent {
      * @param user Target user object
      */
     onMentionsClickMessage: PropTypes.func,
+    /**
+     * The component that will be rendered if the message has been deleted.
+     * All of Message's props are passed into this component.
+     */
+    MessageDeleted: PropTypes.func,
   };
 
   static defaultProps = {
@@ -215,6 +220,7 @@ class MessageLivestream extends React.PureComponent {
       handleDelete,
       t,
       tDateTimeParser,
+      MessageDeleted,
     } = this.props;
     const hasAttachment = Boolean(
       message.attachments && message.attachments.length,
@@ -239,7 +245,7 @@ class MessageLivestream extends React.PureComponent {
     }
 
     if (message.deleted_at) {
-      return null;
+      return MessageDeleted ? <MessageDeleted {...this.props} /> : null;
     }
 
     if (editing) {

--- a/src/components/MessageLivestream.js
+++ b/src/components/MessageLivestream.js
@@ -119,7 +119,7 @@ class MessageLivestream extends React.PureComponent {
      * The component that will be rendered if the message has been deleted.
      * All of Message's props are passed into this component.
      */
-    MessageDeleted: PropTypes.func,
+    MessageDeleted: PropTypes.elementType,
   };
 
   static defaultProps = {

--- a/src/components/MessageLivestream.js
+++ b/src/components/MessageLivestream.js
@@ -11,7 +11,7 @@ import { EditMessageForm } from './EditMessageForm';
 import { Gallery } from './Gallery';
 import { MessageRepliesCountButton } from './MessageRepliesCountButton';
 
-import { isOnlyEmojis, renderText } from '../utils';
+import { isOnlyEmojis, renderText, smartRender } from '../utils';
 import { withTranslationContext } from '../context';
 
 const reactionSvg =
@@ -245,7 +245,7 @@ class MessageLivestream extends React.PureComponent {
     }
 
     if (message.deleted_at) {
-      return MessageDeleted ? <MessageDeleted {...this.props} /> : null;
+      return smartRender(MessageDeleted, this.props, null);
     }
 
     if (editing) {

--- a/src/components/MessageSimple.js
+++ b/src/components/MessageSimple.js
@@ -11,10 +11,16 @@ import { MessageRepliesCountButton } from './MessageRepliesCountButton';
 import { Modal } from './Modal';
 import { MessageInput } from './MessageInput';
 import { EditMessageForm } from './EditMessageForm';
+import { MessageDeleted } from './MessageDeleted';
 
 import PropTypes from 'prop-types';
 
-import { isOnlyEmojis, renderText, getReadByTooltipText } from '../utils';
+import {
+  isOnlyEmojis,
+  renderText,
+  getReadByTooltipText,
+  smartRender,
+} from '../utils';
 import { withTranslationContext } from '../context';
 
 /**
@@ -125,22 +131,7 @@ class MessageSimple extends PureComponent {
 
   static defaultProps = {
     Attachment,
-    MessageDeleted: ({ message, t, isMyMessage }) => {
-      const messageClasses = isMyMessage(message)
-        ? 'str-chat__message str-chat__message--me str-chat__message-simple str-chat__message-simple--me'
-        : 'str-chat__message str-chat__message-simple';
-
-      return (
-        <div
-          key={message.id}
-          className={`${messageClasses} str-chat__message--deleted ${message.type} `}
-        >
-          <div className="str-chat__message--deleted-inner">
-            {t('This message was deleted...')}
-          </div>
-        </div>
-      );
-    },
+    MessageDeleted,
   };
 
   state = {
@@ -458,7 +449,7 @@ class MessageSimple extends PureComponent {
     }
 
     if (message.deleted_at) {
-      return <MessageDeleted {...this.props} />; // MessageDeleted is always defined because it has a default value
+      return smartRender(MessageDeleted, this.props, null);
     }
 
     return (

--- a/src/components/MessageSimple.js
+++ b/src/components/MessageSimple.js
@@ -116,10 +116,31 @@ class MessageSimple extends PureComponent {
      * Available props - https://getstream.github.io/stream-chat-react/#messageinput
      * */
     additionalMessageInputProps: PropTypes.object,
+    /**
+     * The component that will be rendered if the message has been deleted.
+     * All of Message's props are passed into this component.
+     */
+    MessageDeleted: PropTypes.func,
   };
 
   static defaultProps = {
     Attachment,
+    MessageDeleted: ({ message, t, isMyMessage }) => {
+      const messageClasses = isMyMessage(message)
+        ? 'str-chat__message str-chat__message--me str-chat__message-simple str-chat__message-simple--me'
+        : 'str-chat__message str-chat__message-simple';
+
+      return (
+        <div
+          key={message.id}
+          className={`${messageClasses} str-chat__message--deleted ${message.type} `}
+        >
+          <div className="str-chat__message--deleted-inner">
+            {t('This message was deleted...')}
+          </div>
+        </div>
+      );
+    },
   };
 
   state = {
@@ -413,6 +434,7 @@ class MessageSimple extends PureComponent {
       handleOpenThread,
       t,
       tDateTimeParser,
+      MessageDeleted,
     } = this.props;
 
     const when = tDateTimeParser(message.created_at).calendar();
@@ -436,18 +458,7 @@ class MessageSimple extends PureComponent {
     }
 
     if (message.deleted_at) {
-      return (
-        <React.Fragment>
-          <div
-            key={message.id}
-            className={`${messageClasses} str-chat__message--deleted ${message.type} `}
-          >
-            <div className="str-chat__message--deleted-inner">
-              {t('This message was deleted...')}
-            </div>
-          </div>
-        </React.Fragment>
-      );
+      return <MessageDeleted {...this.props} />; // MessageDeleted is always defined because it has a default value
     }
 
     return (

--- a/src/components/MessageSimple.js
+++ b/src/components/MessageSimple.js
@@ -126,7 +126,7 @@ class MessageSimple extends PureComponent {
      * The component that will be rendered if the message has been deleted.
      * All of Message's props are passed into this component.
      */
-    MessageDeleted: PropTypes.func,
+    MessageDeleted: PropTypes.elementType,
   };
 
   static defaultProps = {

--- a/src/components/MessageTeam.js
+++ b/src/components/MessageTeam.js
@@ -116,6 +116,11 @@ class MessageTeam extends PureComponent {
     onMentionsClickMessage: PropTypes.func,
     /** Position of message in group. Possible values: top, bottom, middle, single */
     groupStyles: PropTypes.array,
+    /**
+     * The component that will be rendered if the message has been deleted.
+     * All of Message's props are passed into this component.
+     */
+    MessageDeleted: PropTypes.func,
   };
 
   static defaultProps = {
@@ -289,6 +294,7 @@ class MessageTeam extends PureComponent {
       handleDelete,
       t,
       tDateTimeParser,
+      MessageDeleted,
     } = this.props;
     if (message.type === 'message.read') {
       return null;
@@ -298,7 +304,7 @@ class MessageTeam extends PureComponent {
     );
 
     if (message.deleted_at) {
-      return null;
+      return MessageDeleted ? <MessageDeleted {...this.props} /> : null;
     }
 
     let galleryImages =

--- a/src/components/MessageTeam.js
+++ b/src/components/MessageTeam.js
@@ -125,7 +125,7 @@ class MessageTeam extends PureComponent {
      * The component that will be rendered if the message has been deleted.
      * All of Message's props are passed into this component.
      */
-    MessageDeleted: PropTypes.func,
+    MessageDeleted: PropTypes.elementType,
   };
 
   static defaultProps = {

--- a/src/components/MessageTeam.js
+++ b/src/components/MessageTeam.js
@@ -11,7 +11,12 @@ import { Tooltip } from './Tooltip';
 import { Gallery } from './Gallery';
 import { MessageInput } from './MessageInput';
 import PropTypes from 'prop-types';
-import { isOnlyEmojis, renderText, getReadByTooltipText } from '../utils';
+import {
+  isOnlyEmojis,
+  renderText,
+  getReadByTooltipText,
+  smartRender,
+} from '../utils';
 import { withTranslationContext } from '../context';
 
 const reactionSvg =
@@ -304,7 +309,7 @@ class MessageTeam extends PureComponent {
     );
 
     if (message.deleted_at) {
-      return MessageDeleted ? <MessageDeleted {...this.props} /> : null;
+      return smartRender(MessageDeleted, this.props, null);
     }
 
     let galleryImages =

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -470,6 +470,8 @@ export interface MessageProps extends TranslationContextValue {
   editing?: boolean;
   /** The message rendering component, the Message component delegates its rendering logic to this component */
   Message?: React.ElementType<MessageUIComponentProps>;
+  /** Message Deleted rendering component. Optional; if left undefined, the default of the Message rendering component is used */
+  MessageDeleted?: React.ElementType<MessageDeletedProps>;
   /** Allows you to overwrite the attachment component */
   Attachment?: React.ElementType<AttachmentUIComponentProps>;
   /** render HTML instead of markdown. Posting HTML is only allowed server-side */
@@ -533,6 +535,12 @@ export interface MessageUIComponentProps
   channelConfig?: object;
   threadList?: boolean;
   additionalMessageInputProps?: object;
+}
+
+export interface MessageDeletedProps extends TranslationContextValue {
+  /** The message object */
+  message: Client.MessageResponse;
+  isMyMessage(message: Client.MessageResponse): boolean;
 }
 
 export interface ThreadProps
@@ -990,6 +998,10 @@ export class MessageTeam extends React.PureComponent<
 > {}
 export class MessageSimple extends React.PureComponent<
   MessageUIComponentProps,
+  any
+> {}
+export class MessageDeleted extends React.PureComponent<
+  MessageDeletedProps,
   any
 > {}
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Adds `MessageDeleted` prop to all Message components. If left undefined, what happens if a message has been deleted is left up to the component itself. This means that for `MessageSimple` and `MessageCommerce` a default "message deleted" is rendered, whereas for the other Message components nothing is shown.
