### PR TITLE
fix gallery alignment issues + better border rounding

### DIFF
--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -37,8 +37,11 @@ class Gallery extends React.PureComponent {
     const formattedArray = images.map((image) => ({
       src: image.image_url || image.thumb_url,
     }));
+
+    const squareClass = images.length > 3 ? 'str-chat__gallery--square' : '';
+
     return (
-      <div className="str-chat__gallery">
+      <div className={`str-chat__gallery ${squareClass}`}>
         {images.slice(0, 3).map((image, i) => (
           <div
             className="str-chat__gallery-image"

--- a/src/styles/Gallery.scss
+++ b/src/styles/Gallery.scss
@@ -1,7 +1,7 @@
 .str-chat__gallery {
   display: inline-flex;
   flex-wrap: wrap;
-  justify-content: end;
+  justify-content: flex-end;
   overflow: hidden;
 
   &-image {

--- a/src/styles/Gallery.scss
+++ b/src/styles/Gallery.scss
@@ -1,8 +1,7 @@
 .str-chat__gallery {
-  display: flex;
+  display: inline-flex;
   flex-wrap: wrap;
-  width: 100%;
-  max-width: 304px;
+  justify-content: end;
   overflow: hidden;
 
   &-image {
@@ -24,6 +23,14 @@
       height: inherit;
       object-fit: cover;
     }
+  }
+
+  &--square {
+    max-width: 301px; // 300px + 1px margin between images
+  }
+
+  &--square &-image:nth-child(even) {
+    margin-right: 0;
   }
 }
 

--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -15,13 +15,13 @@
 
       &.str-chat__message--has-text.str-chat__message--has-attachment {
         .str-chat__message-attachment--img,
-        .str-chat__message-attachment-card,
-        .str-chat__gallery {
+        .str-chat__message-attachment-card {
           border-radius: $border-radius $border-radius $border-radius 2px;
         }
       }
 
       &--me {
+        text-align: right; // for inline(-flex/block) elements, e.g. gallery
         .str-chat__message {
           &-attachment--img,
           &-attachment-card {
@@ -266,6 +266,7 @@
     justify-content: flex-start;
     padding: 0 0 0 0;
     position: relative;
+    width: 100%;
 
     &-inner {
       position: relative;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
![image](https://user-images.githubusercontent.com/1820506/80976364-a87d3980-8e23-11ea-9668-a4a3e4367425.png)
![image](https://user-images.githubusercontent.com/1820506/80976394-b29f3800-8e23-11ea-9a37-732a4366ae18.png)
![image](https://user-images.githubusercontent.com/1820506/80976417-b92daf80-8e23-11ea-8f05-9f2366e482d7.png)

This fixes alignment for galleries under long messages. It also turns a 3 image gallery into a flat list of thumbnails rather than a square gallery. Lastly, I fixed some issues with the rounded corners (i.e. no longer rounded on the wrong side, and fully rounded corners by tweaking width/margin)
