### PR TITLE
Disable truncation for email urls on messages

### DIFF
--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -963,6 +963,11 @@
       }
     }
   }
+  a[href^="mailto:"] {
+    -webkit-hyphens: none;
+   -moz-hyphens: none;
+    hyphens: none;
+  }
 }
 
 @media screen and (max-width: 375px) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -162,10 +162,13 @@ export const renderText = (message) => {
     list: true,
   });
   for (const urlInfo of urls) {
-    const displayLink = truncate(urlInfo.encoded.replace(/^(www\.)/, ''), {
-      length: 20,
-      omission: '...',
-    });
+    const isEmail = urlInfo.reason === 'email';
+    const displayLink = !isEmail
+      ? truncate(urlInfo.encoded.replace(/^(www\.)/, ''), {
+          length: 20,
+          omission: '...',
+        })
+      : urlInfo.encoded;
     const mkdown = `[${displayLink}](${urlInfo.protocol}${urlInfo.encoded})`;
     text = text.replace(urlInfo.raw, mkdown);
   }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Disabling truncation in case of emails. Also disabling hyphenation as hyphens could lead to confusion.

**Before**:

<img width="272" alt="Screenshot 2020-05-06 at 14 46 36" src="https://user-images.githubusercontent.com/1326024/81178513-98db2d80-8fa8-11ea-8ac0-b9af9b8ef87f.png">

**After**:
<img width="510" alt="Screenshot 2020-05-06 at 14 47 14" src="https://user-images.githubusercontent.com/1326024/81178530-a0023b80-8fa8-11ea-9977-591a25953292.png">

Notice it will still break words in smaller screens:
<img width="388" alt="Screenshot 2020-05-06 at 14 47 28" src="https://user-images.githubusercontent.com/1326024/81178601-bc05dd00-8fa8-11ea-8ffb-f7fd7458642c.png">


