### PR TITLE
Unset channel on delete if it is active

### DIFF
--- a/src/components/ChannelList/ChannelList.js
+++ b/src/components/ChannelList/ChannelList.js
@@ -416,6 +416,11 @@ class ChannelList extends PureComponent {
           channels: [...channels],
           channelUpdateCount: this.state.channelUpdateCount + 1,
         });
+
+        // Unset active channel if it was the deleted one
+        if (e.channel.cid === this.props.channel.cid) {
+          this.props.setActiveChannel({});
+        }
       }
     }
 


### PR DESCRIPTION
## Description of the pull request

Unset channel on delete if the deleted channel was the active one and there's no custom `onChannelDelete` handler.