### PR TITLE
CRS-244 Fix Message UI component type definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -459,13 +459,12 @@ export interface AttachmentUIComponentProps {
   ): void;
 }
 
+// MessageProps are all props shared between the Message component and the Message UI components (e.g. MessageSimple)
 export interface MessageProps extends TranslationContextValue {
   /** The message object */
   message?: Client.MessageResponse;
   /** The client connection object for connecting to Stream */
   client?: Client.StreamChat;
-  /** The current channel this message is displayed in */
-  channel?: Client.Channel;
   /** A list of users that have read this message **/
   readBy?: Array<Client.UserResponse>;
   /** groupStyles, a list of styles to apply to this message. ie. top, bottom, single etc */
@@ -480,24 +479,22 @@ export interface MessageProps extends TranslationContextValue {
   Attachment?: React.ElementType<AttachmentUIComponentProps>;
   /** render HTML instead of markdown. Posting HTML is only allowed server-side */
   unsafeHTML?: boolean;
-  messageActions?: Array<string>;
-  getFlagMessageSuccessNotification?(message: MessageResponse): string;
-  getFlagMessageErrorNotification?(message: MessageResponse): string;
-  getMuteUserSuccessNotification?(message: MessageResponse): string;
-  getMuteUserErrorNotification?(message: MessageResponse): string;
   lastReceivedId?: string | null;
   messageListRect?: DOMRect;
-  members?: SeamlessImmutable.Immutable<{ [user_id: string]: Client.Member }>;
-  watchers?: SeamlessImmutable.Immutable<{ [user_id: string]: Client.User }>;
-  addNotification?(notificationText: string, type: string): any;
-  setEditingState?(message: Client.MessageResponse): any;
   updateMessage?(
     updatedMessage: Client.MessageResponse,
     extraState: object,
   ): void;
-  /** Function executed when user clicks on link to open thread */
-  retrySendMessage?(message: Client.Message): void;
-  removeMessage?(updatedMessage: Client.MessageResponse): void;
+  additionalMessageInputProps?: object;
+  clearEditingState?(e?: React.MouseEvent): void;
+}
+
+// MessageComponentProps defines the props for the Message component
+export interface MessageComponentProps
+  extends MessageProps,
+    TranslationContextValue {
+  /** The current channel this message is displayed in */
+  channel?: Client.Channel;
   /** Function to be called when a @mention is clicked. Function has access to the DOM event and the target user object */
   onMentionsClick?(e: React.MouseEvent, user: Client.UserResponse): void;
   /** Function to be called when hovering over a @mention. Function has access to the DOM event and the target user object */
@@ -506,14 +503,23 @@ export interface MessageProps extends TranslationContextValue {
   onUserClick?(e: React.MouseEvent, user: Client.UserResponse): void;
   /** Function to be called when hovering the user that posted the message. Function has access to the DOM event and the target user object */
   onUserHover?(e: React.MouseEvent, user: Client.UserResponse): void;
+  messageActions?: Array<string>;
+  getFlagMessageSuccessNotification?(message: MessageResponse): string;
+  getFlagMessageErrorNotification?(message: MessageResponse): string;
+  getMuteUserSuccessNotification?(message: MessageResponse): string;
+  getMuteUserErrorNotification?(message: MessageResponse): string;
+  members?: SeamlessImmutable.Immutable<{ [user_id: string]: Client.Member }>;
+  addNotification?(notificationText: string, type: string): any;
+  setEditingState?(message: Client.MessageResponse): any;
+  retrySendMessage?(message: Client.Message): void;
+  removeMessage?(updatedMessage: Client.MessageResponse): void;
   openThread?(
     message: Client.MessageResponse,
     event: React.SyntheticEvent,
   ): void;
-  additionalMessageInputProps?: object;
-  clearEditingState?(e?: React.MouseEvent): void;
 }
 
+// MessageUIComponentProps defines the props for the Message UI components (e.g. MessageSimple)
 export interface MessageUIComponentProps
   extends MessageProps,
     TranslationContextValue {
@@ -539,8 +545,8 @@ export interface MessageUIComponentProps
     event: React.MouseEvent,
     user: Client.UserResponse,
   ): void;
-  onUserClick(e: React.MouseEvent): void;
-  onUserHover(e: React.MouseEvent): void;
+  onUserClick?(e: React.MouseEvent): void;
+  onUserHover?(e: React.MouseEvent): void;
   getMessageActions(): Array<string>;
   channelConfig?: object;
   threadList?: boolean;
@@ -897,7 +903,7 @@ export const Tooltip: React.FC<TooltipProps>;
 export class Chat extends React.PureComponent<ChatProps, any> {}
 export class Channel extends React.PureComponent<ChannelProps, any> {}
 export class Avatar extends React.PureComponent<AvatarProps, any> {}
-export class Message extends React.PureComponent<MessageProps, any> {}
+export class Message extends React.PureComponent<MessageComponentProps, any> {}
 export class MessageList extends React.PureComponent<MessageListProps, any> {}
 export const ChannelHeader: React.FC<ChannelHeaderProps>;
 export class MessageInput extends React.PureComponent<MessageInputProps, any> {}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Currently the typescript definitions (i.e. interfaces) for Message components are set up as follows:

 - MessageProps, which contains all the props for the high level Message component
 - MessageUIComponentProps, which extends MessageProps, and adds some props specific to the UI components.

However, the high level Message component receives several props which the UI components ignore (and which aren’t defined in their PropTypes definitions). I refactored it so it accurately reflects the actual React components.