### PR TITLE
Show tooltips for emojis and attachments in message input

### DIFF
--- a/src/components/MessageInput/MessageInputFlat.js
+++ b/src/components/MessageInput/MessageInputFlat.js
@@ -12,6 +12,7 @@ import {
 import { filterEmoji } from '../../utils';
 import { withTranslationContext } from '../../context';
 import { ChatAutoComplete } from '../ChatAutoComplete';
+import { Tooltip } from '../Tooltip';
 
 /**
  * MessageInputFlat - Large Message Input to be used for the MessageInput.
@@ -184,42 +185,50 @@ class MessageInputFlat extends PureComponent {
                 additionalTextareaProps={this.props.additionalTextareaProps}
               />
 
-              <span
-                className="str-chat__input-flat-emojiselect"
-                onClick={this.props.openEmojiPicker}
-              >
-                <svg width="28" height="28" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M22.217 16.1c.483.25.674.849.423 1.334C21.163 20.294 17.771 22 14 22c-3.867 0-7.347-1.765-8.66-4.605a.994.994 0 0 1 .9-1.407c.385 0 .739.225.9.575C8.135 18.715 10.892 20 14 20c3.038 0 5.738-1.267 6.879-3.476a.99.99 0 0 1 1.338-.424zm1.583-3.652c.341.443.235 1.064-.237 1.384a1.082 1.082 0 0 1-.62.168c-.338 0-.659-.132-.858-.389-.212-.276-.476-.611-1.076-.611-.598 0-.864.337-1.08.614-.197.254-.517.386-.854.386-.224 0-.438-.045-.62-.167-.517-.349-.578-.947-.235-1.388.66-.847 1.483-1.445 2.789-1.445 1.305 0 2.136.6 2.79 1.448zm-14 0c.341.443.235 1.064-.237 1.384a1.082 1.082 0 0 1-.62.168c-.339 0-.659-.132-.858-.389C7.873 13.335 7.61 13 7.01 13c-.598 0-.864.337-1.08.614-.197.254-.517.386-.854.386-.224 0-.438-.045-.62-.167-.518-.349-.579-.947-.235-1.388C4.88 11.598 5.703 11 7.01 11c1.305 0 2.136.6 2.79 1.448zM14 0c7.732 0 14 6.268 14 14s-6.268 14-14 14S0 21.732 0 14 6.268 0 14 0zm8.485 22.485A11.922 11.922 0 0 0 26 14c0-3.205-1.248-6.219-3.515-8.485A11.922 11.922 0 0 0 14 2a11.922 11.922 0 0 0-8.485 3.515A11.922 11.922 0 0 0 2 14c0 3.205 1.248 6.219 3.515 8.485A11.922 11.922 0 0 0 14 26c3.205 0 6.219-1.248 8.485-3.515z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-              <FileUploadButton
-                multiple={this.props.multipleUploads}
-                disabled={
-                  this.props.numberOfUploads >= this.props.maxNumberOfFiles
-                }
-                accepts={this.props.acceptedFiles}
-                handleFiles={this.props.uploadNewFiles}
-              >
-                <span className="str-chat__input-flat-fileupload">
+              <div className="str-chat__emojiselect-wrapper">
+                <Tooltip>{t('Open emoji picker')}</Tooltip>
+                <span
+                  className="str-chat__input-flat-emojiselect"
+                  onClick={this.props.openEmojiPicker}
+                >
                   <svg
-                    width="14"
-                    height="14"
+                    width="28"
+                    height="28"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M1.667.333h10.666c.737 0 1.334.597 1.334 1.334v10.666c0 .737-.597 1.334-1.334 1.334H1.667a1.333 1.333 0 0 1-1.334-1.334V1.667C.333.93.93.333 1.667.333zm2 1.334a1.667 1.667 0 1 0 0 3.333 1.667 1.667 0 0 0 0-3.333zm-2 9.333v1.333h10.666v-4l-2-2-4 4-2-2L1.667 11z"
-                      fillRule="nonzero"
+                      d="M22.217 16.1c.483.25.674.849.423 1.334C21.163 20.294 17.771 22 14 22c-3.867 0-7.347-1.765-8.66-4.605a.994.994 0 0 1 .9-1.407c.385 0 .739.225.9.575C8.135 18.715 10.892 20 14 20c3.038 0 5.738-1.267 6.879-3.476a.99.99 0 0 1 1.338-.424zm1.583-3.652c.341.443.235 1.064-.237 1.384a1.082 1.082 0 0 1-.62.168c-.338 0-.659-.132-.858-.389-.212-.276-.476-.611-1.076-.611-.598 0-.864.337-1.08.614-.197.254-.517.386-.854.386-.224 0-.438-.045-.62-.167-.517-.349-.578-.947-.235-1.388.66-.847 1.483-1.445 2.789-1.445 1.305 0 2.136.6 2.79 1.448zm-14 0c.341.443.235 1.064-.237 1.384a1.082 1.082 0 0 1-.62.168c-.339 0-.659-.132-.858-.389C7.873 13.335 7.61 13 7.01 13c-.598 0-.864.337-1.08.614-.197.254-.517.386-.854.386-.224 0-.438-.045-.62-.167-.518-.349-.579-.947-.235-1.388C4.88 11.598 5.703 11 7.01 11c1.305 0 2.136.6 2.79 1.448zM14 0c7.732 0 14 6.268 14 14s-6.268 14-14 14S0 21.732 0 14 6.268 0 14 0zm8.485 22.485A11.922 11.922 0 0 0 26 14c0-3.205-1.248-6.219-3.515-8.485A11.922 11.922 0 0 0 14 2a11.922 11.922 0 0 0-8.485 3.515A11.922 11.922 0 0 0 2 14c0 3.205 1.248 6.219 3.515 8.485A11.922 11.922 0 0 0 14 26c3.205 0 6.219-1.248 8.485-3.515z"
+                      fillRule="evenodd"
                     />
                   </svg>
                 </span>
-              </FileUploadButton>
-              {SendButton && (
-                <SendButton sendMessage={this.props.handleSubmit} />
-              )}
+              </div>
+              <div className="str-chat__fileupload-wrapper">
+                <Tooltip>{t('Attach files')}</Tooltip>
+                <FileUploadButton
+                  multiple={this.props.multipleUploads}
+                  disabled={
+                    this.props.numberOfUploads >= this.props.maxNumberOfFiles
+                  }
+                  accepts={this.props.acceptedFiles}
+                  handleFiles={this.props.uploadNewFiles}
+                >
+                  <span className="str-chat__input-flat-fileupload">
+                    <svg
+                      width="14"
+                      height="14"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1.667.333h10.666c.737 0 1.334.597 1.334 1.334v10.666c0 .737-.597 1.334-1.334 1.334H1.667a1.333 1.333 0 0 1-1.334-1.334V1.667C.333.93.93.333 1.667.333zm2 1.334a1.667 1.667 0 1 0 0 3.333 1.667 1.667 0 0 0 0-3.333zm-2 9.333v1.333h10.666v-4l-2-2-4 4-2-2L1.667 11z"
+                        fillRule="nonzero"
+                      />
+                    </svg>
+                  </span>
+                </FileUploadButton>
+              </div>
             </div>
+            {SendButton && <SendButton sendMessage={this.props.handleSubmit} />}
           </div>
         </ImageDropzone>
       </div>

--- a/src/components/MessageInput/MessageInputLarge.js
+++ b/src/components/MessageInput/MessageInputLarge.js
@@ -12,6 +12,7 @@ import {
 import { filterEmoji } from '../../utils';
 import { withTranslationContext } from '../../context';
 import { ChatAutoComplete } from '../ChatAutoComplete';
+import { Tooltip } from '../Tooltip';
 
 /**
  * MessageInputLarge - Large Message Input to be used for the MessageInput.
@@ -212,42 +213,58 @@ class MessageInputLarge extends PureComponent {
                 disabled={this.props.disabled}
                 additionalTextareaProps={this.props.additionalTextareaProps}
               />
-
-              <span
-                className="str-chat__input-emojiselect"
-                onClick={this.props.openEmojiPicker}
-              >
-                <svg width="14" height="14" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M11.108 8.05a.496.496 0 0 1 .212.667C10.581 10.147 8.886 11 7 11c-1.933 0-3.673-.882-4.33-2.302a.497.497 0 0 1 .9-.417C4.068 9.357 5.446 10 7 10c1.519 0 2.869-.633 3.44-1.738a.495.495 0 0 1 .668-.212zm.792-1.826a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.298 0-.431.168-.54.307A.534.534 0 0 1 9.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zm-7 0a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.299 0-.432.168-.54.307A.533.533 0 0 1 2.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zM7 0a7 7 0 1 1 0 14A7 7 0 0 1 7 0zm4.243 11.243A5.96 5.96 0 0 0 13 7a5.96 5.96 0 0 0-1.757-4.243A5.96 5.96 0 0 0 7 1a5.96 5.96 0 0 0-4.243 1.757A5.96 5.96 0 0 0 1 7a5.96 5.96 0 0 0 1.757 4.243A5.96 5.96 0 0 0 7 13a5.96 5.96 0 0 0 4.243-1.757z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-
-              <FileUploadButton
-                multiple={this.props.multipleUploads}
-                disabled={
-                  this.props.numberOfUploads >= this.props.maxNumberOfFiles
-                    ? true
-                    : false
-                }
-                accepts={this.props.acceptedFiles}
-                handleFiles={this.props.uploadNewFiles}
-              >
-                <span className="str-chat__input-fileupload">
+              <div className="str-chat__emojiselect-wrapper">
+                <Tooltip>{t('Open emoji picker')}</Tooltip>
+                <span
+                  className="str-chat__input-emojiselect"
+                  onClick={this.props.openEmojiPicker}
+                  onMouseEnter={this.showEmojiTooltip}
+                  onMouseLeave={this.hideEmojiTooltip}
+                  ref={this.emojiPickerRef}
+                >
                   <svg
                     width="14"
                     height="14"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M7 .5c3.59 0 6.5 2.91 6.5 6.5s-2.91 6.5-6.5 6.5S.5 10.59.5 7 3.41.5 7 .5zm0 12c3.031 0 5.5-2.469 5.5-5.5S10.031 1.5 7 1.5A5.506 5.506 0 0 0 1.5 7c0 3.034 2.469 5.5 5.5 5.5zM7.506 3v3.494H11v1.05H7.506V11h-1.05V7.544H3v-1.05h3.456V3h1.05z"
-                      fillRule="nonzero"
+                      d="M11.108 8.05a.496.496 0 0 1 .212.667C10.581 10.147 8.886 11 7 11c-1.933 0-3.673-.882-4.33-2.302a.497.497 0 0 1 .9-.417C4.068 9.357 5.446 10 7 10c1.519 0 2.869-.633 3.44-1.738a.495.495 0 0 1 .668-.212zm.792-1.826a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.298 0-.431.168-.54.307A.534.534 0 0 1 9.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zm-7 0a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.299 0-.432.168-.54.307A.533.533 0 0 1 2.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zM7 0a7 7 0 1 1 0 14A7 7 0 0 1 7 0zm4.243 11.243A5.96 5.96 0 0 0 13 7a5.96 5.96 0 0 0-1.757-4.243A5.96 5.96 0 0 0 7 1a5.96 5.96 0 0 0-4.243 1.757A5.96 5.96 0 0 0 1 7a5.96 5.96 0 0 0 1.757 4.243A5.96 5.96 0 0 0 7 13a5.96 5.96 0 0 0 4.243-1.757z"
+                      fillRule="evenodd"
                     />
                   </svg>
                 </span>
-              </FileUploadButton>
+              </div>
+              <div className="str-chat__fileupload-wrapper">
+                <Tooltip>{t('Attach files')}</Tooltip>
+                <FileUploadButton
+                  multiple={this.props.multipleUploads}
+                  disabled={
+                    this.props.numberOfUploads >= this.props.maxNumberOfFiles
+                      ? true
+                      : false
+                  }
+                  accepts={this.props.acceptedFiles}
+                  handleFiles={this.props.uploadNewFiles}
+                >
+                  <span
+                    className="str-chat__input-fileupload"
+                    onMouseEnter={this.showFileUploaderTooltip}
+                    onMouseLeave={this.hideFileUploaderTooltip}
+                    ref={this.fileUploaderRef}
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M7 .5c3.59 0 6.5 2.91 6.5 6.5s-2.91 6.5-6.5 6.5S.5 10.59.5 7 3.41.5 7 .5zm0 12c3.031 0 5.5-2.469 5.5-5.5S10.031 1.5 7 1.5A5.506 5.506 0 0 0 1.5 7c0 3.034 2.469 5.5 5.5 5.5zM7.506 3v3.494H11v1.05H7.506V11h-1.05V7.544H3v-1.05h3.456V3h1.05z"
+                        fillRule="nonzero"
+                      />
+                    </svg>
+                  </span>
+                </FileUploadButton>
+              </div>
             </div>
             {SendButton && <SendButton sendMessage={this.props.handleSubmit} />}
           </div>

--- a/src/components/MessageInput/MessageInputSmall.js
+++ b/src/components/MessageInput/MessageInputSmall.js
@@ -12,6 +12,7 @@ import {
 import { filterEmoji } from '../../utils';
 import { withTranslationContext } from '../../context';
 import { ChatAutoComplete } from '../ChatAutoComplete';
+import { Tooltip } from '../Tooltip';
 
 /**
  * MessageInputSmall - compact design to be used for the MessageInput. It has all the features of MessageInput minus the typing indicator.
@@ -185,30 +186,11 @@ class MessageInputSmall extends PureComponent {
                 additionalTextareaProps={this.props.additionalTextareaProps}
               />
 
-              <span
-                className="str-chat__small-message-input-emojiselect"
-                onClick={this.props.openEmojiPicker}
-              >
-                <svg width="14" height="14" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M11.108 8.05a.496.496 0 0 1 .212.667C10.581 10.147 8.886 11 7 11c-1.933 0-3.673-.882-4.33-2.302a.497.497 0 0 1 .9-.417C4.068 9.357 5.446 10 7 10c1.519 0 2.869-.633 3.44-1.738a.495.495 0 0 1 .668-.212zm.792-1.826a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.298 0-.431.168-.54.307A.534.534 0 0 1 9.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zm-7 0a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.299 0-.432.168-.54.307A.533.533 0 0 1 2.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zM7 0a7 7 0 1 1 0 14A7 7 0 0 1 7 0zm4.243 11.243A5.96 5.96 0 0 0 13 7a5.96 5.96 0 0 0-1.757-4.243A5.96 5.96 0 0 0 7 1a5.96 5.96 0 0 0-4.243 1.757A5.96 5.96 0 0 0 1 7a5.96 5.96 0 0 0 1.757 4.243A5.96 5.96 0 0 0 7 13a5.96 5.96 0 0 0 4.243-1.757z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-              <FileUploadButton
-                multiple={this.props.multipleUploads}
-                disabled={
-                  this.props.numberOfUploads >= this.props.maxNumberOfFiles
-                    ? true
-                    : false
-                }
-                accepts={this.props.acceptedFiles}
-                handleFiles={this.props.uploadNewFiles}
-              >
+              <div className="str-chat__emojiselect-wrapper">
+                <Tooltip>{t('Open emoji picker')}</Tooltip>
                 <span
-                  className="str-chat__small-message-input-fileupload"
-                  onClick={this.props.openFilePanel}
+                  className="str-chat__small-message-input-emojiselect"
+                  onClick={this.props.openEmojiPicker}
                 >
                   <svg
                     width="14"
@@ -216,12 +198,42 @@ class MessageInputSmall extends PureComponent {
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M7 .5c3.59 0 6.5 2.91 6.5 6.5s-2.91 6.5-6.5 6.5S.5 10.59.5 7 3.41.5 7 .5zm0 12c3.031 0 5.5-2.469 5.5-5.5S10.031 1.5 7 1.5A5.506 5.506 0 0 0 1.5 7c0 3.034 2.469 5.5 5.5 5.5zM7.506 3v3.494H11v1.05H7.506V11h-1.05V7.544H3v-1.05h3.456V3h1.05z"
-                      fillRule="nonzero"
+                      d="M11.108 8.05a.496.496 0 0 1 .212.667C10.581 10.147 8.886 11 7 11c-1.933 0-3.673-.882-4.33-2.302a.497.497 0 0 1 .9-.417C4.068 9.357 5.446 10 7 10c1.519 0 2.869-.633 3.44-1.738a.495.495 0 0 1 .668-.212zm.792-1.826a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.298 0-.431.168-.54.307A.534.534 0 0 1 9.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zm-7 0a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.299 0-.432.168-.54.307A.533.533 0 0 1 2.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zM7 0a7 7 0 1 1 0 14A7 7 0 0 1 7 0zm4.243 11.243A5.96 5.96 0 0 0 13 7a5.96 5.96 0 0 0-1.757-4.243A5.96 5.96 0 0 0 7 1a5.96 5.96 0 0 0-4.243 1.757A5.96 5.96 0 0 0 1 7a5.96 5.96 0 0 0 1.757 4.243A5.96 5.96 0 0 0 7 13a5.96 5.96 0 0 0 4.243-1.757z"
+                      fillRule="evenodd"
                     />
                   </svg>
                 </span>
-              </FileUploadButton>
+              </div>
+
+              <div className="str-chat__fileupload-wrapper">
+                <Tooltip>{t('Attach files')}</Tooltip>
+                <FileUploadButton
+                  multiple={this.props.multipleUploads}
+                  disabled={
+                    this.props.numberOfUploads >= this.props.maxNumberOfFiles
+                      ? true
+                      : false
+                  }
+                  accepts={this.props.acceptedFiles}
+                  handleFiles={this.props.uploadNewFiles}
+                >
+                  <span
+                    className="str-chat__small-message-input-fileupload"
+                    onClick={this.props.openFilePanel}
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M7 .5c3.59 0 6.5 2.91 6.5 6.5s-2.91 6.5-6.5 6.5S.5 10.59.5 7 3.41.5 7 .5zm0 12c3.031 0 5.5-2.469 5.5-5.5S10.031 1.5 7 1.5A5.506 5.506 0 0 0 1.5 7c0 3.034 2.469 5.5 5.5 5.5zM7.506 3v3.494H11v1.05H7.506V11h-1.05V7.544H3v-1.05h3.456V3h1.05z"
+                        fillRule="nonzero"
+                      />
+                    </svg>
+                  </span>
+                </FileUploadButton>
+              </div>
             </div>
             {SendButton && <SendButton sendMessage={this.props.handleSubmit} />}
           </div>

--- a/src/components/Reactions/ReactionSelector.js
+++ b/src/components/Reactions/ReactionSelector.js
@@ -147,7 +147,6 @@ class ReactionSelector extends PureComponent {
       const latestUser = this.getLatestUser(latest_reactions, reaction.id);
 
       const count = reaction_counts && reaction_counts[reaction.id];
-      console.log(latestUser);
       return (
         <li
           key={`item-${reaction.id}`}

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -1,7 +1,9 @@
 import React from 'react';
 
-const Tooltip = ({ children }) => (
-  <div className="str-chat__tooltip">{children}</div>
+const Tooltip = (props) => (
+  <div className="str-chat__tooltip" {...props}>
+    {props.children}
+  </div>
 );
 
 export default React.memo(Tooltip);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,5 +1,6 @@
 {
   "1 reply": "1 reply",
+  "Attach files": "Attach files",
   "Cancel": "Cancel",
   "Channel Missing": "Channel Missing",
   "Connection failure, reconnecting now...": "Connection failure, reconnecting now...",
@@ -21,6 +22,7 @@
   "New Messages!": "New Messages!",
   "Nothing yet...": "Nothing yet...",
   "Only visible to you": "Only visible to you",
+  "Open emoji picker": "Open emoji picker",
   "Pick your emoji": "Pick your emoji",
   "Send": "Send",
   "Sending...": "Sending...",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,5 +1,6 @@
 {
   "1 reply": "1 réponse",
+  "Attach files": "Pièces jointes",
   "Cancel": "Annuler",
   "Channel Missing": "Canal Manquant",
   "Connection failure, reconnecting now...": "Échec de la connexion, reconnexion en cours...",
@@ -21,6 +22,7 @@
   "New Messages!": "Nouveaux Messages!",
   "Nothing yet...": "Aucun message...",
   "Only visible to you": "Visible uniquement pour vous",
+  "Open emoji picker": "Ouvrez le sélecteur d'emoji",
   "Pick your emoji": "Choisissez votre emoji",
   "Send": "Envoyer",
   "Sending...": "Envoi en cours...",

--- a/src/i18n/hi.json
+++ b/src/i18n/hi.json
@@ -1,5 +1,6 @@
 {
   "1 reply": "1 रिप्लाई",
+  "Attach files": "फाइल्स अटैच करे",
   "Cancel": "रद्द करें",
   "Channel Missing": "चैनल उपलब्ध नहीं है",
   "Connection failure, reconnecting now...": "कनेक्शन विफल रहा, अब पुनः कनेक्ट हो रहा है ...",
@@ -21,6 +22,7 @@
   "New Messages!": "नए मैसेज!",
   "Nothing yet...": "कोई मैसेज नहीं है",
   "Only visible to you": "सिर्फ आपको दिखाई दे रहा है",
+  "Open emoji picker": "इमोजी पिकर खोलिये",
   "Pick your emoji": "इमोजी चूस करे",
   "Send": "भेजे",
   "Sending...": "भेजा जा रहा है",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1,5 +1,6 @@
 {
   "1 reply": "Una risposta",
+  "Attach files": "Allega file",
   "Cancel": "Annulla",
   "Channel Missing": "Il canale non esiste",
   "Connection failure, reconnecting now...": "Connessione fallitta, riconnessione in corso...",
@@ -21,6 +22,7 @@
   "New Messages!": "Nuovo messaggio!",
   "Nothing yet...": "Ancora niente...",
   "Only visible to you": "Visibile soltanto da te",
+  "Open emoji picker": "Apri il selettore dellle emoji",
   "Pick your emoji": "Scegli la tua emoji",
   "Send": "Invia",
   "Sending...": "Invio in corso...",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -1,5 +1,6 @@
 {
   "1 reply": "1 antwoord",
+  "Attach files": "Bijlage toevoegen",
   "Cancel": "Annuleer",
   "Channel Missing": "Kanaal niet gevonden",
   "Connection failure, reconnecting now...": "Probleem met de verbinding, opnieuw verbinding maken...",
@@ -21,6 +22,7 @@
   "New Messages!": "Nieuwe Berichten!",
   "Nothing yet...": "Nog niets ...",
   "Only visible to you": "Alleen zichtbaar voor jou",
+  "Open emoji picker": "Open emojipicker",
   "Pick your emoji": "Kies je emoji",
   "Send": "Verstuur",
   "Sending...": "Aan het verzenden...",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -1,5 +1,6 @@
 {
   "1 reply": "1 ответ",
+  "Attach files": "Прикрепить файлы",
   "Cancel": "Отмена",
   "Channel Missing": "Канал не найден",
   "Connection failure, reconnecting now...": "Ошибка соединения, переподключение...",
@@ -21,6 +22,7 @@
   "New Messages!": "Новые сообщения!",
   "Nothing yet...": "Пока ничего нет...",
   "Only visible to you": "Только видно для вас",
+  "Open emoji picker": "Выбрать emoji",
   "Pick your emoji": "Выберите свой emoji",
   "Send": "Отправить",
   "Sending...": "Отправка...",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -1,5 +1,6 @@
 {
   "1 reply": "1 cevap",
+  "Attach files": "Dosya ekle",
   "Cancel": "İptal",
   "Channel Missing": "Kanal bulunamıyor",
   "Connection failure, reconnecting now...": "Bağlantı hatası, tekrar bağlanılıyor...",
@@ -21,6 +22,7 @@
   "New Messages!": "Yeni Mesajlar!",
   "Nothing yet...": "Şimdilik hiçbir şey...",
   "Only visible to you": "Sadece size görünür",
+  "Open emoji picker": "Emoji klavyesini aç",
   "Pick your emoji": "Emoji seçin",
   "Send": "Gönder",
   "Sending...": "Gönderiliyor...",

--- a/src/styles/MessageInput.scss
+++ b/src/styles/MessageInput.scss
@@ -253,27 +253,6 @@
     &__input {
       padding: 10px 40px;
 
-      &-emojiselect,
-      .rfu-file-upload-button {
-        top: calc(100% - 44px);
-      }
-
-      &-emojiselect {
-        right: 90px;
-        @media screen and (min-width: 768px) {
-          right: 50px;
-        }
-      }
-
-      .rfu-file-upload-button {
-        right: 116px;
-        top: calc(100% - 43px);
-
-        @media screen and (min-width: 768px) {
-          right: 76px;
-        }
-      }
-
       &-footer {
         padding: 0 40px 10px;
       }
@@ -297,25 +276,6 @@
           border: 1px solid rgba(0, 0, 0, 0.2);
           font-size: 13px;
           padding: 12px;
-        }
-        &-emojiselect,
-        .rfu-file-upload-button {
-          top: calc(100% - 40px);
-        }
-
-        &-emojiselect {
-          right: 68px;
-          @media screen and (min-width: 768px) {
-            right: 30px;
-          }
-        }
-
-        .rfu-file-upload-button {
-          right: 90px;
-          top: calc(100% - 39px);
-          @media screen and (min-width: 768px) {
-            right: 56px;
-          }
         }
         &-footer {
           padding: 0 20px 10px;

--- a/src/styles/MessageInput.scss
+++ b/src/styles/MessageInput.scss
@@ -29,6 +29,7 @@
         padding-right: 70px;
       }
     }
+
   }
 
   &-emojiselect,
@@ -318,6 +319,47 @@
       svg {
         fill: white;
       }
+    }
+  }
+}
+
+.str-chat__fileupload-wrapper {
+  .str-chat__tooltip {
+    display: none;
+    bottom: 35px;
+    right: 50px;
+  }
+
+  &:hover {
+    .str-chat__tooltip {
+      display: block;
+    }
+  }
+}
+
+.str-chat__emojiselect-wrapper {
+  .str-chat__tooltip {
+    display: none;
+    bottom: 35px;
+    right: 24px;
+  }
+  &:hover {
+    .str-chat__tooltip {
+      display: block;
+    }
+  }
+}
+.str-chat__small-message-input--textarea-wrapper {
+  .str-chat__fileupload-wrapper {
+    .str-chat__tooltip {
+      bottom: 32px;
+      right: 32px;
+    }
+  }
+  .str-chat__emojiselect-wrapper {
+    .str-chat__tooltip {
+      bottom: 32px;
+      right: 10px;
     }
   }
 }

--- a/src/styles/MessageInputFlat.scss
+++ b/src/styles/MessageInputFlat.scss
@@ -4,6 +4,11 @@
   position: relative;
   z-index: 1;
   width: 100%;
+
+  &-wrapper {
+    display: flex;
+  }
+
   .str-chat__textarea {
     flex: 1;
   }
@@ -43,6 +48,26 @@
 
   &--textarea-wrapper {
     display: flex;
+    flex: 1 0;
+    position: relative;
+
+    .str-chat__fileupload-wrapper {
+      .str-chat__tooltip {
+        bottom: 45px;
+        right: 25px;
+      }
+    }
+    .str-chat__emojiselect-wrapper {
+      .str-chat__tooltip {
+        bottom: 50px;
+        left: 32px;
+        right: unset;
+        &:after {
+          left: 5px;
+          right: unset;
+        }
+      }
+    }
   }
 
   &--emojipicker {
@@ -53,7 +78,7 @@
   .rfu-file-upload-button {
     position: absolute;
     top: calc(100% - 40px);
-    right: 55px;
+    right: 25px;
 
     svg {
       fill: #000;
@@ -61,9 +86,6 @@
       &:hover {
         opacity: 1;
       }
-    }
-    @media screen and (min-width: 768px) {
-      right: 25px;
     }
   }
 }


### PR DESCRIPTION
## Description of the pull request

This cleans up some remainder styling for the icons in the message input and adds a tooltip for those icons.

Examples:

<img width="415" alt="Screenshot 2020-05-11 at 13 29 33" src="https://user-images.githubusercontent.com/1326024/81556975-7e7bc800-938b-11ea-8ce3-07cd15b47018.png">

<img width="415" alt="Screenshot 2020-05-11 at 13 29 19" src="https://user-images.githubusercontent.com/1326024/81556972-7cb20480-938b-11ea-8a9e-810f8df3f34e.png">

<img width="415" alt="Screenshot 2020-05-11 at 14 16 11" src="https://user-images.githubusercontent.com/1326024/81564005-5e520600-9397-11ea-8cfd-2b3a3888efdb.png">

<img width="416" alt="Screenshot 2020-05-11 at 14 15 52" src="https://user-images.githubusercontent.com/1326024/81564014-601bc980-9397-11ea-91e7-027791bc479a.png">

## To-do
- [ ] Add translations