### PR TITLE
CRS-139 MessageInput tests

### DIFF
--- a/src/components/MessageInput/MessageInput.js
+++ b/src/components/MessageInput/MessageInput.js
@@ -142,6 +142,11 @@ class MessageInput extends PureComponent {
      * />
      */
     additionalTextareaProps: PropTypes.object,
+    /**
+     * @param message: the Message object to be sent
+     * @param cid: the channel id
+     */
+    overrideSubmitHandler: PropTypes.func,
   };
 
   static defaultProps = {

--- a/src/components/MessageInput/MessageInputLarge.js
+++ b/src/components/MessageInput/MessageInputLarge.js
@@ -227,6 +227,7 @@ class MessageInputLarge extends PureComponent {
                     height="14"
                     xmlns="http://www.w3.org/2000/svg"
                   >
+                    <title>{t('Open emoji picker')}</title>
                     <path
                       d="M11.108 8.05a.496.496 0 0 1 .212.667C10.581 10.147 8.886 11 7 11c-1.933 0-3.673-.882-4.33-2.302a.497.497 0 0 1 .9-.417C4.068 9.357 5.446 10 7 10c1.519 0 2.869-.633 3.44-1.738a.495.495 0 0 1 .668-.212zm.792-1.826a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.298 0-.431.168-.54.307A.534.534 0 0 1 9.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zm-7 0a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.299 0-.432.168-.54.307A.533.533 0 0 1 2.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zM7 0a7 7 0 1 1 0 14A7 7 0 0 1 7 0zm4.243 11.243A5.96 5.96 0 0 0 13 7a5.96 5.96 0 0 0-1.757-4.243A5.96 5.96 0 0 0 7 1a5.96 5.96 0 0 0-4.243 1.757A5.96 5.96 0 0 0 1 7a5.96 5.96 0 0 0 1.757 4.243A5.96 5.96 0 0 0 7 13a5.96 5.96 0 0 0 4.243-1.757z"
                       fillRule="evenodd"
@@ -234,7 +235,10 @@ class MessageInputLarge extends PureComponent {
                   </svg>
                 </span>
               </div>
-              <div className="str-chat__fileupload-wrapper">
+              <div
+                className="str-chat__fileupload-wrapper"
+                data-testid="fileinput"
+              >
                 <Tooltip>{t('Attach files')}</Tooltip>
                 <FileUploadButton
                   multiple={this.props.multipleUploads}
@@ -257,6 +261,7 @@ class MessageInputLarge extends PureComponent {
                       height="14"
                       xmlns="http://www.w3.org/2000/svg"
                     >
+                      <title>{t('Attach files')}</title>
                       <path
                         d="M7 .5c3.59 0 6.5 2.91 6.5 6.5s-2.91 6.5-6.5 6.5S.5 10.59.5 7 3.41.5 7 .5zm0 12c3.031 0 5.5-2.469 5.5-5.5S10.031 1.5 7 1.5A5.506 5.506 0 0 0 1.5 7c0 3.034 2.469 5.5 5.5 5.5zM7.506 3v3.494H11v1.05H7.506V11h-1.05V7.544H3v-1.05h3.456V3h1.05z"
                         fillRule="nonzero"

--- a/src/components/MessageInput/SendButton.js
+++ b/src/components/MessageInput/SendButton.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import { withTranslationContext } from '../../context';
 
-const SendButton = ({ sendMessage }) => (
+let SendButton = ({ sendMessage, t }) => (
   <button className="str-chat__send-button" onClick={sendMessage}>
     <svg
       width="18"
@@ -8,6 +9,7 @@ const SendButton = ({ sendMessage }) => (
       viewBox="0 0 18 17"
       xmlns="http://www.w3.org/2000/svg"
     >
+      <title>{t('Send')}</title>
       <path
         d="M0 17.015l17.333-8.508L0 0v6.617l12.417 1.89L0 10.397z"
         fillRule="evenodd"
@@ -16,5 +18,7 @@ const SendButton = ({ sendMessage }) => (
     </svg>
   </button>
 );
+
+SendButton = withTranslationContext(SendButton);
 
 export default React.memo(SendButton);

--- a/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -1,0 +1,342 @@
+import React from 'react';
+import {
+  cleanup,
+  render,
+  waitFor,
+  fireEvent,
+  findAllByPlaceholderText,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import axios from 'axios';
+import MessageInput from '../MessageInput';
+import MessageInputLarge from '../MessageInputLarge';
+import { Chat } from '../../Chat';
+import { Channel } from '../../Channel';
+import {
+  generateChannel,
+  generateMember,
+  generateUser,
+  generateMessage,
+  useMockedApis,
+  getOrCreateChannelApi,
+  getTestClientWithUser,
+} from '../../../mock-builders';
+
+jest.mock('axios');
+let chatClient, channel;
+
+// mock i18n
+const t = (t) => t;
+
+// MessageInput components rely on ChannelContext.
+// ChannelContext is created by Channel component,
+// Which relies on ChatContext, created by Chat component.
+const renderComponent = (props = {}) =>
+  render(
+    <Chat client={chatClient}>
+      <Channel channel={channel}>
+        <MessageInput {...props} t={t} />
+      </Channel>
+    </Chat>,
+  );
+
+describe('MessageInput', () => {
+  const inputPlaceholder = 'Type your message';
+  // First, set up a client and channel, so we can properly set up the context etc.
+  beforeAll(async () => {
+    const user1 = generateUser();
+    const message1 = generateMessage({ user: user1 });
+    const mockedChannel = generateChannel({
+      messages: [message1],
+      members: [generateMember({ user: user1 })],
+    });
+    useMockedApis(axios, [getOrCreateChannelApi(mockedChannel)]);
+    chatClient = await getTestClientWithUser({ id: user1.id });
+    channel = chatClient.channel('messaging', mockedChannel.id);
+  });
+
+  afterEach(cleanup);
+
+  it('Should shift focus to the textarea if the `focus` prop is true', async () => {
+    const { getByPlaceholderText } = renderComponent({
+      focus: true,
+    });
+    await waitFor(() => {
+      expect(getByPlaceholderText(inputPlaceholder)).toBe(
+        document.activeElement,
+      );
+    });
+  });
+
+  it('Should open the emoji picker after clicking the icon, and allow adding emojis to the message', async () => {
+    const {
+      container,
+      findByTitle,
+      queryByText,
+      getByDisplayValue,
+    } = renderComponent();
+
+    const emojiIcon = await findByTitle('Open emoji picker');
+    fireEvent.click(emojiIcon);
+
+    expect(queryByText('Pick your emoji…')).toBeInTheDocument();
+
+    const emoji = '💯';
+    const emojiButton = queryByText(emoji);
+    expect(emojiButton).toBeInTheDocument();
+
+    fireEvent.click(emojiButton);
+
+    // expect input to have emoji as value
+    expect(getByDisplayValue(emoji)).toBeInTheDocument();
+
+    // close picker
+    fireEvent.click(container);
+    expect(queryByText('Pick your emoji…')).not.toBeInTheDocument();
+  });
+
+  describe('Attachments', () => {
+    const filename = 'some.txt';
+    const fileUploadUrl = 'http://www.getstream.io'; // real url, because ImagePreview will try to load the image
+
+    const mockUploadApi = () =>
+      jest.fn().mockResolvedValue(
+        Promise.resolve({
+          file: fileUploadUrl,
+        }),
+      );
+
+    // const mockFaultyUploadApi = () => jest.fn().mockResolvedValue(
+    //   Promise.reject()
+    // );
+
+    function dropFile(file, formElement) {
+      fireEvent.drop(formElement, {
+        dataTransfer: {
+          files: [file],
+        },
+      });
+    }
+
+    it('Pasting images and files should work', async () => {
+      const doImageUploadRequest = mockUploadApi();
+      const {
+        findByPlaceholderText,
+        findByText,
+        findByDisplayValue,
+      } = renderComponent({
+        doFileUploadRequest: mockUploadApi(),
+        doImageUploadRequest,
+      });
+
+      const file = new File(['content'], filename, { type: 'text/plain' });
+      const image = new File(['content'], filename, { type: 'image/png' });
+
+      const clipboardEvent = new Event('paste', {
+        bubbles: true,
+      });
+      // set `clipboardData`. Mock DataTransfer object
+      clipboardEvent.clipboardData = {
+        items: [
+          {
+            kind: 'file',
+            getAsFile: () => file,
+          },
+          {
+            kind: 'file',
+            getAsFile: () => image,
+          },
+        ],
+      };
+      const formElement = await findByPlaceholderText(inputPlaceholder);
+      formElement.dispatchEvent(clipboardEvent);
+      const filenameText = await findByText(filename);
+
+      expect(filenameText).toBeInTheDocument();
+      expect(filenameText.closest('a')).toHaveAttribute('href', fileUploadUrl);
+      await waitFor(() => expect(doImageUploadRequest).toHaveBeenCalled());
+    });
+
+    it('Should upload an image when it is dropped on the dropzone', async () => {
+      const doImageUploadRequest = mockUploadApi();
+      const { findByPlaceholderText } = renderComponent({
+        doImageUploadRequest,
+      });
+      // drop on the form input. Technically could be dropped just outside of it as well, but the input should always work.
+      const formElement = await findByPlaceholderText(inputPlaceholder);
+      dropFile(
+        new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' }),
+        formElement,
+      );
+
+      await waitFor(() => expect(doImageUploadRequest).toHaveBeenCalled());
+    });
+
+    // it('Should call error handler if an image failed to upload', async () => {
+    //   const doImageUploadRequest = mockFaultyUploadApi();
+    //   const errorHandler = jest.fn();
+    //   const { findByPlaceholderText } = renderComponent({
+    //     doImageUploadRequest,
+    //     errorHandler,
+    //   });
+
+    //   const formElement = await findByPlaceholderText(inputPlaceholder);
+    //   dropFile(new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' }), formElement);
+
+    //   await waitFor(() => expect(errorHandler).toHaveBeenCalled());
+    // });
+
+    it('Should upload, display and link to a file when it is dropped on the dropzone', async () => {
+      const filename = 'some.txt';
+      const { findByPlaceholderText, findByText } = renderComponent({
+        doFileUploadRequest: mockUploadApi(),
+      });
+      // drop on the form input. Technically could be dropped just outside of it as well, but the input should always work.
+      const formElement = await findByPlaceholderText(inputPlaceholder);
+      dropFile(
+        new File(['content'], filename, { type: 'text/plain' }),
+        formElement,
+      );
+
+      const filenameText = await findByText(filename);
+
+      expect(filenameText).toBeInTheDocument();
+      expect(filenameText.closest('a')).toHaveAttribute('href', fileUploadUrl);
+    });
+
+    it('should allow uploading files with the file upload button', async () => {
+      const filename = 'some.txt';
+      const { findByTestId, findByText } = renderComponent({
+        doFileUploadRequest: mockUploadApi(),
+      });
+      const file = new File(['content'], filename, { type: 'text/plain' });
+      const input = (await findByTestId('fileinput')).querySelector('input');
+
+      fireEvent.change(input, {
+        target: {
+          files: [file],
+        },
+      });
+
+      const filenameText = await findByText(filename);
+
+      expect(filenameText).toBeInTheDocument();
+      expect(filenameText.closest('a')).toHaveAttribute('href', fileUploadUrl);
+    });
+
+    // TODO: Check if pasting plaintext is not prevented
+    // TODO: Failed image/file uploads -> ImagePreview throws error
+    // TODO: Remove image/file -> difficult because there is no easy selector and components are in react-file-utils
+  });
+
+  describe('Submitting', () => {
+    function setMessage(message, input) {
+      fireEvent.change(input, {
+        target: {
+          value: message,
+        },
+      });
+    }
+
+    it('Should submit the input value when clicking the submit button', async () => {
+      const submitMock = jest.fn().mockResolvedValue(Promise.resolve());
+      const { findByTitle, findByPlaceholderText } = renderComponent({
+        sendMessage: submitMock,
+      });
+      const submitButton = await findByTitle('Send');
+
+      const messageText = 'Some text';
+      setMessage(messageText, await findByPlaceholderText(inputPlaceholder));
+      fireEvent.click(submitButton);
+
+      expect(submitMock).toHaveBeenCalled();
+      expect(
+        submitMock.mock.calls[submitMock.mock.calls.length - 1][0].text,
+      ).toEqual(messageText);
+    });
+
+    it('Should use overrideSubmitHandler if specified', async () => {
+      const submitMock = jest.fn().mockResolvedValue(Promise.resolve());
+      const { findByTitle, findByPlaceholderText } = renderComponent({
+        overrideSubmitHandler: submitMock,
+      });
+      const submitButton = await findByTitle('Send');
+
+      setMessage('something', await findByPlaceholderText(inputPlaceholder));
+      fireEvent.click(submitButton);
+
+      expect(submitMock).toHaveBeenCalled();
+    });
+
+    it('Should not do anything if the message is empty and has no files', async () => {
+      const submitMock = jest.fn().mockResolvedValue(Promise.resolve());
+      const { findByTitle } = renderComponent({
+        sendMessage: submitMock,
+      });
+      const submitButton = await findByTitle('Send');
+
+      fireEvent.click(submitButton);
+
+      expect(submitMock).not.toHaveBeenCalled();
+    });
+
+    // TODO: Submitting with images?
+    // TODO: Submitting with files?
+  });
+
+  describe('Editing', () => {
+    it('Should edit a message if it is passed through the message prop', async () => {
+      const submitMock = jest.fn().mockResolvedValue(Promise.resolve());
+
+      const { findByTitle } = renderComponent({
+        editMessage: submitMock,
+        clearEditingState: () => {},
+        message: generateMessage({
+          mentioned_users: [],
+        }),
+      });
+      const submitButton = await findByTitle('Send');
+      fireEvent.click(submitButton);
+
+      expect(submitMock).toHaveBeenCalled();
+    });
+
+    it('Should take file attachments from the Message object in props and pass them down to the Input', () => {
+      const file = {
+        type: 'file',
+        asset_url: 'somewhere.txt',
+        mime_type: 'text/plain',
+        title: 'title',
+        file_size: 1000,
+      };
+      const image = {
+        type: 'image',
+        image_url: 'somewhere.png',
+        fallback: 'fallback.png',
+      };
+
+      const attachments = [file, image];
+
+      const MessageChecker = ({ fileUploads, imageUploads }) => {
+        expect(Object.keys(fileUploads).length).toEqual(1);
+        expect(Object.keys(imageUploads).length).toEqual(1);
+        const fileUpload = Object.values(fileUploads)[0];
+        const imageUpload = Object.values(imageUploads)[0];
+
+        expect(fileUpload.url).toEqual(file.asset_url);
+        expect(imageUpload.url).toEqual(image.image_url);
+        return null;
+      };
+
+      renderComponent({
+        Input: MessageChecker,
+        message: generateMessage({
+          attachments,
+          mentioned_users: [],
+        }),
+      });
+    });
+  });
+
+  // TODO: mentioned users
+});

--- a/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -15,6 +15,10 @@ import {
   getTestClientWithUser,
 } from '../../../mock-builders';
 
+jest.mock('blueimp-load-image/js/load-image-fetch', () => {
+  return jest.fn().mockImplementation(() => Promise.resolve());
+});
+
 jest.mock('axios');
 let chatClient, channel;
 

--- a/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -13,8 +13,9 @@ import {
   useMockedApis,
   getOrCreateChannelApi,
   getTestClientWithUser,
-} from '../../../mock-builders';
+} from '/mock-builders';
 
+// mock image loader fn used by ImagePreview
 jest.mock('blueimp-load-image/js/load-image-fetch', () => {
   return jest.fn().mockImplementation(() => Promise.resolve());
 });
@@ -24,9 +25,6 @@ let chatClient, channel;
 
 // mock i18n
 const t = (t) => t;
-
-// silence console.warn because some components log large warnings in catch statements
-console.warn = () => {};
 
 const submitMock = jest.fn();
 const editMock = jest.fn();
@@ -244,7 +242,7 @@ describe('MessageInput', () => {
         doImageUploadRequest,
         errorHandler,
       });
-
+      jest.spyOn(console, 'warn').mockImplementationOnce(() => null);
       const formElement = await findByPlaceholderText(inputPlaceholder);
       const file = new File(['(⌐□_□)'], 'chucknorris.png', {
         type: 'image/png',
@@ -273,7 +271,7 @@ describe('MessageInput', () => {
         doFileUploadRequest,
         errorHandler,
       });
-
+      jest.spyOn(console, 'warn').mockImplementationOnce(() => null);
       const formElement = await findByPlaceholderText(inputPlaceholder);
       const file = new File(['content'], 'chucknorris.txt', {
         type: 'text/plain',


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Note that these tests don't really try to mock out child components. This means that some of the functionality in these tests relies on the implementation of its children. With that said, I tried to stick to a declarative style as much as possible, so that the actual implementation of those children doesn't really matter, as long as they do what is expected for MessageInput to work properly. In that sense it follows what's in this article: https://kentcdodds.com/blog/why-i-never-use-shallow-rendering/
