### PR TITLE
make mutes prop optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -112,7 +112,7 @@ export interface ChannelProps
   LoadingErrorIndicator?: React.ElementType<LoadingErrorIndicatorProps>;
   Message?: React.ElementType<MessageUIComponentProps>;
   Attachment?: React.ElementType<AttachmentUIComponentProps>;
-  mutes: Client.Mute[];
+  mutes?: Client.Mute[];
   multipleUploads?: boolean;
   acceptedFiles?: string[];
   maxNumberOfFiles?: number;
@@ -340,7 +340,7 @@ export interface MessageListProps
   unsafeHTML?: boolean;
   messageLimit?: number;
   messageActions?: Array<string>;
-  mutes: Client.Mute[];
+  mutes?: Client.Mute[];
   getFlagMessageSuccessNotification?(message: MessageResponse): string;
   getFlagMessageErrorNotification?(message: MessageResponse): string;
   getMuteUserSuccessNotification?(message: MessageResponse): string;
@@ -537,7 +537,7 @@ export interface MessageUIComponentProps
   isMyMessage?(message: Client.MessageResponse): boolean;
   isUserMuted?(): boolean;
   handleOpenThread?(event: React.BaseSyntheticEvent): void;
-  mutes: Client.Mute[];
+  mutes?: Client.Mute[];
   onMentionsClickMessage?(
     event: React.MouseEvent,
     user: Client.UserResponse,


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

This commit 6ac325a6c68c4467b360b5917787bea7765a3c06 introduced typescript build errors:
```
Overload 1 of 2, '(props: Readonly<ChannelProps>): Channel', gave the following error.
    Property 'mutes' is missing in type '{ children: Element[]; }' but required in type 'Readonly<ChannelProps>'.
  Overload 2 of 2, '(props: ChannelProps, context?: any): Channel', gave the following error.
    Property 'mutes' is missing in type '{ children: Element[]; }' but required in type 'Readonly<ChannelProps>'.
```

This is happen because top level components: `Channel`, `MessageList`, `Message` now require `mutes` prop.

In this PR I set mutes property back to optional for user extendable components, such as `Channel`, `MessageList`, `Message`, and leaved it as required for `MessageActions` component, which seems not user extendable.