### PR TITLE
Fix client tests mock

### DIFF
--- a/src/components/ChannelList/ChannelList.js
+++ b/src/components/ChannelList/ChannelList.js
@@ -60,6 +60,7 @@ class ChannelList extends PureComponent {
     LoadingErrorIndicator: PropTypes.oneOfType([
       PropTypes.node,
       PropTypes.func,
+      PropTypes.elementType,
     ]),
     /**
      * Custom UI Component for container of list of channels. Note that, list (UI component) of channels is passed

--- a/src/components/ChannelList/__tests__/ChannelList.test.js
+++ b/src/components/ChannelList/__tests__/ChannelList.test.js
@@ -21,13 +21,6 @@ import {
   erroredGetApi,
 } from 'mock-builders';
 
-// eslint-disable-next-line no-undef
-afterEach(cleanup);
-
-// Wierd hack to avoid big warnings
-// Maybe better to find a better solution for it.
-console.warn = () => null;
-
 /**
  * We are gonna use following custom UI components for preview and list.
  * If we use ChannelPreviewMessanger or ChannelPreviewLastmessage here, then changes
@@ -57,9 +50,11 @@ const ChannelListComponent = (props) => {
 jest.mock('axios');
 
 describe('ChannelList', () => {
+  afterEach(cleanup);
+
   it('should render error indicator if queryChannels api fail', async () => {
     useMockedApis(axios, [erroredGetApi()]);
-
+    jest.spyOn(console, 'warn').mockImplementationOnce(() => null);
     const chatClientVishal = getTestClient();
     await chatClientVishal.setUser({ id: 'vishal' });
 
@@ -80,7 +75,7 @@ describe('ChannelList', () => {
     });
   });
 
-  it.skip('should move the channel to top if new message is received', async () => {
+  it('should move the channel to top if new message is received', async () => {
     const channel1 = generateChannel();
     const channel2 = generateChannel();
     const channel3 = generateChannel();
@@ -125,7 +120,7 @@ describe('ChannelList', () => {
     expect(channelPreview.isEqualNode(items[0])).toBeTruthy();
   });
 
-  it.skip('should move the new channel to top of list if notification.added_to_channel is received', async () => {
+  it('should move the new channel to top of list if notification.added_to_channel is received', async () => {
     const channel1 = generateChannel();
     const channel2 = generateChannel();
     const channel3 = generateChannel();

--- a/src/components/MessageList/__tests__/MessageList.test.js
+++ b/src/components/MessageList/__tests__/MessageList.test.js
@@ -27,7 +27,7 @@ jest.mock('axios');
 describe('MessageList', () => {
   let chatClientVishal;
 
-  it.skip('should add new message at bottom of the list', async () => {
+  it('should add new message at bottom of the list', async () => {
     const user1 = generateUser();
     const user2 = generateUser();
     const mockedChannel = generateChannel({

--- a/src/mock-builders/index.js
+++ b/src/mock-builders/index.js
@@ -4,10 +4,10 @@
 import { StreamChat } from 'stream-chat';
 
 const apiKey = 'API_KEY';
+const token = 'dummy_token';
 
 const setUser = (client, user) => {
   return new Promise((resolve) => {
-    const token = 'dummy_token';
     client.connectionId = 'dumm_connection_id';
     client.user = user;
     client.user.mutes = [];
@@ -18,19 +18,24 @@ const setUser = (client, user) => {
   });
 };
 
-export const getTestClient = () => {
-  const client = new StreamChat(apiKey);
-
+function mockClient(client) {
+  jest.spyOn(client, '_setToken').mockImplementation();
+  jest.spyOn(client, '_setupConnection').mockImplementation();
+  client.tokenManager = {
+    tokenReady: jest.fn(() => true),
+    getToken: jest.fn(() => token),
+  };
   client.setUser = setUser.bind(null, client);
-
   return client;
+}
+
+export const getTestClient = () => {
+  return mockClient(new StreamChat(apiKey));
 };
 
 export const getTestClientWithUser = async (user) => {
-  const client = new StreamChat(apiKey);
-
+  const client = mockClient(new StreamChat(apiKey));
   await setUser(client, user);
-
   return client;
 };
 


### PR DESCRIPTION
## Description of the pull request

Some recent changes on stream-chat introduced a new way to handle users
and tokens. This led to some of our tests breaking, as our mocking
implementation no longer complied with the actual API of the library.

Here we fix this by mocking and abstracting away the bits that deal with
user and tokens.