### PR TITLE
Fix MessageSimple types

### DIFF
--- a/src/components/Message/MessageSimple.js
+++ b/src/components/Message/MessageSimple.js
@@ -218,11 +218,11 @@ class MessageSimple extends PureComponent {
   }
 
   isMine() {
-    const { message } = this.props;
-    if (!message) {
+    const { message, isMyMessage } = this.props;
+    if (!message || !isMyMessage) {
       return false;
     }
-    return this.props.isMyMessage(message);
+    return isMyMessage(message);
   }
 
   hasReactions = () => {
@@ -264,7 +264,7 @@ class MessageSimple extends PureComponent {
           className="str-chat__message-simple-status"
           data-testid="message-status-sending"
         >
-          <Tooltip>{t('Sending...')}</Tooltip>
+          <Tooltip>{t && t('Sending...')}</Tooltip>
           <LoadingIndicator />
         </span>
       );
@@ -312,7 +312,7 @@ class MessageSimple extends PureComponent {
           className="str-chat__message-simple-status"
           data-testid="message-status-received"
         >
-          <Tooltip>{t('Delivered')}</Tooltip>
+          <Tooltip>{t && t('Delivered')}</Tooltip>
           <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
             <path
               d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0zm3.72 6.633a.955.955 0 1 0-1.352-1.352L6.986 8.663 5.633 7.31A.956.956 0 1 0 4.28 8.663l2.029 2.028a.956.956 0 0 0 1.353 0l4.058-4.058z"
@@ -514,12 +514,12 @@ class MessageSimple extends PureComponent {
         >
           {message.type === 'error' && (
             <div className="str-chat__simple-message--error-message">
-              {t('Error · Unsent')}
+              {t && t('Error · Unsent')}
             </div>
           )}
           {message.status === 'failed' && (
             <div className="str-chat__simple-message--error-message">
-              {t('Message Failed · Click to try again')}
+              {t && t('Message Failed · Click to try again')}
             </div>
           )}
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -973,11 +973,7 @@ export class MessageTeam extends React.PureComponent<
   any
 > {}
 
-export interface MessageSimpleProps extends MessageUIComponentProps {
-  isMyMessage(message: Client.MessageResponse): boolean;
-  t: i18next.TFunction;
-  tDateTimeParser: (datetime: string | number) => { calendar: () => string };
-}
+export interface MessageSimpleProps extends MessageUIComponentProps {}
 
 export type MessageSimpleState = {
   isFocused: boolean;
@@ -1105,7 +1101,7 @@ export interface TranslationContext
   extends React.Context<TranslationContextValue> {}
 export interface TranslationContextValue {
   t?: i18next.TFunction;
-  tDateTimeParser?(datetime: string | number): object;
+  tDateTimeParser?: (input: string | number) => Dayjs.Dayjs;
 }
 
 export interface Streami18nOptions {


### PR DESCRIPTION
Rely on the MessageUIComponentProps directly. Fixes https://github.com/GetStream/stream-chat-react/issues/291.

## Description of the pull request

Though on the implementation of the message UI components, we explicitly rely on some props to be there, the types are currently not accurately reflecting this. https://github.com/GetStream/stream-chat-react/commit/8d72c986439121ddefc0007e0ab9cb89f558f444 tried to work around this issue by making the specific UI component types more strict, following the actual implementation, but this causes problems as the higher-order components that wrap those UI components would need to comply to their more strict interface also. We could achieve this by [refining](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types) the UI component types in those HOCs, but this is a broader work and could introduce breaking changes in the typescript API of some of those components.