### PR TITLE
CRS-261 correctly set attachment type based on mime, small fixes to audio com…

### DIFF
--- a/src/components/Audio/Audio.js
+++ b/src/components/Audio/Audio.js
@@ -84,7 +84,7 @@ const Audio = ({ og }) => {
               </div>
             )}
           </div>
-          <img src={image_url} alt={`${description}`} />
+          {image_url && <img src={image_url} alt={`${description}`} />}
         </div>
         <div className="str-chat__audio__content">
           <span className="str-chat__audio__content--title">

--- a/src/components/MessageInput/MessageInputState.js
+++ b/src/components/MessageInput/MessageInputState.js
@@ -17,6 +17,17 @@ import { generateRandomId } from '../../utils';
  * @typedef {import("stream-chat").FileUploadAPIResponse} FileUploadAPIResponse
  */
 
+/**
+ * Get attachment type from MIME type
+ * @param {string} mime
+ * @returns {string}
+ */
+const getAttachmentTypeFromMime = (mime) => {
+  if (mime.includes('video/')) return 'media';
+  if (mime.includes('audio/')) return 'audio';
+  return 'file';
+};
+
 /** @type {{ [id: string]: import('types').FileUpload }} */
 const emptyFileUploads = {};
 /** @type {{ [id: string]: import('types').ImageUpload }} */
@@ -70,7 +81,7 @@ function initState(message) {
           state: 'finished',
           file: {
             name: attachment.title,
-            type: attachment.mime_type,
+            type: getAttachmentTypeFromMime(attachment.mime_type),
             size: attachment.file_size,
           },
         });
@@ -356,7 +367,7 @@ export default function useMessageInputState(props) {
       .map((id) => fileUploads[id])
       .filter((upload) => upload.state !== 'failed')
       .map((upload) => ({
-        type: 'file',
+        type: getAttachmentTypeFromMime(upload.file.type),
         asset_url: upload.url,
         title: upload.file.name,
         mime_type: upload.file.type,

--- a/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -376,6 +376,7 @@ describe('MessageInput', () => {
         expect.objectContaining({
           attachments: expect.arrayContaining([
             expect.objectContaining({
+              type: 'image',
               image_url: fileUploadUrl,
             }),
           ]),
@@ -403,6 +404,37 @@ describe('MessageInput', () => {
         expect.objectContaining({
           attachments: expect.arrayContaining([
             expect.objectContaining({
+              type: 'file',
+              asset_url: fileUploadUrl,
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('should an audio attachment if an audio file is dropped into the input', async () => {
+      const doFileUploadRequest = mockUploadApi();
+      const { findByTitle, findByPlaceholderText } = renderComponent({
+        doFileUploadRequest,
+      });
+      const submitButton = await findByTitle('Send');
+
+      const formElement = await findByPlaceholderText(inputPlaceholder);
+      const file = new File(['Message in a bottle'], 'the-police.mp3', {
+        type: 'audio/mp3',
+      });
+      dropFile(file, formElement);
+
+      // wait for file uploading to complete before trying to send the message
+      // eslint-disable-next-line jest/prefer-called-with
+      await waitFor(() => expect(doFileUploadRequest).toHaveBeenCalled());
+      fireEvent.click(submitButton);
+      expect(submitMock).toHaveBeenCalledWith(
+        channel.cid,
+        expect.objectContaining({
+          attachments: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'audio',
               asset_url: fileUploadUrl,
             }),
           ]),

--- a/src/styles/Attachment.scss
+++ b/src/styles/Attachment.scss
@@ -47,6 +47,8 @@
 }
 
 .str-chat__message-attachment {
+  overflow: hidden;
+
   &:hover {
     background: transparent;
   }

--- a/src/styles/Audio.scss
+++ b/src/styles/Audio.scss
@@ -4,7 +4,7 @@
     overflow: hidden;
     position: relative;
     border-radius: 6px;
-    margin: 8px 0 0;
+    margin: 0;
     display: flex;
     background: #f1f1f1;
   }


### PR DESCRIPTION
…ponent/styles

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Old situation: any upload that's not an image gets attachment type 'file'.
New situation: attachments can also be of type 'audio' or 'media' (based on MIME type). This is consistent with what's defined in the Attachment component.
