### PR TITLE
fix: allow videotypes that actually render

### DIFF
--- a/src/components/Attachment/Attachment.js
+++ b/src/components/Attachment/Attachment.js
@@ -11,6 +11,8 @@ import { Image } from '../Image';
 import { Card } from '../Card';
 import { SafeAnchor } from '../SafeAnchor';
 
+const SUPPORTED_VIDEO_FORMATS = ['video/mp4', 'video/ogg', 'video/webm'];
+
 /**
  * Attachment - The message attachment
  *
@@ -50,7 +52,7 @@ class Attachment extends PureComponent {
       type = 'image';
     } else if (
       a.type === 'video' ||
-      (a.mime_type && a.mime_type.indexOf('video/') !== -1)
+      (a.mime_type && SUPPORTED_VIDEO_FORMATS.indexOf(a.mime_type) !== -1)
     ) {
       type = 'media';
     } else if (a.type === 'file') {


### PR DESCRIPTION
# Submit a pull request

looked into why .avi wasn't rendering: https://stackoverflow.com/questions/4129674/does-html5-video-playback-support-the-avi-format

only render videos that are supported, show rest as file.

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
