### PR TITLE
Refactor ReactionsList and SimpleReactionsList

### DIFF
--- a/src/components/Reactions/ReactionsList.js
+++ b/src/components/Reactions/ReactionsList.js
@@ -12,6 +12,7 @@ const ReactionsList = ({
   reaction_counts,
   reactionOptions = defaultMinimalEmojis,
   reverse = false,
+  onClick,
 }) => {
   const getTotalReactionCount = () =>
     Object.values(reaction_counts || {}).reduce(
@@ -38,6 +39,7 @@ const ReactionsList = ({
       className={`str-chat__reaction-list ${
         reverse ? 'str-chat__reaction-list--reverse' : ''
       }`}
+      onClick={onClick}
     >
       <ul>
         {getReactionTypes().map((reactionType) => {
@@ -71,6 +73,7 @@ ReactionsList.propTypes = {
   /** Provide a list of reaction options [{id: 'angry', emoji: 'angry'}] */
   reactionOptions: PropTypes.array,
   reverse: PropTypes.bool,
+  onClick: PropTypes.func,
 };
 
 export default React.memo(ReactionsList);

--- a/src/components/Reactions/ReactionsList.js
+++ b/src/components/Reactions/ReactionsList.js
@@ -67,7 +67,7 @@ const ReactionsList = ({
 ReactionsList.propTypes = {
   reactions: PropTypes.array,
   /** Object/map of reaction id/type (e.g. 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry') vs count */
-  reaction_counts: PropTypes.object,
+  reaction_counts: PropTypes.objectOf(PropTypes.number.isRequired),
   /** Provide a list of reaction options [{id: 'angry', emoji: 'angry'}] */
   reactionOptions: PropTypes.array,
   reverse: PropTypes.bool,

--- a/src/components/Reactions/SimpleReactionsList.js
+++ b/src/components/Reactions/SimpleReactionsList.js
@@ -1,176 +1,107 @@
-/* eslint-disable */
-import React from 'react';
+// @ts-check
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
+// @ts-ignore
 import { NimbleEmoji } from 'emoji-mart';
-
 import { defaultMinimalEmojis, emojiSetDef, emojiData } from '../../utils';
 
-class SimpleReactionsList extends React.PureComponent {
-  static propTypes = {
-    reactions: PropTypes.array,
-    /** Object/map of reaction id/type (e.g. 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry') vs count */
-    reaction_counts: PropTypes.object,
-    showTooltip: PropTypes.bool,
-    /** Provide a list of reaction options [{id: 'angry', emoji: 'angry'}] */
-    reactionOptions: PropTypes.array,
-    /**
-     * Handler to set/unset reaction on message.
-     *
-     * @param type e.g. 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry'
-     * */
-    handleReaction: PropTypes.func,
-  };
+/** @type {React.FC<import("types").SimpleReactionsListProps>} */
+const SimpleReactionsList = ({
+  reactions,
+  reaction_counts,
+  reactionOptions = defaultMinimalEmojis,
+  handleReaction,
+}) => {
+  const [tooltipReactionType, setTooltipReactionType] = useState(null);
+  const reactionSelectorTooltip = useRef(null);
 
-  static defaultProps = {
-    showTooltip: true,
-    reactionOptions: defaultMinimalEmojis,
-    emojiSetDef,
-  };
+  /** @param {string | null} type */
+  const getUsersPerReactionType = (type) =>
+    reactions
+      ?.map((reaction) => {
+        if (reaction.type === type) {
+          return reaction.user?.name || reaction.user?.id;
+        }
+        return null;
+      })
+      .filter(Boolean);
 
-  state = {
-    showTooltip: false,
-    users: [],
-  };
-
-  showTooltip = () => {
-    this.setState({
-      showTooltip: true,
-    });
-  };
-
-  hideTooltip = () => {
-    this.setState({
-      showTooltip: false,
-    });
-  };
-
-  handleReaction = (e, type) => {
-    if (e !== undefined && e.preventDefault) {
-      e.preventDefault();
-    }
-    this.props.handleReaction(type);
-    this.setUsernames(type);
-  };
-
-  getReactionCount = () => {
-    const reaction_counts = this.props.reaction_counts;
-    let count = null;
-    if (
-      reaction_counts !== null &&
-      reaction_counts !== undefined &&
-      Object.keys(reaction_counts).length > 0
-    ) {
-      count = 0;
-      Object.keys(reaction_counts).map(
-        (key) => (count += reaction_counts[key]),
-      );
-    }
-    return count;
-  };
-
-  renderUsers = (users) =>
-    users.map((user, i) => {
-      let text = user;
-      if (i + 1 < users.length) {
-        text += ', ';
-      }
-      return (
-        <span className="latest-user-username" key={`key-${i}-${user}`}>
-          {text}
-        </span>
-      );
-    });
-
-  getReactionsByType = (reactions) => {
-    const reactionsByType = {};
-    reactions.map((item) => {
-      if (reactionsByType[item.type] === undefined) {
-        return (reactionsByType[item.type] = [item]);
-      } else {
-        return (reactionsByType[item.type] = [
-          ...reactionsByType[item.type],
-          item,
-        ]);
-      }
-    });
-    return reactionsByType;
-  };
-
-  renderReactions = (reactions) => {
-    const reactionsByType = this.getReactionsByType(reactions);
-    const reactionsEmojis = this.props.reactionOptions.reduce(
-      (acc, cur) => ({ ...acc, [cur.id]: cur }),
-      {},
-    );
-    return Object.keys(reactionsByType).map((type, i) => (
-      <li
-        className="str-chat__simple-reactions-list-item"
-        key={`${reactionsByType[type][0].id}-${i}`}
-        onClick={(e) => this.handleReaction(e, type)}
-      >
-        <span onMouseEnter={() => this.setUsernames(type)}>
-          <NimbleEmoji
-            emoji={reactionsEmojis[type]}
-            {...emojiSetDef}
-            size={13}
-            data={emojiData}
-          />
-          &nbsp;
-        </span>
-      </li>
-    ));
-  };
-
-  getUsernames = (reactions) =>
-    reactions.map((item) =>
-      item.user !== null ? item.user.name || item.user.id : 'null',
+  const getTotalReactionCount = () =>
+    Object.values(reaction_counts || {}).reduce(
+      (total, count) => total + count,
+      0,
     );
 
-  setUsernames = (type) => {
-    const reactionsByType = this.getReactionsByType(this.props.reactions);
-
-    const reactions = reactionsByType[type];
-    const users = this.getUsernames(reactions);
-
-    this.setState(
-      {
-        users,
-      },
-      () => this.showTooltip(),
-    );
+  const getReactionTypes = () => {
+    if (!reactions) return [];
+    const allTypes = new Set();
+    reactions.forEach(({ type }) => {
+      allTypes.add(type);
+    });
+    return Array.from(allTypes);
   };
 
-  renderUsernames = (users) => users.join(', ');
+  /** @param {string} type */
+  const getOptionForType = (type) =>
+    reactionOptions.find((option) => option.id === type);
 
-  render() {
-    const { reactions } = this.props;
-    if (!reactions || reactions.length === 0) {
-      return null;
-    }
-    return (
-      <ul
-        data-testid="simple-reaction-list"
-        className="str-chat__simple-reactions-list"
-        onMouseLeave={this.hideTooltip}
-      >
-        {this.state.showTooltip && (
-          <div
-            className="str-chat__simple-reactions-list-tooltip"
-            ref={this.reactionSelectorTooltip}
+  return (
+    <ul
+      data-testid="simple-reaction-list"
+      className="str-chat__simple-reactions-list"
+      onMouseLeave={() => setTooltipReactionType(null)}
+    >
+      {getReactionTypes().map((reactionType, i) => {
+        const emojiDefinition = getOptionForType(reactionType);
+        return (
+          <li
+            className="str-chat__simple-reactions-list-item"
+            key={`${emojiDefinition?.id}-${i}`}
+            onClick={() => handleReaction && handleReaction(reactionType)}
           >
-            <div className="arrow" />
-            {this.renderUsernames(this.state.users)}
-          </div>
-        )}
-        {this.renderReactions(reactions)}
-        {reactions.length !== 0 && (
-          <li className="str-chat__simple-reactions-list-item--last-number">
-            {this.getReactionCount()}
-          </li>
-        )}
-      </ul>
-    );
-  }
-}
+            <span onMouseEnter={() => setTooltipReactionType(reactionType)}>
+              <NimbleEmoji
+                emoji={emojiDefinition}
+                {...emojiSetDef}
+                size={13}
+                data={emojiData}
+              />
+              &nbsp;
+            </span>
 
-export default SimpleReactionsList;
+            {tooltipReactionType === getOptionForType(reactionType)?.id && (
+              <div
+                className="str-chat__simple-reactions-list-tooltip"
+                ref={reactionSelectorTooltip}
+              >
+                <div className="arrow" />
+                {getUsersPerReactionType(tooltipReactionType)?.join(', ')}
+              </div>
+            )}
+          </li>
+        );
+      })}
+      {reactions?.length !== 0 && (
+        <li className="str-chat__simple-reactions-list-item--last-number">
+          {getTotalReactionCount()}
+        </li>
+      )}
+    </ul>
+  );
+};
+
+SimpleReactionsList.propTypes = {
+  reactions: PropTypes.array,
+  /** Object/map of reaction id/type (e.g. 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry') vs count */
+  reaction_counts: PropTypes.object,
+  /** Provide a list of reaction options [{id: 'angry', emoji: 'angry'}] */
+  reactionOptions: PropTypes.array,
+  /**
+   * Handler to set/unset reaction on message.
+   *
+   * @param type e.g. 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry'
+   * */
+  handleReaction: PropTypes.func,
+};
+
+export default React.memo(SimpleReactionsList);

--- a/src/components/Reactions/SimpleReactionsList.js
+++ b/src/components/Reactions/SimpleReactionsList.js
@@ -1,5 +1,5 @@
 // @ts-check
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 // @ts-ignore
 import { NimbleEmoji } from 'emoji-mart';
@@ -13,7 +13,6 @@ const SimpleReactionsList = ({
   handleReaction,
 }) => {
   const [tooltipReactionType, setTooltipReactionType] = useState(null);
-  const reactionSelectorTooltip = useRef(null);
 
   /** @param {string | null} type */
   const getUsersPerReactionType = (type) =>
@@ -70,10 +69,7 @@ const SimpleReactionsList = ({
             </span>
 
             {tooltipReactionType === getOptionForType(reactionType)?.id && (
-              <div
-                className="str-chat__simple-reactions-list-tooltip"
-                ref={reactionSelectorTooltip}
-              >
+              <div className="str-chat__simple-reactions-list-tooltip">
                 <div className="arrow" />
                 {getUsersPerReactionType(tooltipReactionType)?.join(', ')}
               </div>
@@ -93,7 +89,7 @@ const SimpleReactionsList = ({
 SimpleReactionsList.propTypes = {
   reactions: PropTypes.array,
   /** Object/map of reaction id/type (e.g. 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry') vs count */
-  reaction_counts: PropTypes.object,
+  reaction_counts: PropTypes.objectOf(PropTypes.number.isRequired),
   /** Provide a list of reaction options [{id: 'angry', emoji: 'angry'}] */
   reactionOptions: PropTypes.array,
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,7 @@ export const commonEmoji = {
   short_names: [],
   custom: true,
 };
-
+/** @type {import("types").MinimalEmojiInterface[]} */
 export const defaultMinimalEmojis = [
   {
     id: 'like',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -619,7 +619,7 @@ export interface ReactionSelectorProps {
    * }
    * ```
    * */
-  latest_reactions: Client.ReactionResponse[];
+  latest_reactions?: Client.ReactionResponse[];
   /**
    * {
    *  'like': 9,
@@ -627,7 +627,7 @@ export interface ReactionSelectorProps {
    *  'haha': 2
    * }
    */
-  reaction_counts: {
+  reaction_counts?: {
     [reaction_type: string]: number;
   };
   /** Enable the avatar display */
@@ -672,7 +672,7 @@ export interface ReactionsListProps {
    */
   reaction_counts?: {
     [reaction_type: string]: number;
-  } | {};
+  };
   /** Provide a list of reaction options [{name: 'angry', emoji: 'angry'}] */
   reactionOptions?: MinimalEmojiInterface[];
   onClick?(): void;
@@ -864,11 +864,9 @@ export interface SimpleReactionsListProps {
    *  'haha': 2
    * }
    */
-  reaction_counts?:
-    | {
-        [reaction_type: string]: number;
-      }
-    | {};
+  reaction_counts?: {
+    [reaction_type: string]: number;
+  };
   /** Provide a list of reaction options [{name: 'angry', emoji: 'angry'}] */
   reactionOptions?: MinimalEmojiInterface[];
   handleReaction?(reactionType: string): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -662,7 +662,7 @@ export interface ReactionsListProps {
    * }
    * ```
    * */
-  reactions: Client.ReactionResponse[];
+  reactions?: Client.ReactionResponse[];
   /**
    * {
    *  'like': 9,
@@ -670,11 +670,11 @@ export interface ReactionsListProps {
    *  'haha': 2
    * }
    */
-  reaction_counts: {
+  reaction_counts?: {
     [reaction_type: string]: number;
-  };
+  } | {};
   /** Provide a list of reaction options [{name: 'angry', emoji: 'angry'}] */
-  reactionOptions?: MinimalEmojiInterface;
+  reactionOptions?: MinimalEmojiInterface[];
   onClick?(): void;
   reverse?: boolean;
   emojiSetDef?: EnojiSetDef;
@@ -856,7 +856,7 @@ export interface ModalProps {
 }
 export interface SafeAnchorProps {}
 export interface SimpleReactionsListProps {
-  reactions: Client.ReactionResponse[];
+  reactions?: Client.ReactionResponse[];
   /**
    * {
    *  'like': 9,
@@ -864,12 +864,13 @@ export interface SimpleReactionsListProps {
    *  'haha': 2
    * }
    */
-  reaction_counts: {
-    [reaction_type: string]: number;
-  };
-  showTooltip?: boolean;
+  reaction_counts?:
+    | {
+        [reaction_type: string]: number;
+      }
+    | {};
   /** Provide a list of reaction options [{name: 'angry', emoji: 'angry'}] */
-  reactionOptions?: MinimalEmojiInterface;
+  reactionOptions?: MinimalEmojiInterface[];
   handleReaction?(reactionType: string): void;
 }
 export interface TooltipProps {}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
This refactors ReactionsList and SimpleReactionsList to use hooks. There is some overlap in functionality between the two components, but I decided to not separate that into some separate module (or hook) because it's only used by these two components, and it's just two functions that take some prop and convert it into something that can be rendered (i.e. not stateful).