### PR TITLE
Make <MessageSimple /> a functional component

### DIFF
--- a/src/components/Message/MessageDeleted.js
+++ b/src/components/Message/MessageDeleted.js
@@ -37,6 +37,8 @@ const MessageDeleted = (props) => {
 
 MessageDeleted.propTypes = {
   /** The [message object](https://getstream.io/chat/docs/#message_format) */
+  // @ts-ignore
+  // Ignoring this for now as Typescript definitions on 'strem-chat' are wrong.
   message: MessagePropTypes,
   /** @deprecated This is no longer needed. The component should now rely on the user role custom hook */
   isMyMessage: PropTypes.func,

--- a/src/components/Message/MessageSimple.js
+++ b/src/components/Message/MessageSimple.js
@@ -1,5 +1,5 @@
 // @ts-check
-import React, { PureComponent } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import MessageRepliesCountButton from './MessageRepliesCountButton';
@@ -9,7 +9,7 @@ import {
   getReadByTooltipText,
   smartRender,
 } from '../../utils';
-import { withTranslationContext } from '../../context';
+import { TranslationContext, ChannelContext } from '../../context';
 import { Attachment as DefaultAttachment } from '../Attachment';
 import { Avatar } from '../Avatar';
 import { Gallery } from '../Gallery';
@@ -20,438 +20,441 @@ import { Tooltip } from '../Tooltip';
 import { LoadingIndicator } from '../Loading';
 import { ReactionsList, ReactionSelector } from '../Reactions';
 import DefaultMessageDeleted from './MessageDeleted';
+import { useUserRole } from './hooks/useUserRole';
+import { useReactionHandler } from './hooks/useReactionHandler';
+import { useOpenThreadHandler } from './hooks/useOpenThreadHandler';
+import { useMentionsHandler } from './hooks/useMentionsHandler';
+import { useMuteHandler } from './hooks/useMuteHandler';
+import { useFlagHandler } from './hooks/useFlagHandler';
+import { isUserMuted, areMessagePropsEqual } from './utils';
+import { useEditHandler } from './hooks/useEditHandler';
+import { useDeleteHandler } from './hooks/useDeleteHandler';
+import { useActionHandler } from './hooks/useActionHandler';
+import { useRetryHandler } from './hooks/useRetryHandler';
+import { useUserHandler } from './hooks/useUserHandler';
+
+/** @type {(message: import('stream-chat').MessageResponse | undefined) => boolean} */
+const messageHasReactions = (message) => {
+  if (!message) {
+    return false;
+  }
+  return Boolean(message.latest_reactions && message.latest_reactions.length);
+};
+
+/** @type {(message: import('stream-chat').MessageResponse | undefined) => boolean} */
+const messageHasAttachments = (message) => {
+  return Boolean(message && message.attachments && message.attachments.length);
+};
 
 /**
  * MessageSimple - Render component, should be used together with the Message component
  *
  * @example ../../docs/MessageSimple.md
- * @typedef { import('types').MessageSimpleProps } Props
- * @typedef { import('types').MessageSimpleState } State
- * @extends PureComponent<Props, State>
+ * @type { React.FC<import('types').MessageSimpleProps> }
  */
-class MessageSimple extends PureComponent {
-  static propTypes = {
-    /** The [message object](https://getstream.io/chat/docs/#message_format) */
-    message: PropTypes.object,
-    /**
-     * The attachment UI component.
-     * Default: [Attachment](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Attachment.js)
-     * */
-    Attachment: PropTypes.elementType,
-    /**
-     * @deprecated Its not recommended to use this anymore. All the methods in this HOC are provided explicitly.
-     *
-     * The higher order message component, most logic is delegated to this component
-     * @see See [Message HOC](https://getstream.github.io/stream-chat-react/#message) for example
-     *
-     * */
-    Message: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.func,
-      PropTypes.object,
-    ]).isRequired,
-    /** render HTML instead of markdown. Posting HTML is only allowed server-side */
-    unsafeHTML: PropTypes.bool,
-    /** Client object */
-    client: PropTypes.object,
-    /** If its parent message in thread. */
-    initialMessage: PropTypes.bool,
-    /** Channel config object */
-    channelConfig: PropTypes.object,
-    /** If component is in thread list */
-    threadList: PropTypes.bool,
-    /** Function to open thread on current messxage */
-    handleOpenThread: PropTypes.func,
-    /** If the message is in edit state */
-    editing: PropTypes.bool,
-    /** Function to exit edit state */
-    clearEditingState: PropTypes.func,
-    /** Returns true if message belongs to current user */
-    isMyMessage: PropTypes.func,
-    /**
-     * Returns all allowed actions on message by current user e.g., [edit, delete, flag, mute]
-     * Please check [Message](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message.js) component for default implementation.
-     * */
-    getMessageActions: PropTypes.func,
-    /**
-     * Function to publish updates on message to channel
-     *
-     * @param message Updated [message object](https://getstream.io/chat/docs/#message_format)
-     * */
-    updateMessage: PropTypes.func,
-    /**
-     * Reattempt sending a message
-     * @param message A [message object](https://getstream.io/chat/docs/#message_format) to resent.
-     */
-    handleRetry: PropTypes.func,
-    /**
-     * Add or remove reaction on message
-     *
-     * @param type Type of reaction - 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry'
-     * @param event Dom event which triggered this function
-     */
-    handleReaction: PropTypes.func,
-    /** If actions such as edit, delete, flag, mute are enabled on message */
-    actionsEnabled: PropTypes.bool,
-    /** DOMRect object for parent MessageList component */
-    messageListRect: PropTypes.object,
-    /**
-     * Handler for actions. Actions in combination with attachments can be used to build [commands](https://getstream.io/chat/docs/#channel_commands).
-     *
-     * @param name {string} Name of action
-     * @param value {string} Value of action
-     * @param event Dom event that triggered this handler
-     */
-    handleAction: PropTypes.func,
-    /**
-     * The handler for hover event on @mention in message
-     *
-     * @param event Dom hover event which triggered handler.
-     * @param user Target user object
-     */
-    onMentionsHoverMessage: PropTypes.func,
-    /**
-     * The handler for click event on @mention in message
-     *
-     * @param event Dom click event which triggered handler.
-     * @param user Target user object
-     */
-    onMentionsClickMessage: PropTypes.func,
-    /**
-     * The handler for click event on the user that posted the message
-     *
-     * @param event Dom click event which triggered handler.
-     */
-    onUserClick: PropTypes.func,
-    /**
-     * The handler for mouseOver event on the user that posted the message
-     *
-     * @param event Dom mouseOver event which triggered handler.
-     */
-    onUserHover: PropTypes.func,
-    /**
-     * Additional props for underlying MessageInput component.
-     * Available props - https://getstream.github.io/stream-chat-react/#messageinput
-     * */
-    additionalMessageInputProps: PropTypes.object,
-    /**
-     * The component that will be rendered if the message has been deleted.
-     * All of Message's props are passed into this component.
-     */
-    MessageDeleted: PropTypes.elementType,
-  };
+// eslint-disable-next-line sonarjs/cognitive-complexity
+const MessageSimple = (props) => {
+  const {
+    clearEditingState,
+    editing,
+    message,
+    messageListRect,
+    threadList,
+    updateMessage: propUpdateMessage,
+    handleAction: propHandleAction,
+    handleOpenThread: propHandleOpenThread,
+    handleReaction: propHandleReaction,
+    handleRetry: propHandleRetry,
+    onUserClick: onUserClickCustomHandler,
+    onUserHover: onUserHoverCustomHandler,
+    tDateTimeParser: propTDateTimeParser,
+  } = props;
+  /**
+   *@type {import('types').ChannelContextValue}
+   */
+  const { updateMessage: channelUpdateMessage } = useContext(ChannelContext);
+  const updateMessage = propUpdateMessage || channelUpdateMessage;
+  const { tDateTimeParser } = useContext(TranslationContext);
+  const [showDetailedReactions, setShowDetailedReactions] = useState(false);
+  const [actionsBoxOpen, setActionsBoxOpen] = useState(false);
+  const { isMyMessage } = useUserRole(props.message);
+  const handleOpenThread = useOpenThreadHandler(message);
+  const handleReaction = useReactionHandler(message);
+  const handleAction = useActionHandler(message);
+  const handleRetry = useRetryHandler();
+  const { onUserClick, onUserHover } = useUserHandler(
+    {
+      onUserClickHandler: onUserClickCustomHandler,
+      onUserHoverHandler: onUserHoverCustomHandler,
+    },
+    message,
+  );
+  const {
+    Attachment = DefaultAttachment,
+    MessageDeleted = DefaultMessageDeleted,
+  } = props;
+  /** @type { React.RefObject<ReactionSelector> | null } */
+  const reactionSelectorRef = React.createRef();
 
-  static defaultProps = {
-    Attachment: DefaultAttachment,
-    MessageDeleted: DefaultMessageDeleted,
-  };
-
-  state = {
-    isFocused: false,
-    actionsBoxOpen: false,
-    showDetailedReactions: false,
-  };
-
-  messageActionsRef = React.createRef();
-
-  reactionSelectorRef = React.createRef();
+  /** @type {EventListener} */
+  const closeDetailedReactions = useCallback(
+    (event) => {
+      if (
+        event.target &&
+        // @ts-ignore
+        reactionSelectorRef?.current?.reactionSelector?.current?.contains(
+          event.target,
+        )
+      ) {
+        return;
+      }
+      setShowDetailedReactions(() => false);
+    },
+    [setShowDetailedReactions, reactionSelectorRef],
+  );
+  /** @type {() => void} Typescript syntax */
+  const onReactionListClick = () => setShowDetailedReactions(true);
+  useEffect(() => {
+    if (showDetailedReactions) {
+      document.addEventListener('click', closeDetailedReactions);
+      document.addEventListener('touchend', closeDetailedReactions);
+    } else {
+      document.removeEventListener('click', closeDetailedReactions);
+      document.removeEventListener('touchend', closeDetailedReactions);
+    }
+    return () => {
+      document.removeEventListener('click', closeDetailedReactions);
+      document.removeEventListener('touchend', closeDetailedReactions);
+    };
+  }, [showDetailedReactions, closeDetailedReactions]);
 
   /** @type {() => void} Typescript syntax */
-  _onClickOptionsAction = () => {
-    this.setState(
-      {
-        actionsBoxOpen: true,
-      },
-      () => document.addEventListener('click', this._hideOptions, false),
+  const hideOptions = () => setActionsBoxOpen(false);
+  useEffect(() => {
+    if (message?.deleted_at) {
+      document.removeEventListener('click', closeDetailedReactions);
+      document.removeEventListener('touchend', closeDetailedReactions);
+      document.removeEventListener('click', hideOptions);
+    }
+  }, [message, closeDetailedReactions]);
+  const dateTimeParser = propTDateTimeParser || tDateTimeParser;
+  const when =
+    dateTimeParser &&
+    message &&
+    dateTimeParser(message.created_at).calendar &&
+    dateTimeParser(message.created_at).calendar();
+  const hasReactions = messageHasReactions(message);
+  const hasAttachment = messageHasAttachments(message);
+
+  const messageClasses = isMyMessage
+    ? 'str-chat__message str-chat__message--me str-chat__message-simple str-chat__message-simple--me'
+    : 'str-chat__message str-chat__message-simple';
+
+  const images =
+    hasAttachment &&
+    message?.attachments?.filter(
+      /** @type {(item: import('stream-chat').Attachment) => boolean} Typescript syntax */
+      (item) => item.type === 'image',
     );
-  };
 
-  /** @type {() => void} Typescript syntax */
-  _hideOptions = () => {
-    this.setState({
-      actionsBoxOpen: false,
-    });
-    document.removeEventListener('click', this._hideOptions, false);
-  };
-
-  /** @type {() => void} Typescript syntax */
-  _clickReactionList = () => {
-    this.setState(
-      () => ({
-        showDetailedReactions: true,
-      }),
-      () => {
-        document.addEventListener('click', this._closeDetailedReactions);
-        document.addEventListener('touchend', this._closeDetailedReactions);
-      },
-    );
-  };
-
-  /** @type {EventListener} Typescript syntax */
-  _closeDetailedReactions = (e) => {
-    if (
-      !this.reactionSelectorRef.current.reactionSelector.current.contains(
-        e.target,
-      )
-    ) {
-      this.setState(
-        () => ({
-          showDetailedReactions: false,
-        }),
-        () => {
-          document.removeEventListener('click', this._closeDetailedReactions);
-          document.removeEventListener(
-            'touchend',
-            this._closeDetailedReactions,
-          );
-        },
-      );
-    }
-  };
-
-  componentWillUnmount() {
-    if (!this.props.message?.deleted_at) {
-      document.removeEventListener('click', this._closeDetailedReactions);
-      document.removeEventListener('touchend', this._closeDetailedReactions);
-      document.removeEventListener('click', this._hideOptions);
-    }
-  }
-
-  isMine() {
-    const { message, isMyMessage } = this.props;
-    if (!message || !isMyMessage) {
-      return false;
-    }
-    return isMyMessage(message);
-  }
-
-  hasReactions = () => {
-    const { message } = this.props;
-    if (!message) {
-      return false;
-    }
-    return Boolean(message.latest_reactions && message.latest_reactions.length);
-  };
-
-  hasAttachment = () => {
-    const { message } = this.props;
-    return Boolean(
-      message && message.attachments && message.attachments.length,
-    );
-  };
-
-  renderStatus = () => {
-    const {
-      readBy,
-      client,
-      message,
-      threadList,
-      lastReceivedId,
-      t,
-    } = this.props;
-    if (!this.isMine() || message?.type === 'error') {
-      return null;
-    }
-    const justReadByMe =
-      readBy &&
-      readBy.length === 1 &&
-      readBy[0] &&
-      client &&
-      readBy[0].id === client.user.id;
-    if (message && message.status === 'sending') {
-      return (
-        <span
-          className="str-chat__message-simple-status"
-          data-testid="message-status-sending"
-        >
-          <Tooltip>{t && t('Sending...')}</Tooltip>
-          <LoadingIndicator />
-        </span>
-      );
-    }
-    if (readBy && readBy.length !== 0 && !threadList && !justReadByMe) {
-      const lastReadUser = readBy.filter(
-        /** @type {(item: import('stream-chat').UserResponse) => boolean} Typescript syntax */
-        (item) => !!item && !!client && item.id !== client.user.id,
-      )[0];
-      return (
-        <span
-          className="str-chat__message-simple-status"
-          data-testid="message-status-read-by"
-        >
-          <Tooltip>
-            {readBy &&
-              getReadByTooltipText(readBy, this.props.t, this.props.client)}
-          </Tooltip>
-          <Avatar
-            name={lastReadUser && lastReadUser.name ? lastReadUser.name : null}
-            image={
-              lastReadUser && lastReadUser.image ? lastReadUser.image : null
-            }
-            size={15}
-          />
-          {readBy.length > 2 && (
-            <span
-              className="str-chat__message-simple-status-number"
-              data-testid="message-status-read-by-many"
-            >
-              {readBy.length - 1}
-            </span>
-          )}
-        </span>
-      );
-    }
-    if (
-      message &&
-      message.status === 'received' &&
-      message.id === lastReceivedId &&
-      !threadList
-    ) {
-      return (
-        <span
-          className="str-chat__message-simple-status"
-          data-testid="message-status-received"
-        >
-          <Tooltip>{t && t('Delivered')}</Tooltip>
-          <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
-            <path
-              d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0zm3.72 6.633a.955.955 0 1 0-1.352-1.352L6.986 8.663 5.633 7.31A.956.956 0 1 0 4.28 8.663l2.029 2.028a.956.956 0 0 0 1.353 0l4.058-4.058z"
-              fill="#006CFF"
-              fillRule="evenodd"
-            />
-          </svg>
-        </span>
-      );
-    }
+  if (message?.type === 'message.read' || message?.type === 'message.date') {
     return null;
-  };
+  }
 
-  renderMessageActions = () => {
-    const {
-      getMessageActions,
-      messageListRect,
-      handleFlag,
-      handleMute,
-      handleEdit,
-      handleDelete,
-      isUserMuted,
-    } = this.props;
-    const messageActions = getMessageActions();
-
-    if (messageActions.length === 0) {
-      return null;
-    }
-
-    return (
-      <div
-        data-testid="message-actions"
-        onClick={this._onClickOptionsAction}
-        className="str-chat__message-simple__actions__action str-chat__message-simple__actions__action--options"
-      >
-        <MessageActionsBox
-          getMessageActions={getMessageActions}
-          open={this.state.actionsBoxOpen}
-          messageListRect={messageListRect}
-          handleFlag={handleFlag}
-          isUserMuted={isUserMuted}
-          handleMute={handleMute}
-          handleEdit={handleEdit}
-          handleDelete={handleDelete}
-          mine={this.isMine()}
-        />
-        <svg
-          width="11"
-          height="4"
-          viewBox="0 0 11 4"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1.5 3a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
-            fillRule="nonzero"
+  if (message?.deleted_at) {
+    return smartRender(MessageDeleted, { message }, null);
+  }
+  return (
+    <React.Fragment>
+      {editing && (
+        <Modal open={editing} onClose={clearEditingState}>
+          <MessageInput
+            Input={EditMessageForm}
+            message={message}
+            clearEditingState={clearEditingState}
+            updateMessage={updateMessage}
+            {...props.additionalMessageInputProps}
           />
-        </svg>
-      </div>
-    );
-  };
+        </Modal>
+      )}
+      {message && (
+        <div
+          key={message.id || ''}
+          className={`
+						${messageClasses}
+						str-chat__message--${message.type}
+						str-chat__message--${message.status}
+						${message.text ? 'str-chat__message--has-text' : 'has-no-text'}
+						${hasAttachment ? 'str-chat__message--has-attachment' : ''}
+						${hasReactions ? 'str-chat__message--with-reactions' : ''}
+					`.trim()}
+          onMouseLeave={hideOptions}
+        >
+          <MessageSimpleStatus {...props} />
 
-  renderOptions() {
-    const {
-      message,
-      initialMessage,
-      channelConfig,
-      threadList,
-      handleOpenThread,
-    } = this.props;
-    if (
-      !message ||
-      message.type === 'error' ||
-      message.type === 'system' ||
-      message.type === 'ephemeral' ||
-      message.status === 'failed' ||
-      message.status === 'sending' ||
-      initialMessage
-    ) {
-      return null;
-    }
-    if (this.isMine()) {
-      return (
-        <div className="str-chat__message-simple__actions">
-          {this.renderMessageActions()}
-          {!threadList && channelConfig && channelConfig.replies && (
-            <div
-              data-testid="thread-action"
-              onClick={handleOpenThread}
-              className="str-chat__message-simple__actions__action str-chat__message-simple__actions__action--thread"
-            >
-              <svg width="14" height="10" xmlns="http://www.w3.org/2000/svg">
-                <path
-                  d="M8.516 3c4.78 0 4.972 6.5 4.972 6.5-1.6-2.906-2.847-3.184-4.972-3.184v2.872L3.772 4.994 8.516.5V3zM.484 5l4.5-4.237v1.78L2.416 5l2.568 2.125v1.828L.484 5z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </div>
+          {message.user && (
+            <Avatar
+              image={message.user.image}
+              name={message.user.name || message.user.id}
+              onClick={onUserClick}
+              onMouseOver={onUserHover}
+            />
           )}
-          {channelConfig && channelConfig.reactions && (
-            <div
-              data-testid="simple-message-reaction-action"
-              className="str-chat__message-simple__actions__action str-chat__message-simple__actions__action--reactions"
-              onClick={this._clickReactionList}
-            >
-              <svg
-                width="16"
-                height="14"
-                viewBox="0 0 16 14"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M11.108 8.05a.496.496 0 0 1 .212.667C10.581 10.147 8.886 11 7 11c-1.933 0-3.673-.882-4.33-2.302a.497.497 0 0 1 .9-.417C4.068 9.357 5.446 10 7 10c1.519 0 2.869-.633 3.44-1.738a.495.495 0 0 1 .668-.212zm.792-1.826a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.298 0-.431.168-.54.307A.534.534 0 0 1 9.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zm-7 0a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.299 0-.432.168-.54.307A.533.533 0 0 1 2.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zM7 0a7 7 0 1 1 0 14A7 7 0 0 1 7 0zm4.243 11.243A5.96 5.96 0 0 0 13 7a5.96 5.96 0 0 0-1.757-4.243A5.96 5.96 0 0 0 7 1a5.96 5.96 0 0 0-4.243 1.757A5.96 5.96 0 0 0 1 7a5.96 5.96 0 0 0 1.757 4.243A5.96 5.96 0 0 0 7 13a5.96 5.96 0 0 0 4.243-1.757z"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </div>
-          )}
-        </div>
-      );
-    }
-
-    return (
-      <div className="str-chat__message-simple__actions">
-        {channelConfig && channelConfig.reactions && (
           <div
-            className="str-chat__message-simple__actions__action str-chat__message-simple__actions__action--reactions"
-            onClick={this._clickReactionList}
+            data-testid="message-inner"
+            className="str-chat__message-inner"
+            onClick={() => {
+              if (
+                message.status === 'failed' &&
+                (propHandleRetry || handleRetry)
+              ) {
+                const retryHandler = propHandleRetry || handleRetry;
+                // FIXME: type checking fails here because in the case of a failed message,
+                // `message` is of type Client.Message (i.e. request object)
+                // instead of Client.MessageResponse (i.e. server response object)
+                // @ts-ignore
+                retryHandler(message);
+              }
+            }}
           >
-            <svg width="14" height="14" xmlns="http://www.w3.org/2000/svg">
-              <path
-                d="M11.108 8.05a.496.496 0 0 1 .212.667C10.581 10.147 8.886 11 7 11c-1.933 0-3.673-.882-4.33-2.302a.497.497 0 0 1 .9-.417C4.068 9.357 5.446 10 7 10c1.519 0 2.869-.633 3.44-1.738a.495.495 0 0 1 .668-.212zm.792-1.826a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.298 0-.431.168-.54.307A.534.534 0 0 1 9.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zm-7 0a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.299 0-.432.168-.54.307A.533.533 0 0 1 2.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zM7 0a7 7 0 1 1 0 14A7 7 0 0 1 7 0zm4.243 11.243A5.96 5.96 0 0 0 13 7a5.96 5.96 0 0 0-1.757-4.243A5.96 5.96 0 0 0 7 1a5.96 5.96 0 0 0-4.243 1.757A5.96 5.96 0 0 0 1 7a5.96 5.96 0 0 0 1.757 4.243A5.96 5.96 0 0 0 7 13a5.96 5.96 0 0 0 4.243-1.757z"
-                fillRule="evenodd"
+            {!message.text && (
+              <React.Fragment>
+                {
+                  <MessageSimpleOptions
+                    {...props}
+                    hideOptions={hideOptions}
+                    actionsBoxOpen={actionsBoxOpen}
+                    setActionsBoxOpen={setActionsBoxOpen}
+                    onReactionListClick={onReactionListClick}
+                  />
+                }
+                {/* if reactions show them */}
+                {hasReactions && !showDetailedReactions && (
+                  <ReactionsList
+                    reactions={message.latest_reactions}
+                    reaction_counts={message.reaction_counts}
+                    onClick={onReactionListClick}
+                    reverse={true}
+                  />
+                )}
+                {showDetailedReactions && (
+                  <ReactionSelector
+                    handleReaction={propHandleReaction || handleReaction}
+                    detailedView
+                    reaction_counts={message.reaction_counts}
+                    latest_reactions={message.latest_reactions}
+                    messageList={messageListRect}
+                    ref={reactionSelectorRef}
+                  />
+                )}
+              </React.Fragment>
+            )}
+
+            <div className="str-chat__message-attachment-container">
+              {hasAttachment &&
+                message.attachments?.map(
+                  /** @type {(item: import('stream-chat').Attachment) => React.ReactElement | null} Typescript syntax */
+                  (attachment, index) => {
+                    if (
+                      attachment.type === 'image' &&
+                      images &&
+                      images.length > 1
+                    )
+                      return null;
+                    return (
+                      <Attachment
+                        key={`${message.id}-${index}`}
+                        attachment={attachment}
+                        actionHandler={propHandleAction || handleAction}
+                      />
+                    );
+                  },
+                )}
+            </div>
+            {images && images.length > 1 && <Gallery images={images} />}
+            {message.text && (
+              <MessageSimpleText
+                {...props}
+                actionsBoxOpen={actionsBoxOpen}
+                hideOptions={hideOptions}
+                setActionsBoxOpen={setActionsBoxOpen}
+                showDetailedReactions={showDetailedReactions}
+                onReactionListClick={onReactionListClick}
+                // FIXME: There's some unmatched definition between the infered and the declared
+                // ReactionSelector reference
+                // @ts-ignore
+                reactionSelectorRef={reactionSelectorRef}
               />
-            </svg>
+            )}
+            {!threadList && message.reply_count !== 0 && (
+              <div className="str-chat__message-simple-reply-button">
+                <MessageRepliesCountButton
+                  onClick={propHandleOpenThread || handleOpenThread}
+                  reply_count={message.reply_count}
+                />
+              </div>
+            )}
+            <div
+              className={`str-chat__message-data str-chat__message-simple-data`}
+            >
+              {!isMyMessage && message.user ? (
+                <span className="str-chat__message-simple-name">
+                  {message.user.name || message.user.id}
+                </span>
+              ) : null}
+              <span className="str-chat__message-simple-timestamp">{when}</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </React.Fragment>
+  );
+};
+
+/**
+ * @type { React.FC<import('types').MessageSimpleTextProps> }
+ */
+const MessageSimpleText = (props) => {
+  const {
+    onMentionsClickMessage: propOnMentionsClick,
+    onMentionsHoverMessage: propOnMentionsHover,
+    actionsBoxOpen,
+    actionsEnabled,
+    hideOptions,
+    message,
+    messageListRect,
+    onReactionListClick,
+    reactionSelectorRef,
+    setActionsBoxOpen,
+    showDetailedReactions,
+    unsafeHTML,
+  } = props;
+  const { onMentionsClick, onMentionsHover } = useMentionsHandler(message);
+  const { t } = useContext(TranslationContext);
+  const { isMyMessage } = useUserRole(message);
+  const hasReactions = messageHasReactions(message);
+  const hasAttachment = messageHasAttachments(message);
+  const handleReaction = useReactionHandler(message);
+
+  if (!message || !message.text) {
+    return null;
+  }
+
+  return (
+    <div className="str-chat__message-text">
+      <div
+        data-testid="message-simple-inner-wrapper"
+        className={`
+          str-chat__message-text-inner str-chat__message-simple-text-inner
+          ${hasAttachment ? 'str-chat__message-text-inner--has-attachment' : ''}
+          ${
+            isOnlyEmojis(message.text)
+              ? 'str-chat__message-simple-text-inner--is-emoji'
+              : ''
+          }
+        `.trim()}
+        onMouseOver={propOnMentionsHover || onMentionsHover}
+        onClick={propOnMentionsClick || onMentionsClick}
+      >
+        {message.type === 'error' && (
+          <div className="str-chat__simple-message--error-message">
+            {t && t('Error · Unsent')}
           </div>
         )}
+        {message.status === 'failed' && (
+          <div className="str-chat__simple-message--error-message">
+            {t && t('Message Failed · Click to try again')}
+          </div>
+        )}
+
+        {unsafeHTML ? (
+          <div dangerouslySetInnerHTML={{ __html: message.html }} />
+        ) : (
+          renderText(message)
+        )}
+
+        {/* if reactions show them */}
+        {hasReactions && !showDetailedReactions && (
+          <ReactionsList
+            reactions={message.latest_reactions}
+            reaction_counts={message.reaction_counts}
+            onClick={onReactionListClick}
+            reverse={true}
+          />
+        )}
+        {showDetailedReactions && (
+          <ReactionSelector
+            mine={isMyMessage}
+            handleReaction={handleReaction}
+            actionsEnabled={actionsEnabled}
+            detailedView
+            reaction_counts={message.reaction_counts}
+            latest_reactions={message.latest_reactions}
+            messageList={messageListRect}
+            // @ts-ignore
+            ref={reactionSelectorRef}
+          />
+        )}
+      </div>
+      {
+        <MessageSimpleOptions
+          {...props}
+          hideOptions={hideOptions}
+          actionsBoxOpen={actionsBoxOpen}
+          setActionsBoxOpen={setActionsBoxOpen}
+        />
+      }
+    </div>
+  );
+};
+
+/**
+ * @type { React.FC<import('types').MessageSimpleOptionsProps> }
+ */
+const MessageSimpleOptions = (props) => {
+  const {
+    message,
+    initialMessage,
+    threadList,
+    actionsBoxOpen,
+    hideOptions,
+    setActionsBoxOpen,
+    onReactionListClick,
+    handleOpenThread: propHandleOpenThread,
+  } = props;
+  const { isMyMessage } = useUserRole(message);
+  const handleOpenThread = useOpenThreadHandler(message);
+  /**
+   * @type {import('types').ChannelContextValue}
+   */
+  const { channel } = useContext(ChannelContext);
+  const channelConfig = channel?.getConfig();
+  if (
+    !message ||
+    message.type === 'error' ||
+    message.type === 'system' ||
+    message.type === 'ephemeral' ||
+    message.status === 'failed' ||
+    message.status === 'sending' ||
+    initialMessage
+  ) {
+    return null;
+  }
+  if (isMyMessage) {
+    return (
+      <div className="str-chat__message-simple__actions">
+        {
+          <MessageSimpleActions
+            {...props}
+            actionsBoxOpen={actionsBoxOpen}
+            hideOptions={hideOptions}
+            setActionsBoxOpen={setActionsBoxOpen}
+          />
+        }
         {!threadList && channelConfig && channelConfig.replies && (
           <div
-            onClick={handleOpenThread}
+            data-testid="thread-action"
+            onClick={propHandleOpenThread || handleOpenThread}
             className="str-chat__message-simple__actions__action str-chat__message-simple__actions__action--thread"
           >
             <svg width="14" height="10" xmlns="http://www.w3.org/2000/svg">
@@ -462,266 +465,379 @@ class MessageSimple extends PureComponent {
             </svg>
           </div>
         )}
-        {this.renderMessageActions()}
-      </div>
-    );
-  }
-
-  renderMessageText = () => {
-    const {
-      actionsEnabled,
-      message,
-      unsafeHTML,
-      handleReaction,
-      onMentionsHoverMessage,
-      onMentionsClickMessage,
-      messageListRect,
-      t,
-    } = this.props;
-    const hasReactions = this.hasReactions();
-    const hasAttachment = this.hasAttachment();
-
-    if (!message || !message.text) {
-      return null;
-    }
-
-    return (
-      <div className="str-chat__message-text">
-        <div
-          data-testid="message-simple-inner-wrapper"
-          className={`
-            str-chat__message-text-inner str-chat__message-simple-text-inner
-            ${
-              this.state.isFocused
-                ? 'str-chat__message-text-inner--focused'
-                : ''
-            }
-            ${
-              hasAttachment
-                ? 'str-chat__message-text-inner--has-attachment'
-                : ''
-            }
-            ${
-              isOnlyEmojis(message.text)
-                ? 'str-chat__message-simple-text-inner--is-emoji'
-                : ''
-            }
-          `.trim()}
-          onMouseOver={onMentionsHoverMessage}
-          onClick={onMentionsClickMessage}
-        >
-          {message.type === 'error' && (
-            <div className="str-chat__simple-message--error-message">
-              {t && t('Error · Unsent')}
-            </div>
-          )}
-          {message.status === 'failed' && (
-            <div className="str-chat__simple-message--error-message">
-              {t && t('Message Failed · Click to try again')}
-            </div>
-          )}
-
-          {unsafeHTML ? (
-            <div dangerouslySetInnerHTML={{ __html: message.html }} />
-          ) : (
-            renderText(message)
-          )}
-
-          {/* if reactions show them */}
-          {hasReactions && !this.state.showDetailedReactions && (
-            <ReactionsList
-              reactions={message.latest_reactions}
-              reaction_counts={message.reaction_counts}
-              onClick={this._clickReactionList}
-              reverse={true}
-            />
-          )}
-          {this.state.showDetailedReactions && (
-            <ReactionSelector
-              mine={this.isMine()}
-              handleReaction={handleReaction}
-              actionsEnabled={actionsEnabled}
-              detailedView
-              reaction_counts={message.reaction_counts}
-              latest_reactions={message.latest_reactions}
-              messageList={messageListRect}
-              ref={this.reactionSelectorRef}
-            />
-          )}
-        </div>
-        {this.renderOptions()}
-      </div>
-    );
-  };
-
-  render() {
-    const {
-      message,
-      Attachment,
-      editing,
-      clearEditingState,
-      handleRetry,
-      updateMessage,
-      handleReaction,
-      messageListRect,
-      handleAction,
-      onUserClick,
-      onUserHover,
-      threadList,
-      handleOpenThread,
-      tDateTimeParser,
-      MessageDeleted,
-    } = this.props;
-    const when =
-      tDateTimeParser &&
-      message &&
-      tDateTimeParser(message.created_at).calendar &&
-      tDateTimeParser(message.created_at).calendar();
-    const hasReactions = this.hasReactions();
-    const hasAttachment = this.hasAttachment();
-
-    const messageClasses = this.isMine()
-      ? 'str-chat__message str-chat__message--me str-chat__message-simple str-chat__message-simple--me'
-      : 'str-chat__message str-chat__message-simple';
-
-    const images =
-      hasAttachment &&
-      message?.attachments?.filter(
-        /** @type {(item: import('stream-chat').Attachment) => boolean} Typescript syntax */
-        (item) => item.type === 'image',
-      );
-
-    if (message?.type === 'message.read' || message?.type === 'message.date') {
-      return null;
-    }
-
-    if (message?.deleted_at) {
-      return smartRender(MessageDeleted, this.props, null);
-    }
-    return (
-      <React.Fragment>
-        {editing && (
-          <Modal open={editing} onClose={clearEditingState}>
-            <MessageInput
-              Input={EditMessageForm}
-              message={message}
-              clearEditingState={clearEditingState}
-              updateMessage={updateMessage}
-              {...this.props.additionalMessageInputProps}
-            />
-          </Modal>
-        )}
-        {message && (
+        {channelConfig && channelConfig.reactions && (
           <div
-            key={message.id || ''}
-            className={`
-						${messageClasses}
-						str-chat__message--${message.type}
-						str-chat__message--${message.status}
-						${message.text ? 'str-chat__message--has-text' : 'has-no-text'}
-						${hasAttachment ? 'str-chat__message--has-attachment' : ''}
-						${hasReactions ? 'str-chat__message--with-reactions' : ''}
-					`.trim()}
-            onMouseLeave={this._hideOptions}
+            data-testid="simple-message-reaction-action"
+            className="str-chat__message-simple__actions__action str-chat__message-simple__actions__action--reactions"
+            onClick={onReactionListClick}
           >
-            {this.renderStatus()}
-
-            {message.user && (
-              <Avatar
-                image={message.user.image}
-                name={message.user.name || message.user.id}
-                onClick={onUserClick}
-                onMouseOver={onUserHover}
-              />
-            )}
-            <div
-              data-testid="message-inner"
-              className="str-chat__message-inner"
-              onClick={() => {
-                if (message.status === 'failed' && handleRetry) {
-                  // FIXME: type checking fails here because in the case of a failed message,
-                  // `message` is of type Client.Message (i.e. request object)
-                  // instead of Client.MessageResponse (i.e. server response object)
-                  // @ts-ignore
-                  handleRetry(message);
-                }
-              }}
+            <svg
+              width="16"
+              height="14"
+              viewBox="0 0 16 14"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              {!message.text && (
-                <React.Fragment>
-                  {this.renderOptions()}
-                  {/* if reactions show them */}
-                  {hasReactions && !this.state.showDetailedReactions && (
-                    <ReactionsList
-                      reactions={message.latest_reactions}
-                      reaction_counts={message.reaction_counts}
-                      onClick={this._clickReactionList}
-                      reverse={true}
-                    />
-                  )}
-                  {this.state.showDetailedReactions && (
-                    <ReactionSelector
-                      handleReaction={handleReaction}
-                      detailedView
-                      reaction_counts={message.reaction_counts}
-                      latest_reactions={message.latest_reactions}
-                      messageList={messageListRect}
-                      ref={this.reactionSelectorRef}
-                    />
-                  )}
-                </React.Fragment>
-              )}
-
-              <div className="str-chat__message-attachment-container">
-                {hasAttachment &&
-                  message.attachments?.map(
-                    /** @type {(item: import('stream-chat').Attachment) => React.ReactElement | null} Typescript syntax */
-                    (attachment, index) => {
-                      if (
-                        attachment.type === 'image' &&
-                        images &&
-                        images.length > 1
-                      )
-                        return null;
-                      return (
-                        // @ts-ignore Attachment is not yet typed
-                        <Attachment
-                          key={`${message.id}-${index}`}
-                          attachment={attachment}
-                          actionHandler={handleAction}
-                        />
-                      );
-                    },
-                  )}
-              </div>
-              {images && images.length > 1 && <Gallery images={images} />}
-              {message.text && this.renderMessageText()}
-              {!threadList && message.reply_count !== 0 && (
-                <div className="str-chat__message-simple-reply-button">
-                  <MessageRepliesCountButton
-                    onClick={handleOpenThread}
-                    reply_count={message.reply_count}
-                  />
-                </div>
-              )}
-              <div
-                className={`str-chat__message-data str-chat__message-simple-data`}
-              >
-                {!this.isMine() && message.user ? (
-                  <span className="str-chat__message-simple-name">
-                    {message.user.name || message.user.id}
-                  </span>
-                ) : null}
-                <span className="str-chat__message-simple-timestamp">
-                  {when}
-                </span>
-              </div>
-            </div>
+              <path
+                d="M11.108 8.05a.496.496 0 0 1 .212.667C10.581 10.147 8.886 11 7 11c-1.933 0-3.673-.882-4.33-2.302a.497.497 0 0 1 .9-.417C4.068 9.357 5.446 10 7 10c1.519 0 2.869-.633 3.44-1.738a.495.495 0 0 1 .668-.212zm.792-1.826a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.298 0-.431.168-.54.307A.534.534 0 0 1 9.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zm-7 0a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.299 0-.432.168-.54.307A.533.533 0 0 1 2.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zM7 0a7 7 0 1 1 0 14A7 7 0 0 1 7 0zm4.243 11.243A5.96 5.96 0 0 0 13 7a5.96 5.96 0 0 0-1.757-4.243A5.96 5.96 0 0 0 7 1a5.96 5.96 0 0 0-4.243 1.757A5.96 5.96 0 0 0 1 7a5.96 5.96 0 0 0 1.757 4.243A5.96 5.96 0 0 0 7 13a5.96 5.96 0 0 0 4.243-1.757z"
+                fillRule="evenodd"
+              />
+            </svg>
           </div>
         )}
-      </React.Fragment>
+      </div>
     );
   }
-}
 
-export default withTranslationContext(MessageSimple);
+  return (
+    <div className="str-chat__message-simple__actions">
+      {channelConfig && channelConfig.reactions && (
+        <div
+          className="str-chat__message-simple__actions__action str-chat__message-simple__actions__action--reactions"
+          onClick={onReactionListClick}
+        >
+          <svg width="14" height="14" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M11.108 8.05a.496.496 0 0 1 .212.667C10.581 10.147 8.886 11 7 11c-1.933 0-3.673-.882-4.33-2.302a.497.497 0 0 1 .9-.417C4.068 9.357 5.446 10 7 10c1.519 0 2.869-.633 3.44-1.738a.495.495 0 0 1 .668-.212zm.792-1.826a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.298 0-.431.168-.54.307A.534.534 0 0 1 9.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zm-7 0a.477.477 0 0 1-.119.692.541.541 0 0 1-.31.084.534.534 0 0 1-.428-.194c-.106-.138-.238-.306-.539-.306-.299 0-.432.168-.54.307A.533.533 0 0 1 2.538 7a.544.544 0 0 1-.31-.084.463.463 0 0 1-.117-.694c.33-.423.742-.722 1.394-.722.653 0 1.068.3 1.396.724zM7 0a7 7 0 1 1 0 14A7 7 0 0 1 7 0zm4.243 11.243A5.96 5.96 0 0 0 13 7a5.96 5.96 0 0 0-1.757-4.243A5.96 5.96 0 0 0 7 1a5.96 5.96 0 0 0-4.243 1.757A5.96 5.96 0 0 0 1 7a5.96 5.96 0 0 0 1.757 4.243A5.96 5.96 0 0 0 7 13a5.96 5.96 0 0 0 4.243-1.757z"
+              fillRule="evenodd"
+            />
+          </svg>
+        </div>
+      )}
+      {!threadList && channelConfig && channelConfig.replies && (
+        <div
+          onClick={handleOpenThread}
+          className="str-chat__message-simple__actions__action str-chat__message-simple__actions__action--thread"
+        >
+          <svg width="14" height="10" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M8.516 3c4.78 0 4.972 6.5 4.972 6.5-1.6-2.906-2.847-3.184-4.972-3.184v2.872L3.772 4.994 8.516.5V3zM.484 5l4.5-4.237v1.78L2.416 5l2.568 2.125v1.828L.484 5z"
+              fillRule="evenodd"
+            />
+          </svg>
+        </div>
+      )}
+      {
+        <MessageSimpleActions
+          {...props}
+          actionsBoxOpen={actionsBoxOpen}
+          hideOptions={hideOptions}
+          setActionsBoxOpen={setActionsBoxOpen}
+        />
+      }
+    </div>
+  );
+};
+
+/**
+ * @type { React.FC<import('types').MessageSimpleActionsProps> }
+ */
+const MessageSimpleActions = ({
+  addNotification,
+  message,
+  mutes,
+  getMessageActions,
+  messageListRect,
+  handleFlag: propHandleFlag,
+  handleMute: propHandleMute,
+  handleEdit: propHandleEdit,
+  handleDelete: propHandleDelete,
+  actionsBoxOpen,
+  hideOptions,
+  setEditingState,
+  setActionsBoxOpen,
+  getMuteUserSuccessNotification,
+  getMuteUserErrorNotification,
+  getFlagMessageErrorNotification,
+  getFlagMessageSuccessNotification,
+}) => {
+  const { isMyMessage } = useUserRole(message);
+  const handleDelete = useDeleteHandler(message);
+  const handleEdit = useEditHandler(message, setEditingState);
+  const handleFlag = useFlagHandler(message, {
+    notify: addNotification,
+    getSuccessNotification: getMuteUserSuccessNotification,
+    getErrorNotification: getMuteUserErrorNotification,
+  });
+  const handleMute = useMuteHandler(message, {
+    notify: addNotification,
+    getErrorNotification: getFlagMessageErrorNotification,
+    getSuccessNotification: getFlagMessageSuccessNotification,
+  });
+  const messageActions = getMessageActions();
+  const isMuted = useCallback(() => {
+    return isUserMuted(message, mutes);
+  }, [message, mutes]);
+  useEffect(() => {
+    if (actionsBoxOpen) {
+      document.addEventListener('click', hideOptions);
+    } else {
+      document.removeEventListener('click', hideOptions);
+    }
+    return () => {
+      document.removeEventListener('click', hideOptions);
+    };
+  }, [actionsBoxOpen, hideOptions]);
+  /** @type {() => void} Typescript syntax */
+  const onClickOptionsAction = () => setActionsBoxOpen(true);
+
+  if (messageActions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="message-actions"
+      onClick={onClickOptionsAction}
+      className="str-chat__message-simple__actions__action str-chat__message-simple__actions__action--options"
+    >
+      <MessageActionsBox
+        getMessageActions={getMessageActions}
+        open={actionsBoxOpen}
+        messageListRect={messageListRect}
+        handleFlag={propHandleFlag || handleFlag}
+        isUserMuted={isMuted}
+        handleMute={propHandleMute || handleMute}
+        handleEdit={propHandleEdit || handleEdit}
+        handleDelete={propHandleDelete || handleDelete}
+        mine={isMyMessage}
+      />
+      <svg
+        width="11"
+        height="4"
+        viewBox="0 0 11 4"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M1.5 3a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+          fillRule="nonzero"
+        />
+      </svg>
+    </div>
+  );
+};
+
+/** @type { React.FC<import('types').MessageSimpleProps> } */
+const MessageSimpleStatus = ({
+  readBy,
+  message,
+  threadList,
+  lastReceivedId,
+}) => {
+  const { t } = useContext(TranslationContext);
+  /**
+   * @type {import('types').ChannelContextValue}
+   */
+  const { client } = useContext(ChannelContext);
+  const { isMyMessage } = useUserRole(message);
+  if (!isMyMessage || message?.type === 'error') {
+    return null;
+  }
+  const justReadByMe =
+    readBy &&
+    readBy.length === 1 &&
+    readBy[0] &&
+    client &&
+    readBy[0].id === client.user.id;
+  if (message && message.status === 'sending') {
+    return (
+      <span
+        className="str-chat__message-simple-status"
+        data-testid="message-status-sending"
+      >
+        <Tooltip>{t && t('Sending...')}</Tooltip>
+        <LoadingIndicator />
+      </span>
+    );
+  }
+  if (readBy && readBy.length !== 0 && !threadList && !justReadByMe) {
+    const lastReadUser = readBy.filter(
+      /** @type {(item: import('stream-chat').UserResponse) => boolean} Typescript syntax */
+      (item) => !!item && !!client && item.id !== client.user.id,
+    )[0];
+    return (
+      <span
+        className="str-chat__message-simple-status"
+        data-testid="message-status-read-by"
+      >
+        <Tooltip>{readBy && getReadByTooltipText(readBy, t, client)}</Tooltip>
+        <Avatar
+          name={lastReadUser && lastReadUser.name ? lastReadUser.name : null}
+          image={lastReadUser && lastReadUser.image ? lastReadUser.image : null}
+          size={15}
+        />
+        {readBy.length > 2 && (
+          <span
+            className="str-chat__message-simple-status-number"
+            data-testid="message-status-read-by-many"
+          >
+            {readBy.length - 1}
+          </span>
+        )}
+      </span>
+    );
+  }
+  if (
+    message &&
+    message.status === 'received' &&
+    message.id === lastReceivedId &&
+    !threadList
+  ) {
+    return (
+      <span
+        className="str-chat__message-simple-status"
+        data-testid="message-status-received"
+      >
+        <Tooltip>{t && t('Delivered')}</Tooltip>
+        <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0zm3.72 6.633a.955.955 0 1 0-1.352-1.352L6.986 8.663 5.633 7.31A.956.956 0 1 0 4.28 8.663l2.029 2.028a.956.956 0 0 0 1.353 0l4.058-4.058z"
+            fill="#006CFF"
+            fillRule="evenodd"
+          />
+        </svg>
+      </span>
+    );
+  }
+  return null;
+};
+
+MessageSimple.propTypes = {
+  /** The [message object](https://getstream.io/chat/docs/#message_format) */
+  // @ts-ignore
+  message: PropTypes.object,
+  /**
+   * The attachment UI component.
+   * Default: [Attachment](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Attachment.js)
+   * */
+  // @ts-ignore
+  Attachment: PropTypes.elementType,
+  /**
+   * @deprecated Its not recommended to use this anymore. All the methods in this HOC are provided explicitly.
+   *
+   * The higher order message component, most logic is delegated to this component
+   * @see See [Message HOC](https://getstream.github.io/stream-chat-react/#message) for example
+   *
+   * */
+  // @ts-ignore
+  Message: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /** render HTML instead of markdown. Posting HTML is only allowed server-side */
+  unsafeHTML: PropTypes.bool,
+  /** Client object */
+  // @ts-ignore
+  client: PropTypes.object,
+  /** If its parent message in thread. */
+  initialMessage: PropTypes.bool,
+  /** Channel config object */
+  // @ts-ignore
+  channelConfig: PropTypes.object,
+  /** If component is in thread list */
+  threadList: PropTypes.bool,
+  /**
+   * Function to open thread on current messxage
+   * @deprecated The component now relies on the useThreadHandler custom hook
+   * You can customize the behaviour for your thread handler on the <Channel> component instead.
+   */
+  handleOpenThread: PropTypes.func,
+  /** If the message is in edit state */
+  editing: PropTypes.bool,
+  /** Function to exit edit state */
+  clearEditingState: PropTypes.func,
+  /** Returns true if message belongs to current user */
+  isMyMessage: PropTypes.func,
+  /**
+   * Returns all allowed actions on message by current user e.g., [edit, delete, flag, mute]
+   * Please check [Message](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message.js) component for default implementation.
+   * */
+  // @ts-ignore
+  getMessageActions: PropTypes.func,
+  /**
+   * Function to publish updates on message to channel
+   *
+   * @param message Updated [message object](https://getstream.io/chat/docs/#message_format)
+   * */
+  updateMessage: PropTypes.func,
+  /**
+   * Reattempt sending a message
+   * @param message A [message object](https://getstream.io/chat/docs/#message_format) to resent.
+   * @deprecated This component now relies on the useRetryHandler custom hook.
+   */
+  handleRetry: PropTypes.func,
+  /**
+   * Add or remove reaction on message
+   *
+   * @param type Type of reaction - 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry'
+   * @param event Dom event which triggered this function
+   * @deprecated This component now relies on the useReactionHandler custom hook.
+   */
+  handleReaction: PropTypes.func,
+  /** If actions such as edit, delete, flag, mute are enabled on message */
+  actionsEnabled: PropTypes.bool,
+  /** DOMRect object for parent MessageList component */
+  messageListRect: PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+    top: PropTypes.number.isRequired,
+    right: PropTypes.number.isRequired,
+    bottom: PropTypes.number.isRequired,
+    left: PropTypes.number.isRequired,
+    toJSON: PropTypes.func.isRequired,
+  }),
+  /**
+   * Handler for actions. Actions in combination with attachments can be used to build [commands](https://getstream.io/chat/docs/#channel_commands).
+   *
+   * @param name {string} Name of action
+   * @param value {string} Value of action
+   * @param event Dom event that triggered this handler
+   * @deprecated This component now relies on the useActionHandler custom hook, and this prop will be removed on the next major release.
+   */
+  handleAction: PropTypes.func,
+  /**
+   * The handler for hover event on @mention in message
+   *
+   * @param event Dom hover event which triggered handler.
+   * @param user Target user object
+   * @deprecated This component now relies on the useMentionsHandler custom hook, and this prop will be removed on the next major release.
+   * You can customize the behaviour for your mention handler on the <Channel> component instead.
+   */
+  onMentionsHoverMessage: PropTypes.func,
+  /**
+   * The handler for click event on @mention in message
+   *
+   * @param event Dom click event which triggered handler.
+   * @param user Target user object
+   * @deprecated This component now relies on the useMentionsHandler custom hook, and this prop will be removed on the next major release.
+   * You can customize the behaviour for your mention handler on the <Channel> component instead.
+   */
+  onMentionsClickMessage: PropTypes.func,
+  /**
+   * The handler for click event on the user that posted the message
+   *
+   * @param event Dom click event which triggered handler.
+   */
+  onUserClick: PropTypes.func,
+  /**
+   * The handler for mouseOver event on the user that posted the message
+   *
+   * @param event Dom mouseOver event which triggered handler.
+   */
+  onUserHover: PropTypes.func,
+  /**
+   * Additional props for underlying MessageInput component.
+   * Available props - https://getstream.github.io/stream-chat-react/#messageinput
+   * */
+  additionalMessageInputProps: PropTypes.object,
+  /**
+   * The component that will be rendered if the message has been deleted.
+   * All of Message's props are passed into this component.
+   */
+  // @ts-ignore
+  MessageDeleted: PropTypes.elementType,
+};
+
+export default React.memo(MessageSimple, areMessagePropsEqual);

--- a/src/components/Message/__tests__/utils.test.js
+++ b/src/components/Message/__tests__/utils.test.js
@@ -1,5 +1,6 @@
 import { generateMessage, generateUser } from 'mock-builders';
 import {
+  areMessagePropsEqual,
   getMessageActions,
   MESSAGE_ACTIONS,
   isUserMuted,
@@ -145,10 +146,12 @@ describe('Message utils', () => {
       const currentProps = { message, readBy: currentReadBy };
       const nextReadBy = [alice, bob];
       const nextProps = { message, readBy: nextReadBy };
+      const arePropsEqual = areMessagePropsEqual(nextProps, currentProps);
       const shouldUpdate = shouldMessageComponentUpdate(
         nextProps,
         currentProps,
       );
+      expect(arePropsEqual).toBe(false);
       expect(shouldUpdate).toBe(true);
     });
 
@@ -158,10 +161,12 @@ describe('Message utils', () => {
       const currentProps = { message, groupStyles: currentGroupStyles };
       const nextGroupStyles = ['bottom', 'right'];
       const nextProps = { message, groupStyles: nextGroupStyles };
+      const arePropsEqual = areMessagePropsEqual(nextProps, currentProps);
       const shouldUpdate = shouldMessageComponentUpdate(
         nextProps,
         currentProps,
       );
+      expect(arePropsEqual).toBe(false);
       expect(shouldUpdate).toBe(true);
     });
 
@@ -171,10 +176,12 @@ describe('Message utils', () => {
       const currentProps = { message, lastReceivedId: currentLastReceivedId };
       const nextLastReceivedId = 'some-other-message';
       const nextProps = { message, lastReceivedId: nextLastReceivedId };
+      const arePropsEqual = areMessagePropsEqual(nextProps, currentProps);
       const shouldUpdate = shouldMessageComponentUpdate(
         nextProps,
         currentProps,
       );
+      expect(arePropsEqual).toBe(false);
       expect(shouldUpdate).toBe(true);
     });
 
@@ -184,10 +191,12 @@ describe('Message utils', () => {
       const currentProps = { message, editing: currentEditing };
       const nextEditing = false;
       const nextProps = { message, editing: nextEditing };
+      const arePropsEqual = areMessagePropsEqual(nextProps, currentProps);
       const shouldUpdate = shouldMessageComponentUpdate(
         nextProps,
         currentProps,
       );
+      expect(arePropsEqual).toBe(false);
       expect(shouldUpdate).toBe(true);
     });
 
@@ -197,10 +206,12 @@ describe('Message utils', () => {
       const currentProps = { message, messageListRect: currentMessageListRect };
       const nextMessageListRect = { x: 20, y: 20, width: 200, height: 200 };
       const nextProps = { message, messageListRect: nextMessageListRect };
+      const arePropsEqual = areMessagePropsEqual(nextProps, currentProps);
       const shouldUpdate = shouldMessageComponentUpdate(
         nextProps,
         currentProps,
       );
+      expect(arePropsEqual).toBe(false);
       expect(shouldUpdate).toBe(true);
     });
   });

--- a/src/components/Message/hooks/__tests__/useActionHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useActionHandler.test.js
@@ -40,7 +40,7 @@ async function renderUseHandleActionHook(message = generateMessage()) {
 
 describe('useHandleAction custom hook', () => {
   afterEach(jest.clearAllMocks);
-  it('should return generate function that handles reactions', async () => {
+  it('should return function that handles actions', async () => {
     const handleAction = await renderUseHandleActionHook();
     expect(typeof handleAction).toBe('function');
   });

--- a/src/components/Message/hooks/__tests__/useDeleteHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useDeleteHandler.test.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { getTestClient, generateMessage, generateChannel } from 'mock-builders';
+import { ChannelContext } from '../../../../context';
+import { useDeleteHandler } from '../useDeleteHandler';
+
+const deleteMessage = jest.fn(() => Promise.resolve(generateMessage()));
+const updateMessage = jest.fn();
+const mouseEventMock = {
+  preventDefault: jest.fn(() => {}),
+};
+
+async function renderUseDeleteHandler(message = generateMessage()) {
+  const client = await getTestClient();
+  client.deleteMessage = deleteMessage;
+  const channel = generateChannel({
+    updateMessage,
+  });
+  const wrapper = ({ children }) => (
+    <ChannelContext.Provider
+      value={{
+        channel,
+        client,
+        updateMessage,
+      }}
+    >
+      {children}
+    </ChannelContext.Provider>
+  );
+  const { result } = renderHook(() => useDeleteHandler(message), { wrapper });
+  return result.current;
+}
+
+describe('useDeleteHandler custom hook', () => {
+  afterEach(jest.clearAllMocks);
+  it('should generate function that handles message deletion', async () => {
+    const handleDelete = await renderUseDeleteHandler();
+    expect(typeof handleDelete).toBe('function');
+  });
+
+  it('should prevent default mouse click event from bubbling', async () => {
+    const handleDelete = await renderUseDeleteHandler();
+    await handleDelete(mouseEventMock);
+    expect(mouseEventMock.preventDefault).toHaveBeenCalledWith();
+  });
+
+  it('should delete a message by its id', async () => {
+    const message = generateMessage();
+    const handleDelete = await renderUseDeleteHandler(message);
+    await handleDelete(mouseEventMock);
+    expect(deleteMessage).toHaveBeenCalledWith(message.id);
+  });
+
+  it('should update the message with the result of deletion', async () => {
+    const message = generateMessage();
+    const deletedMessage = generateMessage();
+    deleteMessage.mockImplementationOnce(() =>
+      Promise.resolve({ message: deletedMessage }),
+    );
+    const handleDelete = await renderUseDeleteHandler(message);
+    await handleDelete(mouseEventMock);
+    expect(updateMessage).toHaveBeenCalledWith(deletedMessage);
+  });
+});

--- a/src/components/Message/hooks/__tests__/useEditHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useEditHandler.test.js
@@ -1,0 +1,37 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { generateMessage } from 'mock-builders';
+import { useEditHandler } from '../useEditHandler';
+
+const setEditingStateMock = jest.fn();
+const mouseEventMock = {
+  preventDefault: jest.fn(() => {}),
+};
+
+function renderUseEditHandler(
+  message = generateMessage(),
+  setEditingState = setEditingStateMock,
+) {
+  const { result } = renderHook(() => useEditHandler(message, setEditingState));
+  return result.current;
+}
+
+describe('useEditHandler custom hook', () => {
+  afterEach(jest.clearAllMocks);
+  it('should generate function that handles message deletion', () => {
+    const handleEdit = renderUseEditHandler();
+    expect(typeof handleEdit).toBe('function');
+  });
+
+  it('should prevent click event from bubbling', () => {
+    const handleEdit = renderUseEditHandler();
+    handleEdit(mouseEventMock);
+    expect(mouseEventMock.preventDefault).toHaveBeenCalledWith();
+  });
+
+  it('should set editing for message', () => {
+    const message = generateMessage();
+    const handleEdit = renderUseEditHandler(message);
+    handleEdit(mouseEventMock);
+    expect(setEditingStateMock).toHaveBeenCalledWith(message);
+  });
+});

--- a/src/components/Message/hooks/__tests__/useFlagHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useFlagHandler.test.js
@@ -42,7 +42,7 @@ async function renderUseHandleFlagHook(
 }
 describe('useHandleFlag custom hook', () => {
   afterEach(jest.clearAllMocks);
-  it('should return generate function that handles mutes', async () => {
+  it('should generate function that handles mutes', async () => {
     const handleFlag = await renderUseHandleFlagHook();
     expect(typeof handleFlag).toBe('function');
   });

--- a/src/components/Message/hooks/__tests__/useMentionsHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useMentionsHandler.test.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { generateUser, generateMessage } from 'mock-builders';
+import { ChannelContext } from '../../../../context';
+import { useMentionsHandler } from '../useMentionsHandler';
+
+const onMentionsClickMock = jest.fn();
+const onMentionsHoverMock = jest.fn();
+const mouseEventMock = {
+  preventDefault: jest.fn(() => {}),
+};
+
+function renderUseMentionsHandlerHook(
+  message = generateMessage(),
+  onMentionsClick = onMentionsClickMock,
+  onMentionsHover = onMentionsHoverMock,
+) {
+  const wrapper = ({ children }) => (
+    <ChannelContext.Provider
+      value={{
+        onMentionsClick,
+        onMentionsHover,
+      }}
+    >
+      {children}
+    </ChannelContext.Provider>
+  );
+  const { result } = renderHook(() => useMentionsHandler(message), {
+    wrapper,
+  });
+  return result.current;
+}
+
+describe('useMentionsHandler custom hook', () => {
+  afterEach(jest.clearAllMocks);
+  it('should return a function', () => {
+    const handleMentions = renderUseMentionsHandlerHook();
+    expect(handleMentions).toStrictEqual({
+      onMentionsClick: expect.any(Function),
+      onMentionsHover: expect.any(Function),
+    });
+  });
+
+  it("should call onMentionsClick with message's mentioned users when user clicks on a mention", () => {
+    const alice = generateUser();
+    const bob = generateUser();
+    const mentioned_users = [alice, bob];
+    const message = generateMessage({ mentioned_users });
+    const { onMentionsClick } = renderUseMentionsHandlerHook(message);
+    onMentionsClick(mouseEventMock);
+    expect(onMentionsClickMock).toHaveBeenCalledWith(
+      mouseEventMock,
+      mentioned_users,
+    );
+  });
+
+  it('should not call onMentionsClick when it is not defined', () => {
+    const alice = generateUser();
+    const bob = generateUser();
+    const mentioned_users = [alice, bob];
+    const message = generateMessage({ mentioned_users });
+    const { onMentionsClick } = renderUseMentionsHandlerHook(message, null);
+    onMentionsClick(mouseEventMock);
+    expect(onMentionsClickMock).not.toHaveBeenCalled();
+  });
+
+  it('should not call onMentionsClick when it message has no mentioned users set', () => {
+    const message = generateMessage({ mentioned_users: null });
+    const { onMentionsClick } = renderUseMentionsHandlerHook(message);
+    onMentionsClick(mouseEventMock);
+    expect(onMentionsClickMock).not.toHaveBeenCalled();
+  });
+
+  it("should call onMentionsHover with message's mentioned users when user hovers on a mention", () => {
+    const alice = generateUser();
+    const bob = generateUser();
+    const mentioned_users = [alice, bob];
+    const message = generateMessage({ mentioned_users });
+    const { onMentionsHover } = renderUseMentionsHandlerHook(message);
+    onMentionsHover(mouseEventMock);
+    expect(onMentionsHoverMock).toHaveBeenCalledWith(
+      mouseEventMock,
+      mentioned_users,
+    );
+  });
+
+  it('should not call onMentionsHover when it is not defined', () => {
+    const alice = generateUser();
+    const bob = generateUser();
+    const mentioned_users = [alice, bob];
+    const message = generateMessage({ mentioned_users });
+    const { onMentionsHover } = renderUseMentionsHandlerHook(
+      message,
+      onMentionsClickMock,
+      null,
+    );
+    onMentionsHover(mouseEventMock);
+    expect(onMentionsHoverMock).not.toHaveBeenCalled();
+  });
+
+  it('should not call onMentionsHover when it message has no mentioned users set', () => {
+    const message = generateMessage({ mentioned_users: null });
+    const { onMentionsHover } = renderUseMentionsHandlerHook(message);
+    onMentionsHover(mouseEventMock);
+    expect(onMentionsHoverMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Message/hooks/__tests__/useMuteHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useMuteHandler.test.js
@@ -46,7 +46,7 @@ async function renderUseHandleMuteHook(
 
 describe('useHandleMute custom hook', () => {
   afterEach(jest.clearAllMocks);
-  it('should return generate function that handles mutes', async () => {
+  it('should generate function that handles mutes', async () => {
     const handleMute = await renderUseHandleMuteHook();
     expect(typeof handleMute).toBe('function');
   });

--- a/src/components/Message/hooks/__tests__/useOpenThreadHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useOpenThreadHandler.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { generateMessage } from 'mock-builders';
+import { ChannelContext } from '../../../../context';
+import { useOpenThreadHandler } from '../useOpenThreadHandler';
+
+const openThreadMock = jest.fn();
+const mouseEventMock = {
+  preventDefault: jest.fn(() => {}),
+};
+
+function renderUseOpenThreadHandlerHook(
+  message = generateMessage(),
+  openThread = openThreadMock,
+) {
+  const wrapper = ({ children }) => (
+    <ChannelContext.Provider
+      value={{
+        openThread,
+      }}
+    >
+      {children}
+    </ChannelContext.Provider>
+  );
+  const { result } = renderHook(() => useOpenThreadHandler(message), {
+    wrapper,
+  });
+  return result.current;
+}
+
+describe('useOpenThreadHandler custom hook', () => {
+  afterEach(jest.clearAllMocks);
+  it('should return generate function that handles mutes', () => {
+    const handleOpenThread = renderUseOpenThreadHandlerHook();
+    expect(typeof handleOpenThread).toBe('function');
+  });
+
+  it('should allow user to open a thread', () => {
+    const message = generateMessage();
+    const handleOpenThread = renderUseOpenThreadHandlerHook(message);
+    handleOpenThread(mouseEventMock);
+    expect(openThreadMock).toHaveBeenCalledWith(message, mouseEventMock);
+  });
+
+  it('should warn user if it is called without a message', () => {
+    jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
+    const handleOpenThread = renderUseOpenThreadHandlerHook(null);
+    handleOpenThread(mouseEventMock);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should warn user if it open thread is not defined in the channel context', () => {
+    jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
+    const handleOpenThread = renderUseOpenThreadHandlerHook(
+      generateMessage(),
+      null,
+    );
+    handleOpenThread(mouseEventMock);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Message/hooks/__tests__/useOpenThreadHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useOpenThreadHandler.test.js
@@ -30,7 +30,7 @@ function renderUseOpenThreadHandlerHook(
 
 describe('useOpenThreadHandler custom hook', () => {
   afterEach(jest.clearAllMocks);
-  it('should return generate function that handles mutes', () => {
+  it('should return a function', () => {
     const handleOpenThread = renderUseOpenThreadHandlerHook();
     expect(typeof handleOpenThread).toBe('function');
   });

--- a/src/components/Message/hooks/__tests__/useReactionHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useReactionHandler.test.js
@@ -50,7 +50,7 @@ async function renderUseReactionHandlerHook(
 
 describe('useReactionHandler custom hook', () => {
   afterEach(jest.clearAllMocks);
-  it('should return generate function that handles reactions', async () => {
+  it('should generate function that handles reactions', async () => {
     const handleReaction = await renderUseReactionHandlerHook();
     expect(typeof handleReaction).toBe('function');
   });

--- a/src/components/Message/hooks/__tests__/useRetryHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useRetryHandler.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { generateMessage } from 'mock-builders';
+import { ChannelContext } from '../../../../context';
+import { useRetryHandler } from '../useRetryHandler';
+
+const retrySendMessage = jest.fn();
+
+function renderUseRetryHandlerHook() {
+  const wrapper = ({ children }) => (
+    <ChannelContext.Provider
+      value={{
+        retrySendMessage,
+      }}
+    >
+      {children}
+    </ChannelContext.Provider>
+  );
+  const { result } = renderHook(() => useRetryHandler(), { wrapper });
+  return result.current;
+}
+
+describe('useReactionHandler custom hook', () => {
+  afterEach(jest.clearAllMocks);
+  it('should generate a function that handles retrying a failed message', () => {
+    const handleRetry = renderUseRetryHandlerHook();
+    expect(typeof handleRetry).toBe('function');
+  });
+
+  it('should retry send message when called', () => {
+    const handleRetry = renderUseRetryHandlerHook();
+    const message = generateMessage();
+    handleRetry(message);
+    expect(retrySendMessage).toHaveBeenCalledWith(message);
+  });
+});

--- a/src/components/Message/hooks/__tests__/useUserHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useUserHandler.test.js
@@ -1,0 +1,53 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { generateUser, generateMessage } from 'mock-builders';
+import { useUserHandler } from '../useUserHandler';
+
+const mouseEventMock = {
+  preventDefault: jest.fn(() => {}),
+};
+
+function renderUseUserHandlerHook(message = generateMessage(), eventHandlers) {
+  const { result } = renderHook(() => useUserHandler(eventHandlers, message));
+  return result.current;
+}
+
+describe('useUserHandler custom hook', () => {
+  afterEach(jest.clearAllMocks);
+  it('should return a handlers for mouse events on the Avatar child component', () => {
+    const handleUserEvents = renderUseUserHandlerHook();
+    expect(handleUserEvents).toStrictEqual({
+      onUserClick: expect.any(Function),
+      onUserHover: expect.any(Function),
+    });
+  });
+
+  it('should call user click handler with user message', () => {
+    const user = generateUser();
+    const message = generateMessage({ user });
+    const customUserClickHandler = jest.fn();
+    const { onUserClick } = renderUseUserHandlerHook(message, {
+      onUserClickHandler: customUserClickHandler,
+    });
+    onUserClick(mouseEventMock);
+    expect(customUserClickHandler).toHaveBeenCalledWith(mouseEventMock, user);
+  });
+
+  it('should call user hover handler with user message', () => {
+    const user = generateUser();
+    const message = generateMessage({ user });
+    const customUserHoverHandler = jest.fn();
+    const { onUserHover } = renderUseUserHandlerHook(message, {
+      onUserHoverHandler: customUserHoverHandler,
+    });
+    onUserHover(mouseEventMock);
+    expect(customUserHoverHandler).toHaveBeenCalledWith(mouseEventMock, user);
+  });
+
+  it('should not throw if no custom handler is set and handler is called', () => {
+    const user = generateUser();
+    const message = generateMessage({ user });
+    const { onUserClick, onUserHover } = renderUseUserHandlerHook(message);
+    expect(() => onUserClick(mouseEventMock)).not.toThrow();
+    expect(() => onUserHover(mouseEventMock)).not.toThrow();
+  });
+});

--- a/src/components/Message/hooks/useActionHandler.js
+++ b/src/components/Message/hooks/useActionHandler.js
@@ -5,7 +5,7 @@ import { ChannelContext } from '../../../context';
 export const handleActionWarning = `Action handler was called, but it is missing one of its required arguments.
       Make sure the ChannelContext was properly set and that this hook was initialized with a valid message.`;
 /**
- * @type {(message: import('stream-chat').MessageResponse) => (name: string, value: string, event: React.MouseEvent<HTMLElement>) => Promise<void>}
+ * @type {(message: import('stream-chat').MessageResponse | undefined) => (name: string, value: string, event: React.MouseEvent<HTMLElement>) => Promise<void>}
  */
 export const useActionHandler = (message) => {
   /**

--- a/src/components/Message/hooks/useDeleteHandler.js
+++ b/src/components/Message/hooks/useDeleteHandler.js
@@ -1,0 +1,21 @@
+// @ts-check
+import { useContext } from 'react';
+import { ChannelContext } from '../../../context';
+
+/**
+ * @type {(message: import('stream-chat').MessageResponse | undefined) =>  (event: React.MouseEvent<HTMLElement>) => Promise<void>}
+ */
+export const useDeleteHandler = (message) => {
+  /**
+   *@type {import('types').ChannelContextValue}
+   */
+  const { updateMessage, client } = useContext(ChannelContext);
+  return async (event) => {
+    event.preventDefault();
+    if (!message || !client || !updateMessage) {
+      return;
+    }
+    const data = await client.deleteMessage(message.id);
+    updateMessage(data.message);
+  };
+};

--- a/src/components/Message/hooks/useEditHandler.js
+++ b/src/components/Message/hooks/useEditHandler.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+/**
+ * @type {(message: import('stream-chat').MessageResponse | undefined, setEditingState: import('types').MessageComponentProps['setEditingState']) =>  (event: React.MouseEvent<HTMLElement>) => void}
+ */
+export const useEditHandler = (message, setEditingState) => {
+  return (event) => {
+    event.preventDefault();
+
+    if (!message || !setEditingState) {
+      return;
+    }
+
+    setEditingState(message);
+  };
+};

--- a/src/components/Message/hooks/useFlagHandler.js
+++ b/src/components/Message/hooks/useFlagHandler.js
@@ -9,7 +9,7 @@ import { validateAndGetMessage } from '../utils';
  *   getSuccessNotification?: import('types').MessageComponentProps['getMuteUserSuccessNotification'],
  *   getErrorNotification?: import('types').MessageComponentProps['getMuteUserErrorNotification'],
  * }} NotificationArg
- * @type {(message: import('stream-chat').MessageResponse, notification: NotificationArg) => (event: React.MouseEvent<HTMLElement>) => Promise<void>}
+ * @type {(message: import('stream-chat').MessageResponse | undefined, notification: NotificationArg) => (event: React.MouseEvent<HTMLElement>) => Promise<void>}
  */
 export const useFlagHandler = (message, notifications) => {
   /**

--- a/src/components/Message/hooks/useMentionsHandler.js
+++ b/src/components/Message/hooks/useMentionsHandler.js
@@ -3,7 +3,8 @@ import { useContext } from 'react';
 import { ChannelContext } from '../../../context';
 
 /**
- * @type {(message: import('stream-chat').MessageResponse | undefined) => { onMentionsClick: React.EventHandler<React.SyntheticEvent>, onMentionsHover: React.EventHandler<React.SyntheticEvent> }}
+ * @typedef {React.EventHandler<React.SyntheticEvent>} Handler
+ * @type {(message: import('stream-chat').MessageResponse | undefined) => { onMentionsClick: Handler, onMentionsHover: Handler }}
  */
 export const useMentionsHandler = (message) => {
   /**

--- a/src/components/Message/hooks/useMentionsHandler.js
+++ b/src/components/Message/hooks/useMentionsHandler.js
@@ -1,0 +1,31 @@
+// @ts-check
+import { useContext } from 'react';
+import { ChannelContext } from '../../../context';
+
+/**
+ * @type {(message: import('stream-chat').MessageResponse | undefined) => { onMentionsClick: React.EventHandler<React.SyntheticEvent>, onMentionsHover: React.EventHandler<React.SyntheticEvent> }}
+ */
+export const useMentionsHandler = (message) => {
+  /**
+   * @type{import('types').ChannelContextValue}
+   */
+  const { onMentionsClick, onMentionsHover } = useContext(ChannelContext);
+
+  return {
+    /** @type {(e: React.MouseEvent<HTMLElement>) => void} Typescript syntax */
+    onMentionsClick: (e) => {
+      if (typeof onMentionsClick !== 'function' || !message?.mentioned_users) {
+        return;
+      }
+      onMentionsClick(e, message.mentioned_users);
+    },
+    /** @type {(e: React.MouseEvent<HTMLElement>) => void} Typescript syntax */
+    onMentionsHover: (e) => {
+      if (typeof onMentionsHover !== 'function' || !message?.mentioned_users) {
+        return;
+      }
+
+      onMentionsHover(e, message.mentioned_users);
+    },
+  };
+};

--- a/src/components/Message/hooks/useMuteHandler.js
+++ b/src/components/Message/hooks/useMuteHandler.js
@@ -9,7 +9,7 @@ import { ChannelContext, TranslationContext } from '../../../context';
  *   getSuccessNotification?: import('types').MessageComponentProps['getMuteUserSuccessNotification'],
  *   getErrorNotification?: import('types').MessageComponentProps['getMuteUserErrorNotification'],
  * }} NotificationArg
- * @type {(message: import('stream-chat').MessageResponse, notification: NotificationArg) => (event: React.MouseEvent<HTMLElement>) => Promise<void>}
+ * @type {(message: import('stream-chat').MessageResponse | undefined, notification: NotificationArg) => (event: React.MouseEvent<HTMLElement>) => Promise<void>}
  */
 export const useMuteHandler = (message, notifications) => {
   /**

--- a/src/components/Message/hooks/useOpenThreadHandler.js
+++ b/src/components/Message/hooks/useOpenThreadHandler.js
@@ -1,0 +1,23 @@
+// @ts-check
+import { useContext } from 'react';
+import { ChannelContext } from '../../../context';
+
+/**
+ * @type {(message: import('stream-chat').MessageResponse | undefined) => (event: React.SyntheticEvent) => void}
+ */
+export const useOpenThreadHandler = (message) => {
+  /**
+   * @type{import('types').ChannelContextValue}
+   */
+  const { openThread } = useContext(ChannelContext);
+
+  return (event) => {
+    if (!openThread || !message) {
+      console.warn(
+        'Open thread handler was called but it is missing one of its parameters',
+      );
+      return;
+    }
+    openThread(message, event);
+  };
+};

--- a/src/components/Message/hooks/useReactionHandler.js
+++ b/src/components/Message/hooks/useReactionHandler.js
@@ -5,7 +5,7 @@ import { ChannelContext } from '../../../context';
 export const reactionHandlerWarning = `Reaction handler was called, but it is missing one of its required arguments.
       Make sure the ChannelContext was properly set and that this hook was initialized with a valid message.`;
 /**
- * @type {(message: import('stream-chat').MessageResponse) => (reactionType: string, event: React.MouseEvent) => Promise<void>}
+ * @type {(message: import('stream-chat').MessageResponse | undefined) => (reactionType: string, event: React.MouseEvent) => Promise<void>}
  */
 export const useReactionHandler = (message) => {
   /**

--- a/src/components/Message/hooks/useRetryHandler.js
+++ b/src/components/Message/hooks/useRetryHandler.js
@@ -1,0 +1,18 @@
+// @ts-check
+import { useContext } from 'react';
+import { ChannelContext } from '../../../context';
+
+/**
+ * @type {() => (message: import('stream-chat').Message | undefined) => Promise<void>}
+ */
+export const useRetryHandler = () => {
+  /**
+   *@type {import('types').ChannelContextValue}
+   */
+  const { retrySendMessage } = useContext(ChannelContext);
+  return async (message) => {
+    if (retrySendMessage && message) {
+      await retrySendMessage(message);
+    }
+  };
+};

--- a/src/components/Message/hooks/useUserHandler.js
+++ b/src/components/Message/hooks/useUserHandler.js
@@ -1,0 +1,31 @@
+// @ts-check
+/**
+ * @typedef {React.EventHandler<React.SyntheticEvent>} Handler
+ * @typedef {(e: React.MouseEvent, user: import('stream-chat').User) => void} UserEventHandler
+ * @type {(eventHandlers: {onUserClickHandler?: UserEventHandler, onUserHoverHandler?: UserEventHandler} , message: import('stream-chat').MessageResponse | undefined) => { onUserClick: Handler, onUserHover: Handler }}
+ */
+export const useUserHandler = (eventHandlers, message) => {
+  return {
+    /** @type {(e: React.MouseEvent<HTMLElement>) => void} Typescript syntax */
+    onUserClick: (e) => {
+      if (
+        typeof eventHandlers?.onUserClickHandler !== 'function' ||
+        !message?.user
+      ) {
+        return;
+      }
+      eventHandlers.onUserClickHandler(e, message.user);
+    },
+    /** @type {(e: React.MouseEvent<HTMLElement>) => void} Typescript syntax */
+    onUserHover: (e) => {
+      if (
+        typeof eventHandlers?.onUserHoverHandler !== 'function' ||
+        !message?.user
+      ) {
+        return;
+      }
+
+      eventHandlers.onUserHoverHandler(e, message.user);
+    },
+  };
+};

--- a/src/components/Message/hooks/useUserRole.js
+++ b/src/components/Message/hooks/useUserRole.js
@@ -11,7 +11,7 @@ import { ChannelContext } from '../../../context';
  *   canEditMessage: boolean;
  *   canDeleteMessage: boolean;
  * }} UserRoles
- * @type {(message: import('stream-chat').MessageResponse) => UserRoles} Typescript syntax
+ * @type {(message: import('stream-chat').MessageResponse | undefined) => UserRoles} Typescript syntax
  */
 export const useUserRole = (message) => {
   /**

--- a/src/components/Message/utils.js
+++ b/src/components/Message/utils.js
@@ -112,6 +112,6 @@ export const MessagePropTypes = PropTypes.shape({
   type: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
   html: PropTypes.string.isRequired,
-  created_at: PropTypes.string.isRequired,
-  updated_at: PropTypes.string.isRequired,
+  created_at: PropTypes.instanceOf(Date).isRequired,
+  updated_at: PropTypes.instanceOf(Date).isRequired,
 }).isRequired;

--- a/src/components/Message/utils.js
+++ b/src/components/Message/utils.js
@@ -89,22 +89,29 @@ export const getMessageActions = (
 /**
  * @type {(nextProps: import('types').MessageComponentProps, props: import('types').MessageComponentProps ) => boolean} Typescript syntax
  */
-export const shouldMessageComponentUpdate = (nextProps, props) => {
-  // Component should only update if:
+export const areMessagePropsEqual = (props, nextProps) => {
   return (
-    // Message content is different
-    nextProps.message !== props.message ||
+    // Message content is equal
+    nextProps.message === props.message &&
     // Message was read by someone
-    !deepequal(nextProps.readBy, props.readBy) ||
+    deepequal(nextProps.readBy, props.readBy) &&
     // Group style changes (it often happens that the last 3 messages of a channel have different group styles)
-    !deepequal(nextProps.groupStyles, props.groupStyles) ||
+    deepequal(nextProps.groupStyles, props.groupStyles) &&
     // Last message received in the channel changes
-    !deepequal(nextProps.lastReceivedId, props.lastReceivedId) ||
+    deepequal(nextProps.lastReceivedId, props.lastReceivedId) &&
     // User toggles edit state
-    nextProps.editing !== props.editing ||
+    nextProps.editing === props.editing &&
     // Message wrapper layout changes
-    nextProps.messageListRect !== props.messageListRect
+    nextProps.messageListRect === props.messageListRect
   );
+};
+
+/**
+ * @type {(nextProps: import('types').MessageComponentProps, props: import('types').MessageComponentProps ) => boolean} Typescript syntax
+ */
+export const shouldMessageComponentUpdate = (props, nextProps) => {
+  // Component should only update if:
+  return !areMessagePropsEqual(props, nextProps);
 };
 
 export const MessagePropTypes = PropTypes.shape({

--- a/src/mock-builders/generator/message.js
+++ b/src/mock-builders/generator/message.js
@@ -5,6 +5,7 @@ export const generateMessage = (options) => {
     id: uuidv4(),
     text: uuidv4(),
     type: 'regular',
+    html: '<p>regular</p>',
     attachments: [],
     created_at: new Date(),
     updated_at: new Date(),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -72,12 +72,12 @@ export interface ChannelContextValue extends ChatContextValue {
     extraState?: object,
   ): void;
   /** Function executed when user clicks on link to open thread */
-  retrySendMessage?(message: Client.Message): void;
+  retrySendMessage?(message: Client.Message): Promise<void>;
   removeMessage?(updatedMessage: Client.MessageResponse): void;
   /** Function to be called when a @mention is clicked. Function has access to the DOM event and the target user object */
-  onMentionsClick?(e: React.MouseEvent, user: Client.UserResponse): void;
+  onMentionsClick?(e: React.MouseEvent, user: Client.UserResponse[]): void;
   /** Function to be called when hovering over a @mention. Function has access to the DOM event and the target user object */
-  onMentionsHover?(e: React.MouseEvent, user: Client.UserResponse): void;
+  onMentionsHover?(e: React.MouseEvent, user: Client.UserResponse[]): void;
   openThread?(
     message: Client.MessageResponse,
     event: React.SyntheticEvent,
@@ -506,6 +506,11 @@ export interface MessageProps extends TranslationContextValue {
   ): void;
   additionalMessageInputProps?: object;
   clearEditingState?(e?: React.MouseEvent): void;
+  getFlagMessageSuccessNotification?(message: MessageResponse): string;
+  getFlagMessageErrorNotification?(message: MessageResponse): string;
+  getMuteUserSuccessNotification?(message: MessageResponse): string;
+  getMuteUserErrorNotification?(message: MessageResponse): string;
+  setEditingState?(message: Client.MessageResponse): any;
 }
 
 export type MessageComponentState = {
@@ -532,13 +537,8 @@ export interface MessageComponentProps
   /** Function to be called when hovering the user that posted the message. Function has access to the DOM event and the target user object */
   onUserHover?(e: React.MouseEvent, user: Client.User): void;
   messageActions?: Array<string>;
-  getFlagMessageSuccessNotification?(message: MessageResponse): string;
-  getFlagMessageErrorNotification?(message: MessageResponse): string;
-  getMuteUserSuccessNotification?(message: MessageResponse): string;
-  getMuteUserErrorNotification?(message: MessageResponse): string;
   members?: SeamlessImmutable.Immutable<{ [user_id: string]: Client.Member }>;
   addNotification?(notificationText: string, type: string): any;
-  setEditingState?(message: Client.MessageResponse): any;
   retrySendMessage?(message: Client.Message): void;
   removeMessage?(updatedMessage: Client.MessageResponse): void;
   mutes?: Client.Mute[];
@@ -980,16 +980,28 @@ export class MessageTeam extends React.PureComponent<
 > {}
 
 export interface MessageSimpleProps extends MessageUIComponentProps {}
-
-export type MessageSimpleState = {
-  isFocused: boolean;
+export interface MessageSimpleTextProps extends MessageSimpleProps {
   actionsBoxOpen: boolean;
+  onReactionListClick: () => void;
   showDetailedReactions: boolean;
-};
-export class MessageSimple extends React.PureComponent<
-  MessageSimpleProps,
-  MessageSimpleState
-> {}
+  reactionSelectorRef: React.RefObject<ReactionSelector>;
+  setActionsBoxOpen: (state: boolean) => void;
+  hideOptions: () => void;
+}
+export interface MessageSimpleOptionsProps extends MessageSimpleProps {
+  actionsBoxOpen: boolean;
+  hideOptions: () => void;
+  setActionsBoxOpen: (state: boolean) => void;
+  onReactionListClick: () => void;
+}
+export interface MessageSimpleActionsProps extends MessageSimpleProps {
+  addNotification?(notificationText: string, type: string): any;
+  actionsBoxOpen: boolean;
+  hideOptions: () => void;
+  setActionsBoxOpen: (state: boolean) => void;
+}
+
+export const MessageSimple: React.FC<MessageSimpleProps>;
 
 export class MessageDeleted extends React.PureComponent<
   MessageDeletedProps,


### PR DESCRIPTION
# Submit a pull request
## Description of the pull request

Refactors the <MessageSimple /> component. Creates some new custom hooks.

### To-do:

- [x] Check component API diffs for breaking changes
- [x] QA
- [x] Clean-up

### The vision

The general idea is to decouple all message UI components from the Message HOC, replacing the logic that now is handled by the later in the form of custom hooks. When migrating the other message UI components, we'll be able to abstract more of the logic that now lives inside the component itself, and that's shared between all of them.