### PR TITLE
CRS-224 ReactionSelector

### DIFF
--- a/src/components/Message/MessageCommerce.js
+++ b/src/components/Message/MessageCommerce.js
@@ -143,7 +143,6 @@ const MessageCommerce = (props) => {
                 <ReactionSelector
                   reverse={false}
                   handleReaction={propHandleReaction || handleReaction}
-                  actionsEnabled={actionsEnabled}
                   detailedView
                   reaction_counts={message.reaction_counts}
                   latest_reactions={message.latest_reactions}

--- a/src/components/Message/MessageLivestream.js
+++ b/src/components/Message/MessageLivestream.js
@@ -65,7 +65,6 @@ const MessageLivestreamComponent = (props) => {
     editing,
     clearEditingState,
     initialMessage,
-    messageListRect,
     unsafeHTML,
     onUserClick: propOnUserClick,
     handleReaction: propHandleReaction,
@@ -169,7 +168,6 @@ const MessageLivestreamComponent = (props) => {
             detailedView
             latest_reactions={message?.latest_reactions}
             reaction_counts={message?.reaction_counts}
-            messageList={messageListRect}
             ref={reactionSelectorRef}
           />
         )}

--- a/src/components/Message/MessageSimple.js
+++ b/src/components/Message/MessageSimple.js
@@ -42,7 +42,6 @@ const MessageSimple = (props) => {
     clearEditingState,
     editing,
     message,
-    messageListRect,
     threadList,
     updateMessage: propUpdateMessage,
     handleAction: propHandleAction,
@@ -187,7 +186,6 @@ const MessageSimple = (props) => {
                     detailedView
                     reaction_counts={message.reaction_counts}
                     latest_reactions={message.latest_reactions}
-                    messageList={messageListRect}
                     ref={reactionSelectorRef}
                   />
                 )}

--- a/src/components/Message/MessageTeam.js
+++ b/src/components/Message/MessageTeam.js
@@ -114,8 +114,6 @@ const MessageTeam = (props) => {
   const galleryImages = getImages(message);
   const attachments = getNonImageAttachments(message);
   const firstGroupStyle = groupStyles ? groupStyles[0] : '';
-  // determine reaction selector alignment
-  const reactionDirection = 'left';
 
   if (message?.type === 'message.read') {
     return null;
@@ -228,7 +226,6 @@ const MessageTeam = (props) => {
                       latest_reactions={message.latest_reactions}
                       reaction_counts={message.reaction_counts}
                       detailedView={true}
-                      direction={reactionDirection}
                       ref={reactionSelectorRef}
                     />
                   )}

--- a/src/components/Message/MessageText.js
+++ b/src/components/Message/MessageText.js
@@ -18,12 +18,14 @@ const MessageTextComponent = (props) => {
   const {
     onMentionsClickMessage: propOnMentionsClick,
     onMentionsHoverMessage: propOnMentionsHover,
+<<<<<<< HEAD
     actionsEnabled,
     customWrapperClass,
     customInnerClass,
     theme = 'simple',
+=======
+>>>>>>> fix MessageText usage of ReactionSelector
     message,
-    messageListRect,
     unsafeHTML,
     customOptionProps,
   } = props;
@@ -95,12 +97,9 @@ const MessageTextComponent = (props) => {
         {showDetailedReactions && (
           <ReactionSelector
             handleReaction={handleReaction}
-            actionsEnabled={actionsEnabled}
             detailedView
             reaction_counts={message.reaction_counts}
             latest_reactions={message.latest_reactions}
-            messageList={messageListRect}
-            // @ts-ignore
             ref={reactionSelectorRef}
           />
         )}

--- a/src/components/Message/MessageText.js
+++ b/src/components/Message/MessageText.js
@@ -18,13 +18,9 @@ const MessageTextComponent = (props) => {
   const {
     onMentionsClickMessage: propOnMentionsClick,
     onMentionsHoverMessage: propOnMentionsHover,
-<<<<<<< HEAD
-    actionsEnabled,
     customWrapperClass,
     customInnerClass,
     theme = 'simple',
-=======
->>>>>>> fix MessageText usage of ReactionSelector
     message,
     unsafeHTML,
     customOptionProps,

--- a/src/components/Message/hooks/__tests__/useReactionHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useReactionHandler.test.js
@@ -191,7 +191,7 @@ describe('useReactionClick custom hook', () => {
       target: reactionSelectorEl,
     };
     const { result } = renderUseReactionClickHook(message, {
-      current: { reactionSelector: { current: reactionListElement } },
+      current: reactionListElement,
     });
     let onDocumentClick;
     const addEventListenerSpy = jest

--- a/src/components/Message/hooks/useReactionHandler.js
+++ b/src/components/Message/hooks/useReactionHandler.js
@@ -96,12 +96,11 @@ export const useReactionClick = (
   /** @type {EventListener} */
   const closeDetailedReactions = useCallback(
     (event) => {
+      console.log(reactionSelectorRef?.current);
       if (
         event.target &&
         // @ts-ignore
-        reactionSelectorRef?.current?.reactionSelector?.current?.contains(
-          event.target,
-        )
+        reactionSelectorRef?.current?.contains(event.target)
       ) {
         return;
       }

--- a/src/components/Message/hooks/useReactionHandler.js
+++ b/src/components/Message/hooks/useReactionHandler.js
@@ -96,7 +96,6 @@ export const useReactionClick = (
   /** @type {EventListener} */
   const closeDetailedReactions = useCallback(
     (event) => {
-      console.log(reactionSelectorRef?.current);
       if (
         event.target &&
         // @ts-ignore

--- a/src/components/Reactions/ReactionSelector.js
+++ b/src/components/Reactions/ReactionSelector.js
@@ -1,237 +1,195 @@
-/* eslint-disable */
-import React, { PureComponent } from 'react';
+// @ts-check
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+// @ts-ignore
 import { NimbleEmoji } from 'emoji-mart';
-
-import { defaultMinimalEmojis, emojiSetDef, emojiData } from '../../utils';
 import { Avatar } from '../Avatar';
 
-/**
- * ReactionSelector - A component for selecting a reaction. Examples are love, wow, like etc.
- *
- * @example ../../docs/ReactionSelector.md
- * @extends PureComponent
- */
-class ReactionSelector extends PureComponent {
-  static propTypes = {
-    /**
-     * Array of latest reactions.
-     * Reaction object has following structure:
-     *
-     * ```json
-     * {
-     *  "type": "love",
-     *  "user_id": "demo_user_id",
-     *  "user": {
-     *    ...userObject
-     *  },
-     *  "created_at": "datetime";
-     * }
-     * ```
-     * */
-    latest_reactions: PropTypes.array,
-    /** Object/map of reaction id/type (e.g. 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry') vs count */
-    reaction_counts: PropTypes.object,
-    /**
-     * Handler to set/unset reaction on message.
-     *
-     * @param type e.g. 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry'
-     * */
-    handleReaction: PropTypes.func.isRequired,
-    /** Enable the avatar display */
-    detailedView: PropTypes.bool,
-    /** Provide a list of reaction options [{id: 'angry', emoji: 'angry'}] */
-    reactionOptions: PropTypes.array,
-    /** If true, reaction list will be shown at trailing end of message bubble. */
-    reverse: PropTypes.bool,
-  };
+import { defaultMinimalEmojis, emojiSetDef, emojiData } from '../../utils';
 
-  static defaultProps = {
-    detailedView: true,
-    reactionOptions: defaultMinimalEmojis,
-    reverse: false,
-    emojiSetDef,
-  };
+/** @type {React.FC<import("types").ReactionSelectorProps>} */
+const ReactionSelector = ({
+  latest_reactions,
+  reaction_counts,
+  reactionOptions = defaultMinimalEmojis,
+  reverse = false,
+  handleReaction,
+  detailedView = true,
+}) => {
+  const [tooltipReactionType, setTooltipReactionType] = useState(null);
+  const [tooltipPositions, setTooltipPositions] = useState(
+    /** @type {{ tooltip: number, arrow: number } | null} */ (null),
+  );
+  /** @type {React.MutableRefObject<HTMLDivElement | null>} */
+  const containerRef = useRef(null);
+  /** @type {React.MutableRefObject<HTMLDivElement | null>} */
+  const tooltipRef = useRef(null);
+  /** @type {React.MutableRefObject<HTMLElement | null>} */
+  const targetRef = useRef(null);
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      showTooltip: false,
-      users: [],
-      position: 0,
-      arrowPosition: 0,
-      positionCalculated: false,
-    };
-    this.reactionSelector = React.createRef();
-    this.reactionSelectorInner = React.createRef();
-    this.reactionSelectorTooltip = React.createRef();
-  }
+  const showTooltip = useCallback((e, reactionType) => {
+    targetRef.current = e.target;
+    setTooltipReactionType(reactionType);
+  }, []);
 
-  showTooltip = async (e, users) => {
-    const target = e.target.getBoundingClientRect();
-    await this.setState(
-      () => ({
-        showTooltip: true,
-        users,
-      }),
-      async () => {
-        await this.setTooltipPosition(target);
-        await this.setArrowPosition(target);
-      },
-    );
-  };
+  const hideTooltip = useCallback(() => {
+    setTooltipReactionType(null);
+    setTooltipPositions(null);
+  }, []);
 
-  hideTooltip = () => {
-    this.setState(() => ({
-      showTooltip: false,
-      users: [],
-      arrowPosition: 0,
-      position: 0,
-      positionCaculated: false,
-    }));
-  };
+  useEffect(() => {
+    if (tooltipReactionType) {
+      const tooltip = tooltipRef.current?.getBoundingClientRect();
+      const target = targetRef.current?.getBoundingClientRect();
+      const container = containerRef.current?.getBoundingClientRect();
 
-  getUsersPerReaction = (reactions, type) =>
-    reactions && reactions.filter((item) => item.type === type);
+      if (!tooltip || !target || !container) return;
 
-  getLatestUser = (reactions, type) => {
-    const filtered = this.getUsersPerReaction(reactions, type);
-    if (filtered && filtered[0] && filtered[0].user) {
-      return filtered[0].user;
-    } else {
-      return 'NotFound';
+      const tooltipPosition =
+        tooltip.width === container.width || tooltip.x < container.x
+          ? 0
+          : target.left + target.width / 2 - container.left - tooltip.width / 2;
+      const arrowPosition =
+        target.x - tooltip.x + target.width / 2 - tooltipPosition;
+      setTooltipPositions({
+        tooltip: tooltipPosition,
+        arrow: arrowPosition,
+      });
     }
-  };
+  }, [tooltipReactionType, containerRef]);
 
-  getUserNames = (reactions, type) => {
-    const filtered = this.getUsersPerReaction(reactions, type);
-    return filtered && filtered.map((item) => item.user || 'NotFound');
-  };
+  /**
+   * @param {string | null} type
+   * @returns {string[] | undefined}
+   * */
+  const getUsersPerReactionType = (type) =>
+    latest_reactions
+      ?.map((reaction) => {
+        if (reaction.type === type) {
+          return reaction.user?.name || reaction.user?.id;
+        }
+        return null;
+      })
+      .filter(Boolean);
 
-  getContainerDimensions = () =>
-    this.reactionSelector.current.getBoundingClientRect();
-  getToolTipDimensions = () =>
-    this.reactionSelectorTooltip.current.getBoundingClientRect();
+  /**
+   * @param {string | null} type
+   * @returns {import("stream-chat").User | undefined}
+   * */
+  const getLatestUserForReactionType = (type) =>
+    latest_reactions?.find(
+      (reaction) => reaction.type === type && !!reaction.user,
+    )?.user;
 
-  setTooltipPosition = async (target) => {
-    const container = await this.getContainerDimensions();
-    const tooltip = await this.getToolTipDimensions();
-    let position;
-
-    if (tooltip.width === container.width || tooltip.x < container.x) {
-      position = 0;
-    } else {
-      position =
-        target.left + target.width / 2 - container.left - tooltip.width / 2;
-    }
-
-    await this.setState(() => ({
-      position,
-    }));
-  };
-
-  setArrowPosition = async (target) => {
-    const tooltip = this.reactionSelectorTooltip.current.getBoundingClientRect();
-    const position = target.x - tooltip.x + target.width / 2;
-
-    await this.setState(() => ({
-      arrowPosition: position,
-      positionCaculated: true,
-    }));
-  };
-
-  renderReactionItems = () => {
-    const { reaction_counts, latest_reactions } = this.props;
-    return this.props.reactionOptions.map((reaction) => {
-      const users = this.getUserNames(latest_reactions, reaction.id);
-      const latestUser = this.getLatestUser(latest_reactions, reaction.id);
-
-      const count = reaction_counts && reaction_counts[reaction.id];
-      return (
-        <li
-          key={`item-${reaction.id}`}
-          className="str-chat__message-reactions-list-item"
-          data-text={reaction.id}
-          onClick={this.props.handleReaction.bind(this, reaction.id)}
+  return (
+    <div
+      data-testid="reaction-selector"
+      className={`str-chat__reaction-selector ${
+        reverse ? 'str-chat__reaction-selector--reverse' : ''
+      }`}
+      ref={containerRef}
+    >
+      {!!tooltipReactionType && detailedView && (
+        <div
+          className="str-chat__reaction-selector-tooltip"
+          ref={tooltipRef}
+          style={{
+            left: tooltipPositions?.tooltip,
+            visibility: tooltipPositions ? 'visible' : 'hidden',
+          }}
         >
-          {Boolean(count) && this.props.detailedView && (
-            <React.Fragment>
-              <div
-                className="latest-user"
-                onMouseEnter={(e) => this.showTooltip(e, users)}
-                onMouseLeave={this.hideTooltip}
-              >
-                {latestUser !== 'NotFound' ? (
-                  <Avatar
-                    image={latestUser.image}
-                    alt={latestUser.name || null}
-                    size={20}
-                    name={latestUser.name || null}
-                  />
-                ) : (
-                  <div className="latest-user-not-found" />
-                )}
-              </div>
-            </React.Fragment>
+          <div className="arrow" style={{ left: tooltipPositions?.arrow }} />
+          {getUsersPerReactionType(tooltipReactionType)?.map(
+            (user, i, users) => (
+              <span className="latest-user-username" key={`key-${i}-${user}`}>
+                {`${user}${i < users.length - 1 ? ', ' : ''}`}
+              </span>
+            ),
           )}
-          <NimbleEmoji emoji={reaction} {...emojiSetDef} data={emojiData} />
+        </div>
+      )}
+      <ul className="str-chat__message-reactions-list">
+        {reactionOptions.map((reactionOption) => {
+          const latestUser = getLatestUserForReactionType(reactionOption.id);
 
-          {Boolean(count) && this.props.detailedView && (
-            <span className="str-chat__message-reactions-list-item__count">
-              {count || ''}
-            </span>
-          )}
-        </li>
-      );
-    });
-  };
+          const count = reaction_counts && reaction_counts[reactionOption.id];
+          return (
+            <li
+              key={`item-${reactionOption.id}`}
+              className="str-chat__message-reactions-list-item"
+              data-text={reactionOption.id}
+              onClick={() =>
+                handleReaction && handleReaction(reactionOption.id)
+              }
+            >
+              {!!count && detailedView && (
+                <React.Fragment>
+                  <div
+                    className="latest-user"
+                    onMouseEnter={(e) => showTooltip(e, reactionOption.id)}
+                    onMouseLeave={hideTooltip}
+                  >
+                    {latestUser ? (
+                      <Avatar
+                        image={latestUser.image}
+                        size={20}
+                        name={latestUser.name || null}
+                      />
+                    ) : (
+                      <div className="latest-user-not-found" />
+                    )}
+                  </div>
+                </React.Fragment>
+              )}
+              <NimbleEmoji
+                emoji={reactionOption}
+                {...emojiSetDef}
+                data={emojiData}
+              />
 
-  renderUsers = (users) =>
-    users.map((user, i) => {
-      let text = user.name || user.id;
-      if (i + 1 < users.length) {
-        text += ', ';
-      }
-      return (
-        <span className="latest-user-username" key={`key-${i}-${user}`}>
-          {text}
-        </span>
-      );
-    });
+              {Boolean(count) && detailedView && (
+                <span className="str-chat__message-reactions-list-item__count">
+                  {count || ''}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
 
-  render() {
-    return (
-      <div
-        data-testid="reaction-selector"
-        className={`str-chat__reaction-selector ${
-          this.props.reverse ? 'str-chat__reaction-selector--reverse' : ''
-        }`}
-        ref={this.reactionSelector}
-      >
-        {this.props.detailedView && (
-          <div
-            className="str-chat__reaction-selector-tooltip"
-            ref={this.reactionSelectorTooltip}
-            style={{
-              visibility: this.state.showTooltip ? 'visible' : 'hidden',
-              left: this.state.position,
-              opacity:
-                this.state.showTooltip && this.state.positionCaculated
-                  ? 1
-                  : 0.01,
-            }}
-          >
-            <div className="arrow" style={{ left: this.state.arrowPosition }} />
-            {this.renderUsers(this.state.users)}
-          </div>
-        )}
+ReactionSelector.propTypes = {
+  /**
+   * Array of latest reactions.
+   * Reaction object has following structure:
+   *
+   * ```json
+   * {
+   *  "type": "love",
+   *  "user_id": "demo_user_id",
+   *  "user": {
+   *    ...userObject
+   *  },
+   *  "created_at": "datetime";
+   * }
+   * ```
+   * */
+  latest_reactions: PropTypes.array,
+  /** Object/map of reaction id/type (e.g. 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry') vs count */
+  reaction_counts: PropTypes.objectOf(PropTypes.number.isRequired),
+  /** Provide a list of reaction options [{id: 'angry', emoji: 'angry'}] */
+  reactionOptions: PropTypes.array,
+  reverse: PropTypes.bool,
+  /**
+   * Handler to set/unset reaction on message.
+   *
+   * @param type e.g. 'like' | 'love' | 'haha' | 'wow' | 'sad' | 'angry'
+   * */
+  handleReaction: PropTypes.func.isRequired,
+  /** Enable the avatar display */
+  detailedView: PropTypes.bool,
+};
 
-        <ul className="str-chat__message-reactions-list">
-          {this.renderReactionItems()}
-        </ul>
-      </div>
-    );
-  }
-}
-
-export default ReactionSelector;
+export default React.memo(ReactionSelector);

--- a/src/components/Reactions/ReactionSelector.js
+++ b/src/components/Reactions/ReactionSelector.js
@@ -1,5 +1,11 @@
 // @ts-check
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, {
+  useState,
+  useCallback,
+  useRef,
+  useImperativeHandle,
+  useEffect,
+} from 'react';
 import PropTypes from 'prop-types';
 // @ts-ignore
 import { NimbleEmoji } from 'emoji-mart';
@@ -7,25 +13,28 @@ import { Avatar } from '../Avatar';
 
 import { defaultMinimalEmojis, emojiSetDef, emojiData } from '../../utils';
 
-/** @type {React.FC<import("types").ReactionSelectorProps>} */
-const ReactionSelector = ({
-  latest_reactions,
-  reaction_counts,
-  reactionOptions = defaultMinimalEmojis,
-  reverse = false,
-  handleReaction,
-  detailedView = true,
-}) => {
+/** @type {React.ForwardRefRenderFunction<HTMLDivElement | null, import("types").ReactionSelectorProps>} */
+const ReactionSelectorWithRef = (
+  {
+    latest_reactions,
+    reaction_counts,
+    reactionOptions = defaultMinimalEmojis,
+    reverse = false,
+    handleReaction,
+    detailedView = true,
+  },
+  ref,
+) => {
   const [tooltipReactionType, setTooltipReactionType] = useState(null);
   const [tooltipPositions, setTooltipPositions] = useState(
     /** @type {{ tooltip: number, arrow: number } | null} */ (null),
   );
-  /** @type {React.MutableRefObject<HTMLDivElement | null>} */
-  const containerRef = useRef(null);
-  /** @type {React.MutableRefObject<HTMLDivElement | null>} */
-  const tooltipRef = useRef(null);
-  /** @type {React.MutableRefObject<HTMLElement | null>} */
-  const targetRef = useRef(null);
+  const containerRef = useRef(/** @type {HTMLDivElement | null} */ (null));
+  const tooltipRef = useRef(/** @type {HTMLDivElement | null} */ (null));
+  const targetRef = useRef(/** @type {HTMLDivElement | null} */ (null));
+
+  // @ts-ignore because it's okay for our ref to be null in the parent component.
+  useImperativeHandle(ref, () => containerRef.current);
 
   const showTooltip = useCallback((e, reactionType) => {
     targetRef.current = e.target;
@@ -159,6 +168,8 @@ const ReactionSelector = ({
     </div>
   );
 };
+
+const ReactionSelector = React.forwardRef(ReactionSelectorWithRef);
 
 ReactionSelector.propTypes = {
   /**

--- a/src/components/Reactions/__tests__/ReactionSelector.test.js
+++ b/src/components/Reactions/__tests__/ReactionSelector.test.js
@@ -152,6 +152,6 @@ describe('ReactionSelector', () => {
 
     fireEvent.click(emoji);
 
-    expect(handleReactionMock).toHaveBeenCalledWith('love', expect.any(Object));
+    expect(handleReactionMock).toHaveBeenCalledWith('love');
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -668,7 +668,7 @@ export interface ReactionsListProps {
    */
   reaction_counts?: {
     [reaction_type: string]: number;
-  };
+  } | {};
   /** Provide a list of reaction options [{name: 'angry', emoji: 'angry'}] */
   reactionOptions?: MinimalEmojiInterface[];
   onClick?(): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -668,7 +668,7 @@ export interface ReactionsListProps {
    */
   reaction_counts?: {
     [reaction_type: string]: number;
-  } | {};
+  };
   /** Provide a list of reaction options [{name: 'angry', emoji: 'angry'}] */
   reactionOptions?: MinimalEmojiInterface[];
   onClick?(): void;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Converts ReactionSelector to hooks.

Note: technically a (small, probably irrelevant) breaking change because there no longer is a ref inside a ref in ReactionsList. Instead, the ref of the container div is directly forwarded by the component. 