### PR TITLE
Fix <ChannelHeader /> component

### DIFF
--- a/src/components/ChannelHeader/ChannelHeader.js
+++ b/src/components/ChannelHeader/ChannelHeader.js
@@ -2,7 +2,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Avatar } from '../Avatar';
-import { ChatContext, ChannelContext, TranslationContext } from '../../context';
+import { ChannelContext, TranslationContext } from '../../context';
 
 /**
  * ChannelHeader - Render some basic information about this channel
@@ -13,9 +13,7 @@ const ChannelHeader = ({ title, live }) => {
   /** @type {import("types").TranslationContextValue} */
   const { t } = useContext(TranslationContext);
   /** @type {import("types").ChannelContextValue} */
-  const { watcher_count } = useContext(ChannelContext);
-  /** @type {import("types").ChatContextValue} */
-  const { channel, openMobileNav } = useContext(ChatContext);
+  const { channel, openMobileNav, watcher_count } = useContext(ChannelContext);
 
   return (
     <div className="str-chat__header-livestream">

--- a/src/components/ChannelHeader/__tests__/ChannelHeader.test.js
+++ b/src/components/ChannelHeader/__tests__/ChannelHeader.test.js
@@ -23,7 +23,7 @@ async function renderComponent(props, channelData) {
   const client = await getTestClientWithUser(alice);
   return render(
     <ChatContext.Provider value={{ client, channel: testChannel1 }}>
-      <ChannelContext.Provider value={{ client }}>
+      <ChannelContext.Provider value={{ client, channel: testChannel1 }}>
         <TranslationContext.Provider value={{ t }}>
           <ChannelHeader {...props} />
         </TranslationContext.Provider>


### PR DESCRIPTION
Get all contextual data from ChannelContext rather than the ChatContext,
as `channel` might not be available on the latter.