### PR TITLE
Fix ReactionSelector typescript error

### DIFF
--- a/src/components/Reactions/ReactionSelector.js
+++ b/src/components/Reactions/ReactionSelector.js
@@ -7,7 +7,6 @@ import React, {
   useEffect,
 } from 'react';
 import PropTypes from 'prop-types';
-// @ts-ignore
 import { NimbleEmoji } from 'emoji-mart';
 import { Avatar } from '../Avatar';
 
@@ -151,6 +150,8 @@ const ReactionSelectorWithRef = (
                 </React.Fragment>
               )}
               <NimbleEmoji
+                // @ts-ignore because emoji-mart types don't support specifying
+                // spriteUrl instead of imageUrl, while the implementation does
                 emoji={reactionOption}
                 {...emojiSetDef}
                 data={emojiData}


### PR DESCRIPTION
#166 Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Added `@ts-ignore` because emoji-mart typescript definitions don't seem to support a usecase that is in fact supported by their actual implementation.

See: https://github.com/missive/emoji-mart/blob/master/src/components/emoji/nimble-emoji.js#L139

`spriteUrl` can be supplied instead of `imageUrl`, but the typescript definitions for their emoji components (e.g. `NimbleEmoji`) only allow `imageUrl` to be passed.
