### PR TITLE
Fix useMentionsHandler hook

### DIFF
--- a/src/components/Message/MessageLivestream.js
+++ b/src/components/Message/MessageLivestream.js
@@ -25,7 +25,7 @@ import {
   useOpenThreadHandler,
   useActionHandler,
   useReactionClick,
-  useMentionsHandler,
+  useMentionsUIHandler,
 } from './hooks';
 import {
   messageHasAttachments,
@@ -88,7 +88,10 @@ const MessageLivestreamComponent = (props) => {
    *@type {import('types').ChannelContextValue}
    */
   const { updateMessage: channelUpdateMessage } = useContext(ChannelContext);
-  const { onMentionsClick, onMentionsHover } = useMentionsHandler(message);
+  const { onMentionsClick, onMentionsHover } = useMentionsUIHandler(message, {
+    onMentionsClick: propOnMentionsClick,
+    onMentionsHover: propOnMentionsHover,
+  });
   const handleAction = useActionHandler(message);
   const handleReaction = useReactionHandler(message);
   const handleOpenThread = useOpenThreadHandler(message);
@@ -210,8 +213,8 @@ const MessageLivestreamComponent = (props) => {
                   ? 'str-chat__message-livestream-text--is-emoji'
                   : ''
               }
-              onMouseOver={propOnMentionsHover || onMentionsHover}
-              onClick={propOnMentionsClick || onMentionsClick}
+              onMouseOver={onMentionsHover}
+              onClick={onMentionsClick}
             >
               {message.type !== 'error' &&
                 message.status !== 'failed' &&

--- a/src/components/Message/MessageTeam.js
+++ b/src/components/Message/MessageTeam.js
@@ -26,6 +26,7 @@ import {
   useRetryHandler,
   useReactionHandler,
   useOpenThreadHandler,
+  useMentionsUIHandler,
 } from './hooks';
 import {
   getNonImageAttachments,
@@ -64,11 +65,11 @@ const MessageTeam = (props) => {
     clearEditingState,
     threadList,
     initialMessage,
-    onMentionsHoverMessage,
-    onMentionsClickMessage,
     unsafeHTML,
     getMessageActions,
     MessageDeleted,
+    onMentionsHoverMessage: propOnMentionsHover,
+    onMentionsClickMessage: propOnMentionsClick,
     channelConfig: propChannelConfig,
     handleAction: propHandleAction,
     handleOpenThread: propHandleOpenThread,
@@ -99,6 +100,10 @@ const MessageTeam = (props) => {
   const handleReaction = useReactionHandler(message);
   const retryHandler = useRetryHandler();
   const retry = propHandleRetry || retryHandler;
+  const { onMentionsClick, onMentionsHover } = useMentionsUIHandler(message, {
+    onMentionsClick: propOnMentionsClick,
+    onMentionsHover: propOnMentionsHover,
+  });
   const { onReactionListClick, showDetailedReactions } = useReactionClick(
     reactionSelectorRef,
     message,
@@ -289,8 +294,8 @@ const MessageTeam = (props) => {
                     ? 'str-chat__message-team-text--is-emoji'
                     : ''
                 }
-                onMouseOver={onMentionsHoverMessage}
-                onClick={onMentionsClickMessage}
+                onMouseOver={onMentionsHover}
+                onClick={onMentionsClick}
               >
                 {unsafeHTML ? (
                   <div dangerouslySetInnerHTML={{ __html: message.html }} />

--- a/src/components/Message/MessageText.js
+++ b/src/components/Message/MessageText.js
@@ -4,9 +4,9 @@ import { isOnlyEmojis, renderText } from '../../utils';
 import { TranslationContext } from '../../context';
 import { ReactionsList, ReactionSelector } from '../Reactions';
 import {
-  useMentionsHandler,
   useReactionHandler,
   useReactionClick,
+  useMentionsUIHandler,
 } from './hooks';
 import { messageHasReactions, messageHasAttachments } from './utils';
 import { MessageOptions } from './MessageOptions';
@@ -26,7 +26,10 @@ const MessageTextComponent = (props) => {
     customOptionProps,
   } = props;
   const reactionSelectorRef = useRef(null);
-  const { onMentionsClick, onMentionsHover } = useMentionsHandler(message);
+  const { onMentionsClick, onMentionsHover } = useMentionsUIHandler(message, {
+    onMentionsClick: propOnMentionsClick,
+    onMentionsHover: propOnMentionsHover,
+  });
   const { onReactionListClick, showDetailedReactions } = useReactionClick(
     reactionSelectorRef,
     message,
@@ -61,8 +64,8 @@ const MessageTextComponent = (props) => {
               : ''
           }
         `.trim()}
-        onMouseOver={propOnMentionsHover || onMentionsHover}
-        onClick={propOnMentionsClick || onMentionsClick}
+        onMouseOver={onMentionsHover}
+        onClick={onMentionsClick}
       >
         {message.type === 'error' && (
           <div className={`str-chat__${theme}-message--error-message`}>

--- a/src/components/Message/hooks/__tests__/useMentionsHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useMentionsHandler.test.js
@@ -2,7 +2,10 @@ import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { generateUser, generateMessage } from 'mock-builders';
 import { ChannelContext } from '../../../../context';
-import { useMentionsHandler } from '../useMentionsHandler';
+import {
+  useMentionsHandler,
+  useMentionsUIHandler,
+} from '../useMentionsHandler';
 
 const onMentionsClickMock = jest.fn();
 const onMentionsHoverMock = jest.fn();
@@ -10,28 +13,33 @@ const mouseEventMock = {
   preventDefault: jest.fn(() => {}),
 };
 
-function renderUseMentionsHandlerHook(
-  message = generateMessage(),
-  onMentionsClick = onMentionsClickMock,
-  onMentionsHover = onMentionsHoverMock,
-) {
-  const wrapper = ({ children }) => (
-    <ChannelContext.Provider
-      value={{
-        onMentionsClick,
-        onMentionsHover,
-      }}
-    >
-      {children}
-    </ChannelContext.Provider>
-  );
-  const { result } = renderHook(() => useMentionsHandler(message), {
-    wrapper,
-  });
-  return result.current;
+function generateHookHandler(hook) {
+  return (
+    message,
+    hookOptions,
+    onMentionsClick = onMentionsClickMock,
+    onMentionsHover = onMentionsHoverMock,
+  ) => {
+    const wrapper = ({ children }) => (
+      <ChannelContext.Provider
+        value={{
+          onMentionsClick,
+          onMentionsHover,
+        }}
+      >
+        {children}
+      </ChannelContext.Provider>
+    );
+    const { result } = renderHook(() => hook(message, hookOptions), {
+      wrapper,
+    });
+    return result.current;
+  };
 }
 
-describe('useMentionsHandler custom hook', () => {
+const renderUseMentionsHandlerHook = generateHookHandler(useMentionsHandler);
+
+describe('useMentionsHandler custom hooks', () => {
   afterEach(jest.clearAllMocks);
   it('should return a function', () => {
     const handleMentions = renderUseMentionsHandlerHook();
@@ -59,7 +67,7 @@ describe('useMentionsHandler custom hook', () => {
     const bob = generateUser();
     const mentioned_users = [alice, bob];
     const message = generateMessage({ mentioned_users });
-    const { onMentionsClick } = renderUseMentionsHandlerHook(message, null);
+    const { onMentionsClick } = renderUseMentionsHandlerHook(message, {}, null);
     onMentionsClick(mouseEventMock);
     expect(onMentionsClickMock).not.toHaveBeenCalled();
   });
@@ -91,6 +99,7 @@ describe('useMentionsHandler custom hook', () => {
     const message = generateMessage({ mentioned_users });
     const { onMentionsHover } = renderUseMentionsHandlerHook(
       message,
+      {},
       onMentionsClickMock,
       null,
     );
@@ -98,10 +107,105 @@ describe('useMentionsHandler custom hook', () => {
     expect(onMentionsHoverMock).not.toHaveBeenCalled();
   });
 
-  it('should not call onMentionsHover when it message has no mentioned users set', () => {
+  it('should not call onMentionsHover when message has no mentioned users set', () => {
     const message = generateMessage({ mentioned_users: null });
     const { onMentionsHover } = renderUseMentionsHandlerHook(message);
     onMentionsHover(mouseEventMock);
     expect(onMentionsHoverMock).not.toHaveBeenCalled();
+  });
+
+  it('should call the custom mention hover handler when one is set', () => {
+    const bob = generateUser();
+    const mentioned_users = [bob];
+    const message = generateMessage({ mentioned_users });
+    const onMentionsHoverHandler = jest.fn();
+    const { onMentionsHover } = renderUseMentionsHandlerHook(message, {
+      onMentionsHover: onMentionsHoverHandler,
+    });
+    onMentionsHover(mouseEventMock);
+    expect(onMentionsHoverHandler).toHaveBeenCalledWith(
+      mouseEventMock,
+      mentioned_users,
+    );
+  });
+
+  it('should call the custom mention click handler when one is set', () => {
+    const bob = generateUser();
+    const mentioned_users = [bob];
+    const message = generateMessage({ mentioned_users });
+    const onMentionsClickHandler = jest.fn();
+    const { onMentionsClick } = renderUseMentionsHandlerHook(message, {
+      onMentionsClick: onMentionsClickHandler,
+    });
+    onMentionsClick(mouseEventMock);
+    expect(onMentionsClickHandler).toHaveBeenCalledWith(
+      mouseEventMock,
+      mentioned_users,
+    );
+  });
+});
+
+const renderUseMentionsUIHandlerHook = generateHookHandler(
+  useMentionsUIHandler,
+);
+
+describe('useMentionsUIHandler', () => {
+  afterEach(jest.clearAllMocks);
+  it('should return a function', () => {
+    const handleMentions = renderUseMentionsUIHandlerHook();
+    expect(handleMentions).toStrictEqual({
+      onMentionsClick: expect.any(Function),
+      onMentionsHover: expect.any(Function),
+    });
+  });
+
+  it("should call onMentionsClick with message's mentioned users when user clicks on a mention", () => {
+    const alice = generateUser();
+    const bob = generateUser();
+    const mentioned_users = [alice, bob];
+    const message = generateMessage({ mentioned_users });
+    const { onMentionsClick } = renderUseMentionsUIHandlerHook(message);
+    onMentionsClick(mouseEventMock);
+    expect(onMentionsClickMock).toHaveBeenCalledWith(
+      mouseEventMock,
+      mentioned_users,
+    );
+  });
+
+  it("should call onMentionsHover with message's mentioned users when user hovers on a mention", () => {
+    const alice = generateUser();
+    const bob = generateUser();
+    const mentioned_users = [alice, bob];
+    const message = generateMessage({ mentioned_users });
+    const { onMentionsHover } = renderUseMentionsUIHandlerHook(message);
+    onMentionsHover(mouseEventMock);
+    expect(onMentionsHoverMock).toHaveBeenCalledWith(
+      mouseEventMock,
+      mentioned_users,
+    );
+  });
+
+  it('should call the custom message mention click processor when one is set', () => {
+    const bob = generateUser();
+    const mentioned_users = [bob];
+    const message = generateMessage({ mentioned_users });
+    const customMentionClickHandler = jest.fn();
+    const { onMentionsClick } = renderUseMentionsUIHandlerHook(message, {
+      onMentionsClick: customMentionClickHandler,
+    });
+    onMentionsClick(mouseEventMock);
+    expect(customMentionClickHandler).toHaveBeenCalledWith(mouseEventMock);
+  });
+
+  it('should call the custom message mention hover handler when one is set', () => {
+    const bob = generateUser();
+    const mentioned_users = [bob];
+    const message = generateMessage({ mentioned_users });
+    const customMentionsHover = jest.fn();
+    const { onMentionsHover } = renderUseMentionsUIHandlerHook(message, {
+      onMentionsHover: customMentionsHover,
+    });
+    onMentionsHover(mouseEventMock);
+    expect(customMentionsHover).toHaveBeenCalledWith(mouseEventMock);
   });
 });

--- a/src/components/Message/hooks/useMentionsHandler.js
+++ b/src/components/Message/hooks/useMentionsHandler.js
@@ -2,11 +2,63 @@
 import { useContext } from 'react';
 import { ChannelContext } from '../../../context';
 
+/** @type {(fn: Function | undefined, message: import('stream-chat').MessageResponse | undefined) => Handler} * */
+function createEventHandler(fn, message) {
+  return (e) => {
+    if (typeof fn !== 'function' || !message?.mentioned_users) {
+      return;
+    }
+    fn(e, message.mentioned_users);
+  };
+}
+
 /**
  * @typedef {React.EventHandler<React.SyntheticEvent>} Handler
- * @type {(message: import('stream-chat').MessageResponse | undefined) => { onMentionsClick: Handler, onMentionsHover: Handler }}
+ * @typedef { import('stream-chat').MessageResponse | undefined } Message
+ * @typedef { (event: React.MouseEvent, user: import('stream-chat').UserResponse[] ) => void } CustomMentionHandler
+ * @type {(
+ *   message: Message,
+ *   customMentionHandler?: {
+ *     onMentionsClick?: CustomMentionHandler,
+ *     onMentionsHover?: CustomMentionHandler
+ *   }
+ * ) => { onMentionsClick: Handler, onMentionsHover: Handler }}
  */
-export const useMentionsHandler = (message) => {
+export const useMentionsHandler = (message, customMentionHandler) => {
+  /**
+   * @type{import('types').ChannelContextValue}
+   */
+  const {
+    onMentionsClick: channelOnMentionsClick,
+    onMentionsHover: channelOnMentionsHover,
+  } = useContext(ChannelContext);
+  const onMentionsClick =
+    customMentionHandler?.onMentionsClick ||
+    channelOnMentionsClick ||
+    (() => {});
+  const onMentionsHover =
+    customMentionHandler?.onMentionsHover ||
+    channelOnMentionsHover ||
+    (() => {});
+
+  return {
+    /** @type {(e: React.MouseEvent<HTMLElement>) => void} Typescript syntax */
+    onMentionsClick: createEventHandler(onMentionsClick, message),
+    /** @type {(e: React.MouseEvent<HTMLElement>) => void} Typescript syntax */
+    onMentionsHover: createEventHandler(onMentionsHover, message),
+  };
+};
+
+/**
+ * @type {(
+ *   message: Message,
+ *   eventHandlers?: {
+ *     onMentionsClick?: Handler,
+ *     onMentionsHover?: Handler,
+ *   },
+ * ) => { onMentionsClick: Handler, onMentionsHover: Handler }}
+ */
+export const useMentionsUIHandler = (message, eventHandlers) => {
   /**
    * @type{import('types').ChannelContextValue}
    */
@@ -14,19 +66,12 @@ export const useMentionsHandler = (message) => {
 
   return {
     /** @type {(e: React.MouseEvent<HTMLElement>) => void} Typescript syntax */
-    onMentionsClick: (e) => {
-      if (typeof onMentionsClick !== 'function' || !message?.mentioned_users) {
-        return;
-      }
-      onMentionsClick(e, message.mentioned_users);
-    },
+    onMentionsClick:
+      eventHandlers?.onMentionsClick ||
+      createEventHandler(onMentionsClick, message),
     /** @type {(e: React.MouseEvent<HTMLElement>) => void} Typescript syntax */
-    onMentionsHover: (e) => {
-      if (typeof onMentionsHover !== 'function' || !message?.mentioned_users) {
-        return;
-      }
-
-      onMentionsHover(e, message.mentioned_users);
-    },
+    onMentionsHover:
+      eventHandlers?.onMentionsHover ||
+      createEventHandler(onMentionsHover, message),
   };
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -537,7 +537,7 @@ export interface MessageComponentProps
   onUserHover?(e: React.MouseEvent, user: Client.User): void;
   messageActions?: Array<string>;
   members?: SeamlessImmutable.Immutable<{ [user_id: string]: Client.Member }>;
-  retrySendMessage?(message: Client.Message): void;
+  retrySendMessage?(message: Client.Message): Promise<void>;
   removeMessage?(updatedMessage: Client.MessageResponse): void;
   mutes?: Client.Mute[];
   openThread?(


### PR DESCRIPTION
Currently, there are two ways we allow our message components mention handlers
to be overwritten. A user might want to overwrite the click event itself
or the user might want to overwrite how we process this event.

Also in the current implementation, our message UI components deal with the latter,
while the <Message /> HOC deals with the first case. This commit makes
sure we keep it this way, by extending the useMentionsHandler custom
hook to handle both use cases while applying them correctly where
they're used - it will be later applied to the Message HOC as well.
