### PR TITLE
Improve edit handler

### DIFF
--- a/src/components/Message/hooks/__tests__/useEditHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useEditHandler.test.js
@@ -1,39 +1,85 @@
-import { renderHook } from '@testing-library/react-hooks';
-import { generateMessage } from 'mock-builders';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { useEditHandler } from '../useEditHandler';
 
-const setEditingStateMock = jest.fn();
 const mouseEventMock = {
   preventDefault: jest.fn(() => {}),
 };
 
 function renderUseEditHandler(
-  message = generateMessage(),
-  setEditingState = setEditingStateMock,
+  customInitialState = undefined,
+  customSetEditingHandler = undefined,
+  customClearEditing = undefined,
 ) {
-  const { result } = renderHook(() => useEditHandler(message, setEditingState));
-  return result.current;
+  const { result } = renderHook(() =>
+    useEditHandler(
+      customInitialState,
+      customSetEditingHandler,
+      customClearEditing,
+    ),
+  );
+  return result;
 }
 
 describe('useEditHandler custom hook', () => {
   afterEach(jest.clearAllMocks);
-  it('should generate function that handles message deletion', () => {
-    const handleEdit = renderUseEditHandler();
-    expect(typeof handleEdit).toBe('function');
+  it('should generate an editing state, a function to set it and a function to delete it', () => {
+    const renderedHook = renderUseEditHandler();
+    expect(renderedHook.current.editing).toBe(false);
+    expect(typeof renderedHook.current.setEdit).toBe('function');
+    expect(typeof renderedHook.current.clearEdit).toBe('function');
   });
 
-  it('should prevent click event from bubbling', () => {
-    const handleEdit = renderUseEditHandler();
-    handleEdit(mouseEventMock);
+  it('should initialize with a custom initial state when called', () => {
+    const renderedHook = renderUseEditHandler(true);
+    expect(renderedHook.current.editing).toBe(true);
+  });
+
+  it('should prevent click event from bubbling when setting edit state', () => {
+    const renderedHook = renderUseEditHandler();
+    act(() => renderedHook.current.setEdit(mouseEventMock));
     expect(mouseEventMock.preventDefault).toHaveBeenCalledWith();
   });
 
-  // TODO: @vini
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('should set editing for message', () => {
-    const message = generateMessage();
-    const handleEdit = renderUseEditHandler(message);
-    handleEdit(mouseEventMock);
-    expect(setEditingStateMock).toHaveBeenCalledWith(message);
+  it('should set editing to true when the set editing function is called', () => {
+    const renderedHook = renderUseEditHandler();
+    expect(renderedHook.current.editing).toBe(false);
+    act(() => renderedHook.current.setEdit(mouseEventMock));
+    expect(renderedHook.current.editing).toBe(true);
+  });
+
+  it('should call the custom editing handler when one is set', () => {
+    const customSetEditingHandler = jest.fn();
+    const renderedHook = renderUseEditHandler(
+      undefined,
+      customSetEditingHandler,
+    );
+    expect(customSetEditingHandler).not.toHaveBeenCalled();
+    act(() => renderedHook.current.setEdit(mouseEventMock));
+    expect(customSetEditingHandler).toHaveBeenCalledWith(mouseEventMock);
+  });
+
+  it('should prevent click event from bubbling when clearing the edit state', () => {
+    const renderedHook = renderUseEditHandler();
+    act(() => renderedHook.current.clearEdit(mouseEventMock));
+    expect(mouseEventMock.preventDefault).toHaveBeenCalledWith();
+  });
+
+  it('should set editing to false when the set editing function is called', () => {
+    const renderedHook = renderUseEditHandler(true);
+    expect(renderedHook.current.editing).toBe(true);
+    act(() => renderedHook.current.clearEdit(mouseEventMock));
+    expect(renderedHook.current.editing).toBe(false);
+  });
+
+  it('should call the custom clear editing handler when one is set', () => {
+    const customClearEditingHandler = jest.fn();
+    const renderedHook = renderUseEditHandler(
+      undefined,
+      undefined,
+      customClearEditingHandler,
+    );
+    expect(customClearEditingHandler).not.toHaveBeenCalled();
+    act(() => renderedHook.current.clearEdit(mouseEventMock));
+    expect(customClearEditingHandler).toHaveBeenCalledWith(mouseEventMock);
   });
 });

--- a/src/components/Message/hooks/useEditHandler.js
+++ b/src/components/Message/hooks/useEditHandler.js
@@ -1,16 +1,35 @@
 // @ts-check
+import { useState } from 'react';
 
 /**
- * @type {(message: import('stream-chat').MessageResponse | undefined, setEditingState: import('types').MessageUIComponentProps['setEditingState']) =>  (event: React.MouseEvent<HTMLElement>) => void}
+ * @type {(
+ *   customInitialState?: boolean,
+ *   customSetEditing?: (event: React.MouseEvent<HTMLElement>) => void,
+ *   customClearEditing?: (event: React.MouseEvent<HTMLElement>) => void
+ * ) => {
+ *   editing: boolean,
+ *   setEdit: (event: React.MouseEvent<HTMLElement>) => void,
+ *   clearEdit: (event: React.MouseEvent<HTMLElement>) => void
+ * }}
  */
-export const useEditHandler = (message, setEditingState) => {
-  return (event) => {
-    event.preventDefault();
+export const useEditHandler = (
+  customInitialState = false,
+  customSetEditing,
+  customClearEditingHandler,
+) => {
+  const [editing, setEditing] = useState(customInitialState);
 
-    if (!message || !setEditingState) {
-      return;
-    }
-
-    setEditingState();
-  };
+  const setEdit =
+    customSetEditing ||
+    ((event) => {
+      event.preventDefault();
+      setEditing(true);
+    });
+  const clearEdit =
+    customClearEditingHandler ||
+    ((event) => {
+      event.preventDefault();
+      setEditing(false);
+    });
+  return { editing, setEdit, clearEdit };
 };

--- a/src/components/MessageActions/MessageActions.js
+++ b/src/components/MessageActions/MessageActions.js
@@ -5,7 +5,6 @@ import {
   useDeleteHandler,
   useUserRole,
   useFlagHandler,
-  useEditHandler,
   useMuteHandler,
 } from '../Message/hooks';
 import { isUserMuted } from '../Message/utils';
@@ -28,7 +27,6 @@ export const MessageActions = (props) => {
     getFlagMessageSuccessNotification,
     handleFlag: propHandleFlag,
     handleMute: propHandleMute,
-    handleEdit: propHandleEdit,
     handleDelete: propHandleDelete,
     inline,
     customWrapperClass,
@@ -37,7 +35,6 @@ export const MessageActions = (props) => {
   const [actionsBoxOpen, setActionsBoxOpen] = useState(false);
   const { isMyMessage } = useUserRole(message);
   const handleDelete = useDeleteHandler(message);
-  const handleEdit = useEditHandler(message, setEditingState);
   const handleFlag = useFlagHandler(message, {
     notify: addNotification,
     getSuccessNotification: getFlagMessageErrorNotification,
@@ -93,7 +90,7 @@ export const MessageActions = (props) => {
         handleFlag={propHandleFlag || handleFlag}
         isUserMuted={isMuted}
         handleMute={propHandleMute || handleMute}
-        handleEdit={propHandleEdit || handleEdit}
+        handleEdit={setEditingState}
         handleDelete={propHandleDelete || handleDelete}
         mine={isMyMessage}
       />


### PR DESCRIPTION
Adding the whole editing state handling to the edit handler hook, as
this now belongs to the message components. While doing it, I noticed
that there are 2 edit handlers passed to the MessageActions component,
both intended to deal with setting the edit state to true. Because of
that, and because for now this component is only used internally, I
removed one of them in favor of the other, simplifying the logic there.
This is needed to complete https://github.com/GetStream/stream-chat-react/pull/415.