### PR TITLE
Allow message timestamp override

### DIFF
--- a/src/components/Message/Message.js
+++ b/src/components/Message/Message.js
@@ -47,6 +47,7 @@ const Message = (props) => {
     onMentionsHover: propOnMentionsHover,
     Message: MessageUIComponent = MessageSimple,
     messageActions = Object.keys(MESSAGE_ACTIONS),
+    formatDate,
     groupStyles = [],
   } = props;
   const { channel: contextChannel } = useContext(ChannelContext);
@@ -100,6 +101,7 @@ const Message = (props) => {
       <MessageUIComponent
         {...props}
         editing={editing}
+        formatDate={formatDate}
         clearEditingState={clearEdit}
         setEditingState={setEdit}
         groupStyles={groupStyles}

--- a/src/components/Message/MessageCommerce.js
+++ b/src/components/Message/MessageCommerce.js
@@ -34,6 +34,7 @@ import MessageTimestamp from './MessageTimestamp';
 const MessageCommerce = (props) => {
   const {
     message,
+    formatDate,
     groupStyles,
     actionsEnabled,
     threadList,
@@ -190,6 +191,7 @@ const MessageCommerce = (props) => {
               </span>
             ) : null}
             <MessageTimestamp
+              formatDate={formatDate}
               customClass="str-chat__message-commerce-timestamp"
               message={message}
               tDateTimeParser={propTDateTimeParser}

--- a/src/components/Message/MessageCommerce.js
+++ b/src/components/Message/MessageCommerce.js
@@ -1,7 +1,6 @@
 // @ts-check
-import React, { useContext, useRef } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import { TranslationContext } from '../../context';
 import { smartRender } from '../../utils';
 import { Attachment as DefaultAttachment } from '../Attachment';
 import { Avatar } from '../Avatar';
@@ -24,6 +23,7 @@ import {
   useOpenThreadHandler,
   useUserHandler,
 } from './hooks';
+import MessageTimestamp from './MessageTimestamp';
 
 /**
  * MessageCommerce - Render component, should be used together with the Message component
@@ -51,7 +51,6 @@ const MessageCommerce = (props) => {
   const handleAction = useActionHandler(message);
   const handleReaction = useReactionHandler(message);
   const handleOpenThread = useOpenThreadHandler(message);
-  const { tDateTimeParser } = useContext(TranslationContext);
   const reactionSelectorRef = useRef(null);
   const { onReactionListClick, showDetailedReactions } = useReactionClick(
     message,
@@ -61,11 +60,6 @@ const MessageCommerce = (props) => {
     onUserClickHandler: propOnUserClick,
     onUserHoverHandler: propOnUserHover,
   });
-  const dateTimeParser = propTDateTimeParser || tDateTimeParser;
-  const when =
-    message &&
-    dateTimeParser &&
-    dateTimeParser(message.created_at).format('LT');
   const { isMyMessage } = useUserRole(message);
   const messageClasses = `str-chat__message-commerce str-chat__message-commerce--${
     isMyMessage ? 'right' : 'left'
@@ -195,7 +189,12 @@ const MessageCommerce = (props) => {
                 {message?.user?.name || message?.user?.id}
               </span>
             ) : null}
-            <span className="str-chat__message-commerce-timestamp">{when}</span>
+            <MessageTimestamp
+              customClass="str-chat__message-commerce-timestamp"
+              message={message}
+              tDateTimeParser={propTDateTimeParser}
+              format="LT"
+            />
           </div>
         </div>
       </div>

--- a/src/components/Message/MessageLivestream.js
+++ b/src/components/Message/MessageLivestream.js
@@ -57,6 +57,7 @@ const MessageLivestreamComponent = (props) => {
     clearEditingState: propClearEdit,
     initialMessage,
     unsafeHTML,
+    formatDate,
     onUserClick: propOnUserClick,
     handleReaction: propHandleReaction,
     handleOpenThread: propHandleOpenThread,
@@ -177,6 +178,7 @@ const MessageLivestreamComponent = (props) => {
         <MessageLivestreamActions
           initialMessage={initialMessage}
           message={message}
+          formatDate={formatDate}
           onReactionListClick={onReactionListClick}
           messageWrapperRef={messageWrapperRef}
           getMessageActions={props.getMessageActions}
@@ -301,6 +303,7 @@ const MessageLivestreamActions = (props) => {
     message,
     channelConfig,
     threadList,
+    formatDate,
     messageWrapperRef,
     onReactionListClick,
     getMessageActions,
@@ -360,6 +363,7 @@ const MessageLivestreamActions = (props) => {
       <MessageTimestamp
         customClass="str-chat__message-livestream-time"
         message={message}
+        formatDate={formatDate}
         tDateTimeParser={propTDateTimeParser}
       />
       {channelConfig && channelConfig.reactions && (

--- a/src/components/Message/MessageLivestream.js
+++ b/src/components/Message/MessageLivestream.js
@@ -37,6 +37,7 @@ import {
 } from './utils';
 import { MessageActions } from '../MessageActions';
 import { ReactionIcon, ThreadIcon, ErrorIcon } from './icons';
+import MessageTimestamp from './MessageTimestamp';
 
 /**
  * MessageLivestream - Render component, should be used together with the Message component
@@ -306,8 +307,6 @@ const MessageLivestreamActions = (props) => {
     handleOpenThread,
     tDateTimeParser: propTDateTimeParser,
   } = props;
-  const { tDateTimeParser } = useContext(TranslationContext);
-  const dateParser = propTDateTimeParser || tDateTimeParser;
   const [actionsBoxOpen, setActionsBoxOpen] = useState(false);
   /** @type {() => void} Typescript syntax */
   const hideOptions = useCallback(() => setActionsBoxOpen(false), []);
@@ -358,9 +357,11 @@ const MessageLivestreamActions = (props) => {
       data-testid={'message-livestream-actions'}
       className={`str-chat__message-livestream-actions`}
     >
-      <span className={`str-chat__message-livestream-time`}>
-        {dateParser && dateParser(message.created_at).format('h:mmA')}
-      </span>
+      <MessageTimestamp
+        customClass="str-chat__message-livestream-time"
+        message={message}
+        tDateTimeParser={propTDateTimeParser}
+      />
       {channelConfig && channelConfig.reactions && (
         <span
           onClick={onReactionListClick}

--- a/src/components/Message/MessageSimple.js
+++ b/src/components/Message/MessageSimple.js
@@ -45,6 +45,7 @@ const MessageSimple = (props) => {
     editing,
     message,
     threadList,
+    formatDate,
     updateMessage: propUpdateMessage,
     handleAction: propHandleAction,
     handleOpenThread: propHandleOpenThread,
@@ -235,6 +236,7 @@ const MessageSimple = (props) => {
               <MessageTimestamp
                 customClass="str-chat__message-simple-timestamp"
                 tDateTimeParser={propTDateTimeParser}
+                formatDate={formatDate}
                 message={message}
                 calendar
               />

--- a/src/components/Message/MessageSimple.js
+++ b/src/components/Message/MessageSimple.js
@@ -30,6 +30,7 @@ import {
   messageHasAttachments,
 } from './utils';
 import { DeliveredCheckIcon } from './icons';
+import MessageTimestamp from './MessageTimestamp';
 
 /**
  * MessageSimple - Render component, should be used together with the Message component
@@ -55,7 +56,6 @@ const MessageSimple = (props) => {
   } = props;
   const { updateMessage: channelUpdateMessage } = useContext(ChannelContext);
   const updateMessage = propUpdateMessage || channelUpdateMessage;
-  const { tDateTimeParser } = useContext(TranslationContext);
   const { isMyMessage } = useUserRole(message);
   const handleOpenThread = useOpenThreadHandler(message);
   const handleReaction = useReactionHandler(message);
@@ -76,12 +76,6 @@ const MessageSimple = (props) => {
     MessageDeleted = DefaultMessageDeleted,
   } = props;
 
-  const dateTimeParser = propTDateTimeParser || tDateTimeParser;
-  const when =
-    dateTimeParser &&
-    message &&
-    dateTimeParser(message.created_at).calendar &&
-    dateTimeParser(message.created_at).calendar();
   const hasReactions = messageHasReactions(message);
   const hasAttachment = messageHasAttachments(message);
 
@@ -238,7 +232,12 @@ const MessageSimple = (props) => {
                   {message.user.name || message.user.id}
                 </span>
               ) : null}
-              <span className="str-chat__message-simple-timestamp">{when}</span>
+              <MessageTimestamp
+                customClass="str-chat__message-simple-timestamp"
+                tDateTimeParser={propTDateTimeParser}
+                message={message}
+                calendar
+              />
             </div>
           </div>
         </div>

--- a/src/components/Message/MessageTeam.js
+++ b/src/components/Message/MessageTeam.js
@@ -40,6 +40,7 @@ import {
   ErrorIcon,
   DeliveredCheckIcon,
 } from './icons';
+import MessageTimestamp from './MessageTimestamp';
 
 /**
  * MessageTeam - Render component, should be used together with the Message component
@@ -73,7 +74,6 @@ const MessageTeam = (props) => {
     onUserClick: propOnUserClick,
     onUserHover: propOnUserHover,
     t: propT,
-    tDateTimeParser: propTDateTimeParser,
   } = props;
 
   /**
@@ -83,11 +83,8 @@ const MessageTeam = (props) => {
     ChannelContext,
   );
   const channelConfig = propChannelConfig || channel?.getConfig();
-  const { t: contextT, tDateTimeParser: contextTDateTimeParser } = useContext(
-    TranslationContext,
-  );
+  const { t: contextT } = useContext(TranslationContext);
   const t = propT || contextT;
-  const tDateTimeParser = propTDateTimeParser || contextTDateTimeParser;
   const groupStyles = props.groupStyles || ['single'];
   const reactionSelectorRef = useRef(null);
   const messageWrapperRef = useRef(null);
@@ -186,13 +183,10 @@ const MessageTeam = (props) => {
               style={{ width: 40, marginRight: 0 }}
             />
           )}
-
-          <time dateTime={message?.created_at} title={message?.created_at}>
-            {message &&
-              tDateTimeParser &&
-              Boolean(Date.parse(message.created_at)) &&
-              tDateTimeParser(message.created_at).format('h:mmA')}
-          </time>
+          <MessageTimestamp
+            message={message}
+            tDateTimeParser={props.tDateTimeParser}
+          />
         </div>
         <div className="str-chat__message-team-group">
           {message &&

--- a/src/components/Message/MessageTeam.js
+++ b/src/components/Message/MessageTeam.js
@@ -56,6 +56,7 @@ const MessageTeam = (props) => {
   const {
     message,
     threadList,
+    formatDate,
     initialMessage,
     unsafeHTML,
     getMessageActions,
@@ -186,6 +187,7 @@ const MessageTeam = (props) => {
           <MessageTimestamp
             message={message}
             tDateTimeParser={props.tDateTimeParser}
+            formatDate={formatDate}
           />
         </div>
         <div className="str-chat__message-team-group">

--- a/src/components/Message/MessageTimestamp.js
+++ b/src/components/Message/MessageTimestamp.js
@@ -1,0 +1,46 @@
+// @ts-check
+import React, { useContext } from 'react';
+import { TranslationContext } from '../../context';
+
+export const defaultTimestampFormat = 'h:mmA';
+
+/**
+ * @typedef { import('types').MessageTimestampProps } Props
+ * @type { React.FC<Props> }
+ */
+const MessageTimestamp = (props) => {
+  const {
+    customClass = '',
+    tDateTimeParser: propTDatetimeParser,
+    format = defaultTimestampFormat,
+    calendar = false,
+    message,
+  } = props;
+  const { tDateTimeParser: contextTDateTimeParser } = useContext(
+    TranslationContext,
+  );
+  const tDateTimeParser = propTDatetimeParser || contextTDateTimeParser;
+
+  if (!message || !tDateTimeParser || !Date.parse(message.created_at)) {
+    return null;
+  }
+  const parsedTime = tDateTimeParser(message.created_at);
+
+  if (calendar && typeof parsedTime.calendar !== 'function') {
+    return null;
+  }
+
+  const when = calendar ? parsedTime.calendar() : parsedTime.format(format);
+
+  return (
+    <time
+      className={customClass}
+      dateTime={message?.created_at}
+      title={message?.created_at}
+    >
+      {when}
+    </time>
+  );
+};
+
+export default React.memo(MessageTimestamp);

--- a/src/components/Message/MessageTimestamp.js
+++ b/src/components/Message/MessageTimestamp.js
@@ -1,36 +1,81 @@
 // @ts-check
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { TranslationContext } from '../../context';
 
 export const defaultTimestampFormat = 'h:mmA';
+export const notValidDateWarning =
+  'MessageTimestamp was called without a message, or message has invalid created_at date.';
+export const noParsingFunctionWarning =
+  'MessageTimestamp was called but there is no datetime parsing function available';
+/**
+ * @type { (
+ *   messageCreatedAt?: string,
+ *   formatDate?: import('types').MessageTimestampProps['formatDate'],
+ *   calendar?: boolean,
+ *   tDateTimeParser?: import('types').MessageTimestampProps['tDateTimeParser'],
+ *   format?: string,
+ * ) => string | null }
+ */
+function getDateString(
+  messageCreatedAt,
+  formatDate,
+  calendar,
+  tDateTimeParser,
+  format,
+) {
+  if (!messageCreatedAt || !Date.parse(messageCreatedAt)) {
+    console.warn(notValidDateWarning);
+    return null;
+  }
 
+  if (typeof formatDate === 'function') {
+    return formatDate(new Date(messageCreatedAt));
+  }
+
+  if (!tDateTimeParser) {
+    console.warn(noParsingFunctionWarning);
+    return null;
+  }
+
+  const parsedTime = tDateTimeParser(messageCreatedAt);
+  if (calendar && typeof parsedTime.calendar !== 'function') {
+    return null;
+  }
+
+  return calendar ? parsedTime.calendar() : parsedTime.format(format);
+}
 /**
  * @typedef { import('types').MessageTimestampProps } Props
  * @type { React.FC<Props> }
  */
 const MessageTimestamp = (props) => {
   const {
-    customClass = '',
+    message,
+    formatDate,
     tDateTimeParser: propTDatetimeParser,
+    customClass = '',
     format = defaultTimestampFormat,
     calendar = false,
-    message,
   } = props;
   const { tDateTimeParser: contextTDateTimeParser } = useContext(
     TranslationContext,
   );
   const tDateTimeParser = propTDatetimeParser || contextTDateTimeParser;
+  const when = useMemo(
+    () =>
+      getDateString(
+        message?.created_at,
+        formatDate,
+        calendar,
+        tDateTimeParser,
+        format,
+      ),
+    [formatDate, calendar, tDateTimeParser, format, message?.created_at],
+  );
 
-  if (!message || !tDateTimeParser || !Date.parse(message.created_at)) {
+  if (!when) {
     return null;
   }
-  const parsedTime = tDateTimeParser(message.created_at);
-
-  if (calendar && typeof parsedTime.calendar !== 'function') {
-    return null;
-  }
-
-  const when = calendar ? parsedTime.calendar() : parsedTime.format(format);
 
   return (
     <time

--- a/src/components/Message/__tests__/MessageTimestamp.test.js
+++ b/src/components/Message/__tests__/MessageTimestamp.test.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import renderer from 'react-test-renderer';
+import { cleanup, render } from '@testing-library/react';
+import { generateMessage } from 'mock-builders';
+import MessageTimestamp, { defaultTimestampFormat } from '../MessageTimestamp';
+import { TranslationContext } from '../../../context';
+
+const messageMock = generateMessage({
+  created_at: '2019-04-03T14:42:47.087869Z',
+});
+describe('<MessageTimestamp />', () => {
+  afterEach(cleanup);
+
+  it('should render correctly', () => {
+    const tree = renderer
+      .create(<MessageTimestamp message={messageMock} />)
+      .toJSON();
+    expect(tree).toMatchInlineSnapshot(`
+      <time
+        className=""
+        dateTime="2019-04-03T14:42:47.087869Z"
+        title="2019-04-03T14:42:47.087869Z"
+      >
+        2:42PM
+      </time>
+    `);
+  });
+
+  it('should not render if no message is available', () => {
+    const { container } = render(<MessageTimestamp message={undefined} />);
+    expect(container.children).toHaveLength(0);
+  });
+
+  it('should not render if message created_at is not a valid date', () => {
+    const message = generateMessage({ created_at: 'I am not a date' });
+    const { container } = render(<MessageTimestamp message={message} />);
+    expect(container.children).toHaveLength(0);
+  });
+
+  it('should render message created_at date with custom datetime parser if one is set', () => {
+    const format = jest.fn();
+    const customDateTimeParser = jest.fn(() => ({ format }));
+    render(
+      <MessageTimestamp
+        message={messageMock}
+        tDateTimeParser={customDateTimeParser}
+      />,
+    );
+    expect(format).toHaveBeenCalledWith(defaultTimestampFormat);
+  });
+
+  it('should render message with custom datetime format if one is set', () => {
+    const format = 'LT';
+    const { queryByText } = render(
+      <MessageTimestamp message={messageMock} format={format} />,
+    );
+    expect(queryByText('2:42 PM')).toBeInTheDocument();
+  });
+
+  it('should render in calendar format if calendar is set to true', () => {
+    const calendarDateTimeParser = { calendar: jest.fn() };
+    render(
+      <TranslationContext.Provider
+        value={{
+          tDateTimeParser: () => calendarDateTimeParser,
+        }}
+      >
+        <MessageTimestamp message={messageMock} calendar />
+      </TranslationContext.Provider>,
+    );
+    expect(calendarDateTimeParser.calendar).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not render if called in calendar mode but no calendar function is available from the datetime parser', () => {
+    const { container } = render(
+      <TranslationContext.Provider
+        value={{
+          tDateTimeParser: () => ({ calendar: undefined }),
+        }}
+      >
+        <MessageTimestamp message={messageMock} calendar />
+      </TranslationContext.Provider>,
+    );
+    expect(container.children).toHaveLength(0);
+  });
+
+  it('should render message with a custom css class when one is set', () => {
+    const customCssClass = 'custom-css-class';
+    const tree = renderer
+      .create(
+        <MessageTimestamp customClass={customCssClass} message={messageMock} />,
+      )
+      .toJSON();
+    expect(tree).toMatchInlineSnapshot(`
+      <time
+        className="custom-css-class"
+        dateTime="2019-04-03T14:42:47.087869Z"
+        title="2019-04-03T14:42:47.087869Z"
+      >
+        2:42PM
+      </time>
+    `);
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1140,6 +1140,8 @@ export interface MessageTimestampProps {
   calendar?: boolean;
   format?: string;
   tDateTimeParser?(datetime: string | number): Dayjs.Dayjs;
+  /** Override the default formatting of the date. This is a function that has access to the original date object. Returns a string or Node  */
+  formatDate?(date: Date): string;
 }
 
 export interface MessageTextProps extends MessageSimpleProps {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -611,6 +611,8 @@ export interface MessageProps extends TranslationContextValue {
   getFlagMessageErrorNotification?(message: MessageResponse): string;
   getMuteUserSuccessNotification?(message: MessageResponse): string;
   getMuteUserErrorNotification?(message: MessageResponse): string;
+  /** Override the default formatting of the date. This is a function that has access to the original date object. Returns a string or Node  */
+  formatDate?(date: Date): string;
 }
 
 export type MessageComponentState = {
@@ -1105,6 +1107,7 @@ export interface MessageLivestreamActionProps {
   getMessageActions(): Array<string>;
   messageWrapperRef?: React.RefObject<HTMLElement>;
   setEditingState?(event?: React.BaseSyntheticEvent): void;
+  formatDate?(date: Date): string;
 }
 export const MessageLivestream: React.FC<MessageLivestreamProps>;
 export type MessageTeamState = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1134,6 +1134,14 @@ export class MessageTeam extends React.PureComponent<
 > {}
 
 export interface MessageSimpleProps extends MessageUIComponentProps {}
+export interface MessageTimestampProps {
+  customClass?: string;
+  message?: Client.MessageResponse;
+  calendar?: boolean;
+  format?: string;
+  tDateTimeParser?(datetime: string | number): Dayjs.Dayjs;
+}
+
 export interface MessageTextProps extends MessageSimpleProps {
   customOptionProps?: Partial<MessageOptionsProps>;
   customInnerClass?: string;


### PR DESCRIPTION
## Description of the pull request

This provides a way for overriding the Datetime information rendered by the message UI components.

Closes #128.

To-do:

- [x] - QA test