### PR TITLE
Only render <SimpleReactionList /> if there are reactions

### DIFF
--- a/src/components/Reactions/SimpleReactionsList.js
+++ b/src/components/Reactions/SimpleReactionsList.js
@@ -14,6 +14,10 @@ const SimpleReactionsList = ({
 }) => {
   const [tooltipReactionType, setTooltipReactionType] = useState(null);
 
+  if (!reactions || reactions.length === 0) {
+    return null;
+  }
+
   /** @param {string | null} type */
   const getUsersPerReactionType = (type) =>
     reactions

--- a/src/components/Reactions/__tests__/SimpleReactionsList.test.js
+++ b/src/components/Reactions/__tests__/SimpleReactionsList.test.js
@@ -48,6 +48,13 @@ const expectEmojiToHaveBeenRendered = (id) => {
 describe('SimpleReactionsList', () => {
   afterEach(jest.clearAllMocks);
 
+  it('should not render anything if there are no reactions', () => {
+    const { container } = renderComponent({
+      reaction_counts: {},
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('should render the total reaction count', () => {
     const { getByText } = renderComponent({
       reaction_counts: {


### PR DESCRIPTION
## Description of the pull request

This check was present on the class version of the component, so we probably dropped it accidentally when migrating it to a functional component.