### PR TITLE
CRS-293 Max attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pretty-bytes": "^5.4.1",
     "prop-types": "^15.7.2",
     "react-fast-compare": "^3.2.0",
-    "react-file-utils": "0.3.17",
+    "react-file-utils": "0.4.0",
     "react-images": "^1.1.7",
     "react-is": "^16.13.1",
     "react-markdown": "^4.3.1",

--- a/src/components/Channel/Channel.js
+++ b/src/components/Channel/Channel.js
@@ -35,6 +35,10 @@ const Channel = ({ EmptyPlaceholder = null, ...props }) => {
   return <ChannelInner {...props} channel={channel} key={channel.cid} />;
 };
 
+Channel.defaultProps = {
+  multipleUploads: true,
+};
+
 Channel.propTypes = {
   /** Which channel to connect to, will initialize the channel if it's not initialized yet */
   channel: PropTypes.instanceOf(StreamChannel),
@@ -96,7 +100,7 @@ Channel.propTypes = {
    * @param {User} user   Target [user object](https://getstream.io/chat/docs/#chat-doc-set-user) which is hovered
    */
   onMentionsHover: PropTypes.func,
-  /** Weather to allow multiple attachment uploads */
+  /** Whether to allow multiple attachment uploads */
   multipleUploads: PropTypes.bool,
   /** List of accepted file types */
   acceptedFiles: PropTypes.array,

--- a/src/components/MessageInput/MessageInputFlat.js
+++ b/src/components/MessageInput/MessageInputFlat.js
@@ -28,10 +28,8 @@ const MessageInputFlat = (props) => {
       <ImageDropzone
         accept={channelContext.acceptedFiles}
         multiple={channelContext.multipleUploads}
-        disabled={
-          channelContext.maxNumberOfFiles !== undefined &&
-          messageInput.numberOfUploads >= channelContext.maxNumberOfFiles
-        }
+        disabled={messageInput.maxFilesLeft === 0}
+        maxNumberOfFiles={messageInput.maxFilesLeft}
         handleFiles={messageInput.uploadNewFiles}
       >
         <div className="str-chat__input-flat-wrapper">
@@ -78,11 +76,7 @@ const MessageInputFlat = (props) => {
               <Tooltip>{t('Attach files')}</Tooltip>
               <FileUploadButton
                 multiple={channelContext.multipleUploads}
-                disabled={
-                  channelContext.maxNumberOfFiles !== undefined &&
-                  messageInput.numberOfUploads >=
-                    channelContext.maxNumberOfFiles
-                }
+                disabled={messageInput.maxFilesLeft === 0}
                 accepts={channelContext.acceptedFiles}
                 handleFiles={messageInput.uploadNewFiles}
               >

--- a/src/components/MessageInput/MessageInputFlat.js
+++ b/src/components/MessageInput/MessageInputFlat.js
@@ -73,7 +73,11 @@ const MessageInputFlat = (props) => {
               className="str-chat__fileupload-wrapper"
               data-testid="fileinput"
             >
-              <Tooltip>{t('Attach files')}</Tooltip>
+              <Tooltip>
+                {messageInput.maxFilesLeft
+                  ? t('Attach files')
+                  : t("You've reached the maximum number of files")}
+              </Tooltip>
               <FileUploadButton
                 multiple={channelContext.multipleUploads}
                 disabled={messageInput.maxFilesLeft === 0}

--- a/src/components/MessageInput/MessageInputLarge.js
+++ b/src/components/MessageInput/MessageInputLarge.js
@@ -100,7 +100,11 @@ const MessageInputLarge = (props) => {
               className="str-chat__fileupload-wrapper"
               data-testid="fileinput"
             >
-              <Tooltip>{t('Attach files')}</Tooltip>
+              <Tooltip>
+                {messageInput.maxFilesLeft
+                  ? t('Attach files')
+                  : t("You've reached the maximum number of files")}
+              </Tooltip>
               <FileUploadButton
                 multiple={channelContext.multipleUploads}
                 disabled={messageInput.maxFilesLeft === 0}

--- a/src/components/MessageInput/MessageInputLarge.js
+++ b/src/components/MessageInput/MessageInputLarge.js
@@ -56,10 +56,8 @@ const MessageInputLarge = (props) => {
       <ImageDropzone
         accept={channelContext.acceptedFiles}
         multiple={channelContext.multipleUploads}
-        disabled={
-          channelContext.maxNumberOfFiles !== undefined &&
-          messageInput.numberOfUploads >= channelContext.maxNumberOfFiles
-        }
+        disabled={messageInput.maxFilesLeft === 0}
+        maxNumberOfFiles={messageInput.maxFilesLeft}
         handleFiles={messageInput.uploadNewFiles}
       >
         <div className="str-chat__input">
@@ -105,11 +103,7 @@ const MessageInputLarge = (props) => {
               <Tooltip>{t('Attach files')}</Tooltip>
               <FileUploadButton
                 multiple={channelContext.multipleUploads}
-                disabled={
-                  channelContext.maxNumberOfFiles !== undefined &&
-                  messageInput.numberOfUploads >=
-                    channelContext.maxNumberOfFiles
-                }
+                disabled={messageInput.maxFilesLeft === 0}
                 accepts={channelContext.acceptedFiles}
                 handleFiles={messageInput.uploadNewFiles}
               >

--- a/src/components/MessageInput/MessageInputSmall.js
+++ b/src/components/MessageInput/MessageInputSmall.js
@@ -23,10 +23,8 @@ const MessageInputSmall = (props) => {
       <ImageDropzone
         accept={channelContext.acceptedFiles}
         multiple={channelContext.multipleUploads}
-        disabled={
-          channelContext.maxNumberOfFiles !== undefined &&
-          messageInput.numberOfUploads >= channelContext.maxNumberOfFiles
-        }
+        disabled={messageInput.maxFilesLeft === 0}
+        maxNumberOfFiles={messageInput.maxFilesLeft}
         handleFiles={messageInput.uploadNewFiles}
       >
         <div
@@ -80,11 +78,7 @@ const MessageInputSmall = (props) => {
               <Tooltip>{t('Attach files')}</Tooltip>
               <FileUploadButton
                 multiple={channelContext.multipleUploads}
-                disabled={
-                  channelContext.maxNumberOfFiles !== undefined &&
-                  messageInput.numberOfUploads >=
-                    channelContext.maxNumberOfFiles
-                }
+                disabled={messageInput.maxFilesLeft === 0}
                 accepts={channelContext.acceptedFiles}
                 handleFiles={messageInput.uploadNewFiles}
               >

--- a/src/components/MessageInput/MessageInputSmall.js
+++ b/src/components/MessageInput/MessageInputSmall.js
@@ -75,7 +75,11 @@ const MessageInputSmall = (props) => {
               className="str-chat__fileupload-wrapper"
               data-testid="fileinput"
             >
-              <Tooltip>{t('Attach files')}</Tooltip>
+              <Tooltip>
+                {messageInput.maxFilesLeft
+                  ? t('Attach files')
+                  : t("You've reached the maximum number of files")}
+              </Tooltip>
               <FileUploadButton
                 multiple={channelContext.multipleUploads}
                 disabled={messageInput.maxFilesLeft === 0}

--- a/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -1,5 +1,11 @@
 import React, { useContext, useEffect } from 'react';
-import { cleanup, render, waitFor, fireEvent } from '@testing-library/react';
+import {
+  cleanup,
+  render,
+  waitFor,
+  fireEvent,
+  act,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MessageInput from '../MessageInput';
 import MessageInputLarge from '../MessageInputLarge';
@@ -43,8 +49,8 @@ const ActiveChannelSetter = ({ activeChannel }) => {
   { InputComponent: MessageInputSmall, name: 'MessageInputSmall' },
   { InputComponent: MessageInputFlat, name: 'MessageInputFlat' },
   { InputComponent: EditMessageForm, name: 'EditMessageForm' },
-].forEach(({ InputComponent, name }) => {
-  const renderComponent = (props = {}) => {
+].forEach(({ InputComponent, name: componentName }) => {
+  const renderComponent = (props = {}, channelProps = {}) => {
     // MessageInput components rely on ChannelContext.
     // ChannelContext is created by Channel component,
     // Which relies on ChatContext, created by Chat component.
@@ -54,6 +60,7 @@ const ActiveChannelSetter = ({ activeChannel }) => {
         <Channel
           doSendMessageRequest={submitMock}
           doUpdateMessageRequest={editMock}
+          {...channelProps}
         >
           <MessageInput Input={InputComponent} {...props} />
         </Channel>
@@ -69,7 +76,7 @@ const ActiveChannelSetter = ({ activeChannel }) => {
     return { submit, ...renderResult };
   };
 
-  describe(`${name}`, () => {
+  describe(`${componentName}`, () => {
     const inputPlaceholder = 'Type your message';
     const username = 'username';
     const userid = 'userid';
@@ -96,6 +103,7 @@ const ActiveChannelSetter = ({ activeChannel }) => {
       fireEvent.drop(formElement, {
         dataTransfer: {
           files: [file],
+          types: ['Files'],
         },
       });
     }
@@ -105,8 +113,8 @@ const ActiveChannelSetter = ({ activeChannel }) => {
 
     const getImage = () =>
       new File(['content'], filename, { type: 'image/png' });
-    const getFile = () =>
-      new File(['content'], filename, { type: 'text/plain' });
+    const getFile = (name = filename) =>
+      new File(['content'], name, { type: 'text/plain' });
 
     const mockUploadApi = () =>
       jest.fn().mockImplementation(() =>
@@ -323,6 +331,76 @@ const ActiveChannelSetter = ({ activeChannel }) => {
             file,
             expect.any(Object),
           ),
+        );
+      });
+
+      it('should not set multiple attribute on the file input if mutltipleUploads is false', async () => {
+        const { findByTestId } = renderComponent(
+          {},
+          {
+            multipleUploads: false,
+          },
+        );
+        const input = (await findByTestId('fileinput')).querySelector('input');
+        expect(input).not.toHaveAttribute('multiple');
+      });
+
+      it('should set multiple attribute on the file input if mutltipleUploads is true', async () => {
+        const { findByTestId } = renderComponent(
+          {},
+          {
+            multipleUploads: true,
+          },
+        );
+        const input = (await findByTestId('fileinput')).querySelector('input');
+        expect(input).toHaveAttribute('multiple');
+      });
+
+      const filename1 = '1.txt';
+      const filename2 = '2.txt';
+      it('should only allow dropping maxNumberOfFiles files into the dropzone', async () => {
+        const { findByPlaceholderText, queryByText } = renderComponent(
+          {
+            doFileUploadRequest: mockUploadApi(),
+          },
+          {
+            maxNumberOfFiles: 1,
+          },
+        );
+
+        const formElement = await findByPlaceholderText(inputPlaceholder);
+
+        const file = getFile(filename1);
+        dropFile(file, formElement);
+        await waitFor(() => expect(queryByText(filename1)).toBeInTheDocument());
+
+        const file2 = getFile(filename2);
+        act(() => dropFile(file2, formElement));
+        await waitFor(() =>
+          expect(queryByText(filename2)).not.toBeInTheDocument(),
+        );
+      });
+
+      it('should only allow uploading 1 file if multipleUploads is false', async () => {
+        const { findByPlaceholderText, queryByText } = renderComponent(
+          {
+            doFileUploadRequest: mockUploadApi(),
+          },
+          {
+            multipleUploads: false,
+          },
+        );
+
+        const formElement = await findByPlaceholderText(inputPlaceholder);
+
+        const file = getFile(filename1);
+        dropFile(file, formElement);
+        await waitFor(() => expect(queryByText(filename1)).toBeInTheDocument());
+
+        const file2 = getFile(filename2);
+        act(() => dropFile(file2, formElement));
+        await waitFor(() =>
+          expect(queryByText(filename2)).not.toBeInTheDocument(),
         );
       });
 

--- a/src/components/MessageInput/hooks/messageInput.js
+++ b/src/components/MessageInput/hooks/messageInput.js
@@ -134,6 +134,7 @@ function messageInputReducer(state, action) {
       };
     case 'setImageUpload': {
       const imageAlreadyExists = state.imageUploads[action.id];
+      if (!imageAlreadyExists && !action.file) return state;
       const imageOrder = imageAlreadyExists
         ? state.imageOrder
         : state.imageOrder.concat(action.id);
@@ -152,6 +153,7 @@ function messageInputReducer(state, action) {
     }
     case 'setFileUpload': {
       const fileAlreadyExists = state.fileUploads[action.id];
+      if (!fileAlreadyExists && !action.file) return state;
       const fileOrder = fileAlreadyExists
         ? state.fileOrder
         : state.fileOrder.concat(action.id);
@@ -560,7 +562,6 @@ export default function useMessageInputState(props) {
         }
         return;
       }
-      if (!imageUploads[id]) return; // removed before done
       dispatch({
         type: 'setImageUpload',
         id,

--- a/src/components/MessageInput/hooks/messageInput.js
+++ b/src/components/MessageInput/hooks/messageInput.js
@@ -1,5 +1,12 @@
 // @ts-check
-import { useReducer, useEffect, useContext, useRef, useCallback } from 'react';
+import {
+  useReducer,
+  useEffect,
+  useContext,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
 import Immutable from 'seamless-immutable';
 import { logChatPromiseExecution } from 'stream-chat';
 import {
@@ -669,11 +676,16 @@ export default function useMessageInputState(props) {
   );
 
   // Number of files that the user can still add. Should never be more than the amount allowed by the API.
-  const maxFilesLeft =
-    Math.min(
-      channelContext.maxNumberOfFiles || apiMaxNumberOfFiles,
-      apiMaxNumberOfFiles,
-    ) - numberOfUploads;
+  // If multipleUploads is false, we only want to allow a single upload.
+  const maxFilesAllowed = useMemo(() => {
+    if (!channelContext.multipleUploads) return 1;
+    if (channelContext.maxNumberOfFiles === undefined) {
+      return apiMaxNumberOfFiles;
+    }
+    return channelContext.maxNumberOfFiles;
+  }, [channelContext.maxNumberOfFiles, channelContext.multipleUploads]);
+
+  const maxFilesLeft = maxFilesAllowed - numberOfUploads;
 
   return {
     ...state,

--- a/src/components/MessageInput/hooks/messageInput.js
+++ b/src/components/MessageInput/hooks/messageInput.js
@@ -33,6 +33,8 @@ const emptyFileUploads = {};
 /** @type {{ [id: string]: import('types').ImageUpload }} */
 const emptyImageUploads = {};
 
+const apiMaxNumberOfFiles = 10;
+
 /**
  * Initializes the state. Empty if the message prop is falsy.
  * @param {import("stream-chat").MessageResponse | undefined} message
@@ -666,8 +668,16 @@ export default function useMessageInputState(props) {
     [uploadNewFiles, insertText],
   );
 
+  // Number of files that the user can still add. Should never be more than the amount allowed by the API.
+  const maxFilesLeft =
+    Math.min(
+      channelContext.maxNumberOfFiles || apiMaxNumberOfFiles,
+      apiMaxNumberOfFiles,
+    ) - numberOfUploads;
+
   return {
     ...state,
+    maxFilesLeft,
     // refs
     textareaRef,
     emojiPickerRef,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -35,6 +35,7 @@
   "Type your message": "Type your message",
   "Unmute": "Unmute",
   "You have no channels currently": "You have no channels currently",
+  "You've reached the maximum number of files": "You've reached the maximum number of files",
   "live": "live",
   "this content could not be displayed": "this content could not be displayed",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -35,7 +35,7 @@
   "Type your message": "Saisissez votre message",
   "Unmute": "Désactiver muet",
   "You have no channels currently": "Vous n'avez actuellement aucun canal",
-  "You've reached the maximum number of files": "",
+  "You've reached the maximum number of files": "Vous avez atteint le nombre maximum de fichiers",
   "live": "en direct",
   "this content could not be displayed": "ce contenu n'a pu être affiché",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} et {{ lastUser }} sont en train d'écrire...",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -35,6 +35,7 @@
   "Type your message": "Saisissez votre message",
   "Unmute": "Désactiver muet",
   "You have no channels currently": "Vous n'avez actuellement aucun canal",
+  "You've reached the maximum number of files": "",
   "live": "en direct",
   "this content could not be displayed": "ce contenu n'a pu être affiché",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} et {{ lastUser }} sont en train d'écrire...",

--- a/src/i18n/hi.json
+++ b/src/i18n/hi.json
@@ -35,7 +35,7 @@
   "Type your message": "अपना मैसेज लिखे",
   "Unmute": "अनम्यूट",
   "You have no channels currently": "आपके पास कोई चैनल नहीं है",
-  "You've reached the maximum number of files": "",
+  "You've reached the maximum number of files": "आप अधिकतम फ़ाइलों तक पहुँच गए हैं",
   "live": "लाइव",
   "this content could not be displayed": "यह कॉन्टेंट लोड नहीं हो पाया",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} और {{ lastUser }} टाइप कर रहे हैं...",

--- a/src/i18n/hi.json
+++ b/src/i18n/hi.json
@@ -35,6 +35,7 @@
   "Type your message": "अपना मैसेज लिखे",
   "Unmute": "अनम्यूट",
   "You have no channels currently": "आपके पास कोई चैनल नहीं है",
+  "You've reached the maximum number of files": "",
   "live": "लाइव",
   "this content could not be displayed": "यह कॉन्टेंट लोड नहीं हो पाया",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} और {{ lastUser }} टाइप कर रहे हैं...",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -35,7 +35,7 @@
   "Type your message": "Scrivi il tuo messaggio",
   "Unmute": "Riattiva le notifiche",
   "You have no channels currently": "Al momento non sono presenti canali",
-  "You've reached the maximum number of files": "",
+  "You've reached the maximum number of files": "Hai raggiunto il numero massimo di file",
   "live": "live",
   "this content could not be displayed": "questo contenuto non puó essere mostrato",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} e {{ lastUser }} stanno scrivendo...",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -35,6 +35,7 @@
   "Type your message": "Scrivi il tuo messaggio",
   "Unmute": "Riattiva le notifiche",
   "You have no channels currently": "Al momento non sono presenti canali",
+  "You've reached the maximum number of files": "",
   "live": "live",
   "this content could not be displayed": "questo contenuto non puó essere mostrato",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} e {{ lastUser }} stanno scrivendo...",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -35,7 +35,7 @@
   "Type your message": "Type je bericht",
   "Unmute": "Unmute",
   "You have no channels currently": "Er zijn geen chats beschikbaar",
-  "You've reached the maximum number of files": "",
+  "You've reached the maximum number of files": "Je hebt het maximale aantal bestanden bereikt",
   "live": "live",
   "this content could not be displayed": "Deze inhoud kan niet weergegeven worden",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} en {{ lastUser }} zijn aan het typen ...",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -35,6 +35,7 @@
   "Type your message": "Type je bericht",
   "Unmute": "Unmute",
   "You have no channels currently": "Er zijn geen chats beschikbaar",
+  "You've reached the maximum number of files": "",
   "live": "live",
   "this content could not be displayed": "Deze inhoud kan niet weergegeven worden",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} en {{ lastUser }} zijn aan het typen ...",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -35,7 +35,7 @@
   "Type your message": "Ваше сообщение",
   "Unmute": "Включить уведомления",
   "You have no channels currently": "У вас нет каналов в данный момент",
-  "You've reached the maximum number of files": "",
+  "You've reached the maximum number of files": "Вы достигли максимального количества файлов",
   "live": "В прямом эфире",
   "this content could not be displayed": "Этот контент не может быть отображен в данный момент",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} и {{ lastUser }} пишут...",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -35,6 +35,7 @@
   "Type your message": "Ваше сообщение",
   "Unmute": "Включить уведомления",
   "You have no channels currently": "У вас нет каналов в данный момент",
+  "You've reached the maximum number of files": "",
   "live": "В прямом эфире",
   "this content could not be displayed": "Этот контент не может быть отображен в данный момент",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} и {{ lastUser }} пишут...",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -35,6 +35,7 @@
   "Type your message": "Mesajınızı yazın",
   "Unmute": "Sesini aç",
   "You have no channels currently": "Henüz kanalınız yok",
+  "You've reached the maximum number of files": "",
   "live": "canlı",
   "this content could not be displayed": "bu içerik gösterilemiyor",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} ve {{ lastUser }} yazıyor...",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -35,7 +35,7 @@
   "Type your message": "Mesajınızı yazın",
   "Unmute": "Sesini aç",
   "You have no channels currently": "Henüz kanalınız yok",
-  "You've reached the maximum number of files": "",
+  "You've reached the maximum number of files": "Maksimum dosya sayısına ulaştınız",
   "live": "canlı",
   "this content could not be displayed": "bu içerik gösterilemiyor",
   "{{ commaSeparatedUsers }} and {{ lastUser }} are typing...": "{{ commaSeparatedUsers }} ve {{ lastUser }} yazıyor...",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2465,12 +2465,10 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-attr-accept@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-1.1.3.tgz#48230c79f93790ef2775fcec4f0db0f5db41ca52"
-  integrity sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==
-  dependencies:
-    core-js "^2.5.0"
+attr-accept@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
 
 autoprefixer@^10.0.1:
   version "10.0.1"
@@ -3620,11 +3618,6 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
-core-js@^2.5.0:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
-  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
 core-js@^3.2.1, core-js@^3.6.4:
   version "3.6.5"
@@ -5129,6 +5122,13 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+file-selector@^0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.1.13.tgz#5efd977ca2bca1700992df1b10e254f4e73d2df4"
+  integrity sha512-T2efCBY6Ps+jLIWdNQsmzt/UnAjKOEAlsZVdnQztg/BtAZGNL4uX1Jet9cMM8gify/x4CSudreji2HssGBNVIQ==
+  dependencies:
+    tslib "^2.0.1"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -9631,13 +9631,14 @@ react-dom@^16.2.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dropzone@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-5.1.1.tgz#b05613ea22f1ab71aa1f7cf5367df7b19468a2f3"
-  integrity sha512-C9kXI3D95rVXbLLg9DvzCnmjplKwpfj/2F/MwvGVM05kDwWMzKVKZnmgZHZUebmiVj4mFOmBs2ObLiKvAxunGw==
+react-dropzone@11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.2.0.tgz#4e54fa3479e6b6bb93f67914e4a27f1260807fdb"
+  integrity sha512-S/qaXQHCCg7MVlcrhqd05MLC6DupITLUB0CFn3iCLs6OTjzxdGDF1WTktTe5Jyq8jZdxYfMHNUZOHL0mg+K0Dw==
   dependencies:
-    attr-accept "^1.1.3"
-    prop-types "^15.6.2"
+    attr-accept "^2.0.0"
+    file-selector "^0.1.12"
+    prop-types "^15.7.2"
 
 react-error-overlay@^6.0.3:
   version "6.0.7"
@@ -9660,16 +9661,16 @@ react-file-icon@^0.2.0:
     react-dom "^16.2.0"
     tinycolor2 "^1.4.1"
 
-react-file-utils@0.3.17:
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/react-file-utils/-/react-file-utils-0.3.17.tgz#99e9a0583d7e0c362565068ffa09a7ea112754ba"
-  integrity sha512-8EFgRZJkIC8w48SLOtsJY3RHkUFtBebl9iyOM6B5qcz74cn7rvWxavXDUc22P7Ibs4xuNgYEfBt0OMdOLjKP7A==
+react-file-utils@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/react-file-utils/-/react-file-utils-0.4.0.tgz#dc18537a94c227cf71648eae9a648f9f719b09a5"
+  integrity sha512-CvjThefxttg1MyxUi0pg2WNA3hHwuEvfrq+3FNRSfSVyijRRkgEjJNhOKR4OzcDHnUCxQjfskPaZWrhHsnkOaA==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.13"
     "@fortawesome/free-regular-svg-icons" "^5.7.0"
     "@fortawesome/react-fontawesome" "^0.1.4"
     blueimp-load-image "^5.13.0"
-    react-dropzone "5.1.1"
+    react-dropzone "11.2.0"
     react-file-icon "^0.2.0"
 
 react-focus-lock@^2.3.1:


### PR DESCRIPTION
# Submit a pull request

## CLA

## Description of the pull request

Draft: relies on https://github.com/GetStream/react-file-utils/pull/22. Relates to https://github.com/GetStream/stream-chat-react/issues/565

This PR uses `channelContext.maxNumberOfFiles` to prevent the user from uploading too many files. It does so by doing two things:
 - setting the `maxNumberOfFiles` prop in `ImageDropzone` (part of `react-file-utils`)
 - disabling the file upload button if needed

Other fixes:
 - Removing while uploading no longer throws
 - if `channelContext.multipleUploads` is set to false, you can now only upload a single file (and its default value is now `true`)

To do:
 - Get translations for tooltip ("You've reached the maximum number of files")
 - UI indication in ImageDropzone, when attempting to drop more than the allowed number of files (in `react-file-utils`)