### PR TITLE
CRS-320 Add own reactions

### DIFF
--- a/src/components/Message/MessageCommerce.js
+++ b/src/components/Message/MessageCommerce.js
@@ -135,6 +135,7 @@ const MessageCommerce = (props) => {
                 <ReactionsList
                   reactions={message.latest_reactions}
                   reaction_counts={message.reaction_counts || undefined}
+                  own_reactions={message.own_reactions}
                   onClick={onReactionListClick}
                 />
               )}
@@ -145,6 +146,7 @@ const MessageCommerce = (props) => {
                   detailedView
                   reaction_counts={message.reaction_counts || undefined}
                   latest_reactions={message.latest_reactions}
+                  own_reactions={message.own_reactions}
                   ref={reactionSelectorRef}
                 />
               )}

--- a/src/components/Message/MessageLivestream.js
+++ b/src/components/Message/MessageLivestream.js
@@ -174,6 +174,7 @@ const MessageLivestreamComponent = (props) => {
             detailedView
             latest_reactions={message?.latest_reactions}
             reaction_counts={message?.reaction_counts || undefined}
+            own_reactions={message.own_reactions}
             ref={reactionSelectorRef}
           />
         )}
@@ -276,6 +277,7 @@ const MessageLivestreamComponent = (props) => {
               <ReactionsList
                 reaction_counts={message.reaction_counts || undefined}
                 reactions={message.latest_reactions}
+                own_reactions={message.own_reactions}
                 handleReaction={propHandleReaction || handleReaction}
               />
             )}

--- a/src/components/Message/MessageSimple.js
+++ b/src/components/Message/MessageSimple.js
@@ -167,6 +167,7 @@ const MessageSimple = (props) => {
                     <ReactionsList
                       reactions={message.latest_reactions}
                       reaction_counts={message.reaction_counts || undefined}
+                      own_reactions={message.own_reactions}
                       onClick={onReactionListClick}
                       reverse={true}
                     />
@@ -177,6 +178,7 @@ const MessageSimple = (props) => {
                     detailedView
                     reaction_counts={message.reaction_counts || undefined}
                     latest_reactions={message.latest_reactions}
+                    own_reactions={message.own_reactions}
                     ref={reactionSelectorRef}
                   />
                 )}

--- a/src/components/Message/MessageTeam.js
+++ b/src/components/Message/MessageTeam.js
@@ -225,6 +225,7 @@ const MessageTeam = (props) => {
                       handleReaction={propHandleReaction || handleReaction}
                       latest_reactions={message.latest_reactions}
                       reaction_counts={message.reaction_counts || undefined}
+                      own_reactions={message.own_reactions}
                       detailedView={true}
                       ref={reactionSelectorRef}
                     />
@@ -315,6 +316,7 @@ const MessageTeam = (props) => {
                   reaction_counts={message.reaction_counts || undefined}
                   handleReaction={propHandleReaction || handleReaction}
                   reactions={message.latest_reactions}
+                  own_reactions={message.own_reactions}
                 />
               )}
             {message?.status === 'failed' && (
@@ -358,6 +360,7 @@ const MessageTeam = (props) => {
                 reaction_counts={message.reaction_counts || undefined}
                 handleReaction={propHandleReaction || handleReaction}
                 reactions={message.latest_reactions}
+                own_reactions={message.own_reactions}
               />
             )}
           {!threadList && message && (

--- a/src/components/Message/MessageText.js
+++ b/src/components/Message/MessageText.js
@@ -104,6 +104,7 @@ const MessageTextComponent = (props) => {
           <ReactionsList
             reactions={message.latest_reactions}
             reaction_counts={message.reaction_counts || undefined}
+            own_reactions={message.own_reactions}
             onClick={onReactionListClick}
             reverse={true}
           />
@@ -114,6 +115,7 @@ const MessageTextComponent = (props) => {
             detailedView
             reaction_counts={message.reaction_counts || undefined}
             latest_reactions={message.latest_reactions}
+            own_reactions={message.own_reactions}
             ref={reactionSelectorRef}
           />
         )}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -949,6 +949,7 @@ export interface ReactionSelectorProps {
   reaction_counts?: {
     [reaction_type: string]: number;
   };
+  own_reactions?: StreamChatReactMessageResponse['own_reactions'];
   /** Enable the avatar display */
   detailedView?: boolean;
   /** Provide a list of reaction options [{name: 'angry', emoji: 'angry'}] */
@@ -992,6 +993,7 @@ export interface ReactionsListProps {
   reaction_counts?: {
     [reaction_type: string]: number;
   };
+  own_reactions?: StreamChatReactMessageResponse['own_reactions'];
   /** Provide a list of reaction options [{name: 'angry', emoji: 'angry'}] */
   reactionOptions?: MinimalEmojiInterface[];
   onClick?(): void;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Pass `message.own_reactions` into reactions components so custom implementations can use it to show the current user's reaction.
