### PR TITLE
fix: prevent firing load more when user is offline

### DIFF
--- a/src/components/Channel/Channel.js
+++ b/src/components/Channel/Channel.js
@@ -293,7 +293,7 @@ const ChannelInner = ({
 
   const loadMore = useCallback(
     async (limit = 100) => {
-      if (!online.current) return 0;
+      if (!online.current || !window.navigator.onLine) return 0;
       // prevent duplicate loading events...
       const oldestMessage = state.messages[0];
       if (state.loadingMore || oldestMessage?.status !== 'received') return 0;


### PR DESCRIPTION
not the most brilliant approach, but our WS is a little bit behind detecting network is down or not
well supported: https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine/onLine