### PR TITLE
stops box from covering svg

### DIFF
--- a/src/styles/ChannelHeader.scss
+++ b/src/styles/ChannelHeader.scss
@@ -124,8 +124,7 @@
 .str-chat__square-button {
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 3px;
-  width: 30px;
-  height: 30px;
+  padding: 10px;
   margin: 0 5px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Height and Width cut off svg on mobile. Adds padding instead to fix issue. 