### PR TITLE
removes extra margin on emoji only messages

### DIFF
--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -625,7 +625,6 @@
       max-width: 460px;
 
       &.str-chat__message-simple-text-inner--is-emoji {
-        margin: 5px 0;
         background: transparent;
         p {
           line-height: 48px;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Removes extra margin on messages that are only emojis.

https://stream-io.atlassian.net/browse/CRS-247
