### PR TITLE
Fix erratic reaction list display

### DIFF
--- a/src/components/Message/hooks/useReactionHandler.js
+++ b/src/components/Message/hooks/useReactionHandler.js
@@ -154,12 +154,16 @@ export const useReactionClick = (
     }
   }, [messageDeleted, closeDetailedReactions, messageWrapperRef]);
 
-  /** @type {() => void} Typescript syntax */
-  const onReactionListClick = () => {
+  /** @type {(e: MouseEvent) => void} Typescript syntax */
+  const onReactionListClick = (e) => {
+    if (e && e.stopPropagation) {
+      e.stopPropagation();
+    }
     setShowDetailedReactions(true);
   };
 
   return {
+    // @ts-expect-error
     onReactionListClick,
     showDetailedReactions,
     isReactionEnabled,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1412,7 +1412,7 @@ export interface MessageLivestreamActionProps {
   channelConfig?: Client.ChannelConfig | Client.ChannelConfigWithInfo;
   threadList?: boolean;
   handleOpenThread?(event: React.BaseSyntheticEvent): void;
-  onReactionListClick?: () => void;
+  onReactionListClick?: (e: MouseEvent) => void;
   getMessageActions(): Array<string>;
   messageWrapperRef?: React.RefObject<HTMLElement>;
   setEditingState?(event?: React.BaseSyntheticEvent): void;


### PR DESCRIPTION
Fixes #715

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Based on my inspection, a race condition of catching the click event happens. For the bug to be reproduced, the list should be scrolled up and down - my guess is that this changes the event handler execution order, but I am not 100%. 

The proposed solution delays the attachment of the hide event handler. It works when testing manually. 