### PR TITLE
Mobile Options onClick

### DIFF
--- a/src/components/Message/MessageText.js
+++ b/src/components/Message/MessageText.js
@@ -12,7 +12,11 @@ import {
   useReactionClick,
   useMentionsUIHandler,
 } from './hooks';
-import { messageHasReactions, messageHasAttachments } from './utils';
+import {
+  handleMobilePress,
+  messageHasReactions,
+  messageHasAttachments,
+} from './utils';
 import MessageOptions from './MessageOptions';
 
 /**
@@ -71,21 +75,6 @@ const MessageTextComponent = (props) => {
     customInnerClass ||
     `str-chat__message-text-inner str-chat__message-${theme}-text-inner`;
 
-  /** @type {(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void} */
-  const handleMobilePress = (event) => {
-    if (event.target instanceof HTMLElement && breakpoint.device === 'mobile') {
-      const closestMessage = event.target.closest('.str-chat__message-simple');
-
-      if (!closestMessage) return;
-
-      if (closestMessage.classList.contains('mobile-press')) {
-        closestMessage.classList.remove('mobile-press');
-      } else {
-        closestMessage.classList.add('mobile-press');
-      }
-    }
-  };
-
   if (!message?.text) {
     return null;
   }
@@ -124,7 +113,9 @@ const MessageTextComponent = (props) => {
         {unsafeHTML && message.html ? (
           <div dangerouslySetInnerHTML={{ __html: message.html }} />
         ) : (
-          <div onClick={handleMobilePress}>{messageText}</div>
+          <div onClick={(event) => handleMobilePress({ breakpoint, event })}>
+            {messageText}
+          </div>
         )}
 
         {/* if reactions show them */}

--- a/src/components/Message/MessageText.js
+++ b/src/components/Message/MessageText.js
@@ -7,16 +7,12 @@ import {
   ReactionSelector as DefaultReactionSelector,
 } from '../Reactions';
 import {
-  useBreakpoint,
+  useMobilePress,
   useReactionHandler,
   useReactionClick,
   useMentionsUIHandler,
 } from './hooks';
-import {
-  handleMobilePress,
-  messageHasReactions,
-  messageHasAttachments,
-} from './utils';
+import { messageHasReactions, messageHasAttachments } from './utils';
 import MessageOptions from './MessageOptions';
 
 /**
@@ -40,7 +36,7 @@ const MessageTextComponent = (props) => {
     /** @type {HTMLDivElement | null} */ (null),
   );
 
-  const breakpoint = useBreakpoint();
+  const { handleMobilePress } = useMobilePress();
 
   const { onMentionsClick, onMentionsHover } = useMentionsUIHandler(message, {
     onMentionsClick: propOnMentionsClick,
@@ -113,9 +109,7 @@ const MessageTextComponent = (props) => {
         {unsafeHTML && message.html ? (
           <div dangerouslySetInnerHTML={{ __html: message.html }} />
         ) : (
-          <div onClick={(event) => handleMobilePress({ breakpoint, event })}>
-            {messageText}
-          </div>
+          <div onClick={handleMobilePress}>{messageText}</div>
         )}
 
         {/* if reactions show them */}

--- a/src/components/Message/MessageText.js
+++ b/src/components/Message/MessageText.js
@@ -7,6 +7,7 @@ import {
   ReactionSelector as DefaultReactionSelector,
 } from '../Reactions';
 import {
+  useBreakpoint,
   useReactionHandler,
   useReactionClick,
   useMentionsUIHandler,
@@ -34,6 +35,8 @@ const MessageTextComponent = (props) => {
   const reactionSelectorRef = useRef(
     /** @type {HTMLDivElement | null} */ (null),
   );
+
+  const breakpoint = useBreakpoint();
 
   const { onMentionsClick, onMentionsHover } = useMentionsUIHandler(message, {
     onMentionsClick: propOnMentionsClick,
@@ -67,6 +70,21 @@ const MessageTextComponent = (props) => {
   const innerClass =
     customInnerClass ||
     `str-chat__message-text-inner str-chat__message-${theme}-text-inner`;
+
+  /** @type {(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void} */
+  const handleMobilePress = (event) => {
+    if (event.target instanceof HTMLElement && breakpoint.device === 'mobile') {
+      const closestMessage = event.target.closest('.str-chat__message-simple');
+
+      if (!closestMessage) return;
+
+      if (closestMessage.classList.contains('mobile-press')) {
+        closestMessage.classList.remove('mobile-press');
+      } else {
+        closestMessage.classList.add('mobile-press');
+      }
+    }
+  };
 
   if (!message?.text) {
     return null;
@@ -106,7 +124,7 @@ const MessageTextComponent = (props) => {
         {unsafeHTML && message.html ? (
           <div dangerouslySetInnerHTML={{ __html: message.html }} />
         ) : (
-          messageText
+          <div onClick={handleMobilePress}>{messageText}</div>
         )}
 
         {/* if reactions show them */}

--- a/src/components/Message/__tests__/MessageText.test.js
+++ b/src/components/Message/__tests__/MessageText.test.js
@@ -260,9 +260,13 @@ describe('<MessageText />', () => {
             onClick={[Function]}
             onMouseOver={[Function]}
           >
-            <p>
-              hello world
-            </p>
+            <div
+              onClick={[Function]}
+            >
+              <p>
+                hello world
+              </p>
+            </div>
           </div>
           <div />
         </div>,
@@ -290,9 +294,13 @@ describe('<MessageText />', () => {
             onClick={[Function]}
             onMouseOver={[Function]}
           >
-            <p>
-              hi mate
-            </p>
+            <div
+              onClick={[Function]}
+            >
+              <p>
+                hi mate
+              </p>
+            </div>
           </div>
           <div />
         </div>,
@@ -319,9 +327,13 @@ describe('<MessageText />', () => {
             onClick={[Function]}
             onMouseOver={[Function]}
           >
-            <p>
-              whatup?!
-            </p>
+            <div
+              onClick={[Function]}
+            >
+              <p>
+                whatup?!
+              </p>
+            </div>
           </div>
           <div />
         </div>,

--- a/src/components/Message/hooks/index.js
+++ b/src/components/Message/hooks/index.js
@@ -4,6 +4,7 @@ export * from './useDeleteHandler';
 export * from './useEditHandler';
 export * from './useFlagHandler';
 export * from './useMentionsHandler';
+export * from './useMobilePress';
 export * from './useMuteHandler';
 export * from './useOpenThreadHandler';
 export * from './usePinHandler';

--- a/src/components/Message/hooks/index.js
+++ b/src/components/Message/hooks/index.js
@@ -1,4 +1,5 @@
 export * from './useActionHandler';
+export * from './useBreakpoint';
 export * from './useDeleteHandler';
 export * from './useEditHandler';
 export * from './useFlagHandler';

--- a/src/components/Message/hooks/useBreakpoint.js
+++ b/src/components/Message/hooks/useBreakpoint.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import throttle from 'lodash.throttle';
+
+const getDeviceWidth = (width) => {
+  if (width < 768) return { device: 'mobile', width };
+  if (width < 1024) return { device: 'tablet', width };
+  return { device: 'full', width };
+};
+
+export const useBreakpoint = () => {
+  const [breakpoint, setBreakpoint] = useState(
+    getDeviceWidth(window.innerWidth),
+  );
+
+  useEffect(() => {
+    const getInnerWidth = throttle(
+      () => setBreakpoint(getDeviceWidth(window.innerWidth)),
+      200,
+    );
+
+    window.addEventListener('resize', getInnerWidth);
+    return () => window.removeEventListener('resize', getInnerWidth);
+  }, []);
+
+  return breakpoint;
+};

--- a/src/components/Message/hooks/useBreakpoint.js
+++ b/src/components/Message/hooks/useBreakpoint.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import throttle from 'lodash.throttle';
 
+/** @type {(width: number) => {device: 'mobile' | 'tablet' | 'full'; width: number}} */
 const getDeviceWidth = (width) => {
   if (width < 768) return { device: 'mobile', width };
   if (width < 1024) return { device: 'tablet', width };

--- a/src/components/Message/hooks/useMobilePress.js
+++ b/src/components/Message/hooks/useMobilePress.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useBreakpoint } from './useBreakpoint';
+
+export const useMobilePress = () => {
+  const [targetMessage, setTargetMessage] = useState(null);
+
+  const breakpoint = useBreakpoint();
+
+  /** @type {(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void} */
+  const handleMobilePress = (event) => {
+    if (event.target instanceof HTMLElement && breakpoint.device === 'mobile') {
+      const closestMessage = event.target.closest('.str-chat__message-simple');
+
+      if (!closestMessage) return;
+      setTargetMessage(closestMessage);
+
+      if (closestMessage.classList.contains('mobile-press')) {
+        closestMessage.classList.remove('mobile-press');
+      } else {
+        closestMessage.classList.add('mobile-press');
+      }
+    }
+  };
+
+  useEffect(() => {
+    const handleClick = (event) => {
+      const isClickInside = targetMessage?.contains(event.target);
+
+      if (!isClickInside && targetMessage) {
+        targetMessage.classList.remove('mobile-press');
+      }
+    };
+
+    if (breakpoint.device === 'mobile') {
+      document.addEventListener('click', handleClick);
+    }
+    return () => document.removeEventListener('click', handleClick);
+  }, [breakpoint, targetMessage]);
+
+  return { handleMobilePress };
+};

--- a/src/components/Message/utils.js
+++ b/src/components/Message/utils.js
@@ -291,18 +291,3 @@ export const MessagePropTypes = PropTypes.shape({
   created_at: PropTypes.instanceOf(Date).isRequired,
   updated_at: PropTypes.instanceOf(Date).isRequired,
 }).isRequired;
-
-/** @type {({ breakpoint, event }: {breakpoint: {device: 'mobile' | 'tablet' | 'full'; width: number}; event: React.MouseEvent<HTMLDivElement, MouseEvent>}) => void} */
-export const handleMobilePress = ({ breakpoint, event }) => {
-  if (event.target instanceof HTMLElement && breakpoint.device === 'mobile') {
-    const closestMessage = event.target.closest('.str-chat__message-simple');
-
-    if (!closestMessage) return;
-
-    if (closestMessage.classList.contains('mobile-press')) {
-      closestMessage.classList.remove('mobile-press');
-    } else {
-      closestMessage.classList.add('mobile-press');
-    }
-  }
-};

--- a/src/components/Message/utils.js
+++ b/src/components/Message/utils.js
@@ -291,3 +291,18 @@ export const MessagePropTypes = PropTypes.shape({
   created_at: PropTypes.instanceOf(Date).isRequired,
   updated_at: PropTypes.instanceOf(Date).isRequired,
 }).isRequired;
+
+/** @type {({ breakpoint, event }: {breakpoint: {device: 'mobile' | 'tablet' | 'full'; width: number}; event: React.MouseEvent<HTMLDivElement, MouseEvent>}) => void} */
+export const handleMobilePress = ({ breakpoint, event }) => {
+  if (event.target instanceof HTMLElement && breakpoint.device === 'mobile') {
+    const closestMessage = event.target.closest('.str-chat__message-simple');
+
+    if (!closestMessage) return;
+
+    if (closestMessage.classList.contains('mobile-press')) {
+      closestMessage.classList.remove('mobile-press');
+    } else {
+      closestMessage.classList.add('mobile-press');
+    }
+  }
+};

--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -691,6 +691,7 @@
         order: -1;
       }
     }
+
     &:hover {
       .str-chat__message-simple__actions__action--options {
         display: flex;
@@ -700,6 +701,18 @@
       }
       .str-chat__message-simple__actions__action--thread {
         display: flex;
+      }
+
+      @media screen and (max-width: 960px) {
+        .str-chat__message-simple__actions__action--options {
+          display: none;
+        }
+        .str-chat__message-simple__actions__action--reactions {
+          display: none;
+        }
+        .str-chat__message-simple__actions__action--thread {
+          display: none;
+        }
       }
     }
   }
@@ -1045,5 +1058,17 @@
         margin-right: -10px;
       }
     }
+  }
+}
+
+.str-chat__message-simple.mobile-press {
+  .str-chat__message-simple__actions__action--options {
+    display: flex;
+  }
+  .str-chat__message-simple__actions__action--reactions {
+    display: flex;
+  }
+  .str-chat__message-simple__actions__action--thread {
+    display: flex;
   }
 }


### PR DESCRIPTION
The MessageText component triggers the display of the MessageOptions (react, reply, actions) onHover. This created some issues on mobile where hover events do not exist. We now disable hover on mobile and trigger an onClick event to show the MessageOptions when a user presses the MessageText component.