### PR TITLE
Fix handling of 1px tall messages

### DIFF
--- a/src/components/MessageList/VirtualizedMessageList.js
+++ b/src/components/MessageList/VirtualizedMessageList.js
@@ -118,13 +118,7 @@ const VirtualizedMessageList = ({
      */
     const Item = (props) => {
       return (
-        <div
-          {...props}
-          style={{
-            display: 'inline-block',
-            width: '100%',
-          }}
-        />
+        <div {...props} className="str-chat__virtual-list-message-wrapper" />
       );
     };
 

--- a/src/styles/VirtualMessage.scss
+++ b/src/styles/VirtualMessage.scss
@@ -24,6 +24,8 @@
 }
 
 .str-chat__virtual-list {
+  // this resolves the issue with 1px tall messages (i.e. deleted messages)
+  font-size: 0;
   .str-chat__message.str-chat__message--deleted {
     align-items: initial;
     padding: 16px 42px;
@@ -33,6 +35,11 @@
   .str-chat__typing-indicator {
     padding: 5px 40px; // important: div height should be big enough to fully contain the avatars
   }
+}
+
+.str-chat__virtual-list-message-wrapper {
+  display: inline-block;
+  width: 100%;
 }
 
 .str-chat__virtual-message__meta {


### PR DESCRIPTION
Explanation:
https://stackoverflow.com/a/38523642/1009797

The above is necessary if we would like to have disappearing messages (due to soft deletion for example). In addition to that, this PR moves the inline styling of the virtual list message wrappers to a class, so that inline-block can be overwritten if necessary. 

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
