### PR TITLE
Fix an error when a hyphen causes a false positive

### DIFF
--- a/src/components/ChatAutoComplete/ChatAutoComplete.js
+++ b/src/components/ChatAutoComplete/ChatAutoComplete.js
@@ -30,10 +30,13 @@ const ChatAutoComplete = (props) => {
   /** @param {string} word */
   const emojiReplace = (word) => {
     const found = emojiIndex?.search(word) || [];
-    const emoji = found.slice(0, 10).find(
-      /** @type {{ ({ emoticons } : import('emoji-mart').EmojiData): boolean }} */
-      ({ emoticons }) => !!emoticons?.includes(word),
-    );
+    const emoji = found
+      .filter(Boolean)
+      .slice(0, 10)
+      .find(
+        /** @type {{ ({ emoticons } : import('emoji-mart').EmojiData): boolean }} */
+        ({ emoticons }) => !!emoticons?.includes(word),
+      );
     if (!emoji || !('native' in emoji)) return null;
     return emoji.native;
   };


### PR DESCRIPTION
The `search` function on `NimbleEmojiIndex` can return an array with
a null value. This in turn causes an error when attempting to
destructure that element later on.

I wasn't able to write a test that highlights this error. I found it
difficult to replace the dependency on NimbleEmojiIndex with a mock.

Open to pointers on how to do that so I can complete this with an actual
failing test.

In the meantime, ensuring that `found` only contains non-null values
will fix the error.

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)
