### PR TITLE
Support for date separators in virtual message list

### DIFF
--- a/src/components/MessageList/MessageListInner.js
+++ b/src/components/MessageList/MessageListInner.js
@@ -2,6 +2,7 @@
 import React, { useMemo } from 'react';
 import isEqual from 'lodash.isequal';
 
+import { insertDates } from './utils';
 import { Message } from '../Message';
 import { InfiniteScroll } from '../InfiniteScrollPaginator';
 
@@ -32,65 +33,6 @@ const getReadStates = (messages, read) => {
   });
 
   return readData;
-};
-
-const insertDates = (messages, lastRead, userID, hideDeletedMessages) => {
-  let unread = false;
-  let lastDateSeparator;
-  const newMessages = [];
-
-  for (let i = 0, l = messages.length; i < l; i += 1) {
-    const message = messages[i];
-
-    if (hideDeletedMessages && message.type === 'deleted') {
-      continue;
-    }
-
-    if (message.type === 'message.read') {
-      newMessages.push(message);
-      continue;
-    }
-
-    const messageDate = message.created_at.toDateString();
-    let prevMessageDate = messageDate;
-
-    if (i > 0) {
-      prevMessageDate = messages[i - 1].created_at.toDateString();
-    }
-
-    if (!unread) {
-      unread = lastRead && new Date(lastRead) < message.created_at;
-
-      // do not show date separator for current user's messages
-      if (unread && message.user.id !== userID) {
-        newMessages.push({
-          type: 'message.date',
-          date: message.created_at,
-          unread,
-        });
-      }
-    }
-
-    if (
-      (i === 0 ||
-        messageDate !== prevMessageDate ||
-        (hideDeletedMessages &&
-          messages[i - 1]?.type === 'deleted' &&
-          lastDateSeparator !== messageDate)) &&
-      newMessages?.[newMessages.length - 1]?.type !== 'message.date' // do not show two date separators in a row
-    ) {
-      lastDateSeparator = messageDate;
-
-      newMessages.push(
-        { type: 'message.date', date: message.created_at },
-        message,
-      );
-    } else {
-      newMessages.push(message);
-    }
-  }
-
-  return newMessages;
 };
 
 const insertIntro = (messages, headerPosition) => {

--- a/src/components/MessageList/VirtualizedMessageList.js
+++ b/src/components/MessageList/VirtualizedMessageList.js
@@ -1,5 +1,6 @@
 // @ts-check
 import React, { useCallback, useContext, useMemo, useRef } from 'react';
+import PropTypes from 'prop-types';
 import { Virtuoso } from 'react-virtuoso';
 
 import { useNewMessageNotification } from './hooks/useNewMessageNotification';
@@ -46,7 +47,10 @@ const VirtualizedMessageList = ({
   LoadingIndicator = DefaultLoadingIndicator,
   EmptyStateIndicator = DefaultEmptyStateIndicator,
   stickToBottomScrollBehavior = 'smooth',
-  disableDateSeparator = false,
+  /**
+   * Setting to false makes the virtual list display date separators.
+   */
+  disableDateSeparator = true,
   DateSeparator = DefaultDateSeparator,
   channel,
 }) => {
@@ -209,6 +213,11 @@ const VirtualizedMessageList = ({
       </div>
     </div>
   );
+};
+
+VirtualizedMessageList.propTypes = {
+  /** Disables the injection of date separator components */
+  disableDateSeparator: PropTypes.bool,
 };
 
 // TODO: fix the types here when everything converted to proper TS

--- a/src/components/MessageList/utils.js
+++ b/src/components/MessageList/utils.js
@@ -1,0 +1,69 @@
+/* eslint-disable no-continue */
+export const insertDates = (
+  messages,
+  lastRead,
+  userID,
+  hideDeletedMessages,
+) => {
+  let unread = false;
+  let lastDateSeparator;
+  const newMessages = [];
+
+  for (let i = 0, l = messages.length; i < l; i += 1) {
+    const message = messages[i];
+
+    if (hideDeletedMessages && message.type === 'deleted') {
+      continue;
+    }
+
+    if (message.type === 'message.read') {
+      newMessages.push(message);
+      continue;
+    }
+
+    const messageDate = message.created_at.toDateString();
+    let prevMessageDate = messageDate;
+
+    if (i > 0) {
+      prevMessageDate = messages[i - 1].created_at.toDateString();
+    }
+
+    if (!unread) {
+      unread = lastRead && new Date(lastRead) < message.created_at;
+
+      // do not show date separator for current user's messages
+      if (unread && message.user.id !== userID) {
+        newMessages.push({
+          type: 'message.date',
+          date: message.created_at,
+          id: message.id,
+          unread,
+        });
+      }
+    }
+
+    if (
+      (i === 0 ||
+        messageDate !== prevMessageDate ||
+        (hideDeletedMessages &&
+          messages[i - 1]?.type === 'deleted' &&
+          lastDateSeparator !== messageDate)) &&
+      newMessages?.[newMessages.length - 1]?.type !== 'message.date' // do not show two date separators in a row
+    ) {
+      lastDateSeparator = messageDate;
+
+      newMessages.push(
+        {
+          type: 'message.date',
+          date: message.created_at,
+          id: message.id,
+        },
+        message,
+      );
+    } else {
+      newMessages.push(message);
+    }
+  }
+
+  return newMessages;
+};

--- a/src/docs/VirtualizedMessageList.md
+++ b/src/docs/VirtualizedMessageList.md
@@ -1,5 +1,5 @@
 The VirtualizedMessageList renders a list of messages in a virtualized list.
-It works pretty well when there are thousands of messages in your channel, it has a shortcoming though, the Message UI should have a fixed height.
+It works pretty well when there are thousands of messages in your channel.
 
 Here's an example of how to use it:
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -546,6 +546,9 @@ export interface FixedHeightMessageProps {
 export interface VirtualizedMessageListInternalProps {
   /** **Available from [chat context](https://getstream.github.io/stream-chat-react/#chat)** */
   client: StreamChatReactClient;
+  channel: Client.Channel;
+  DateSeparator: React.FC<DateSeparatorProps>;
+  disableDateSeparator?: boolean;
   /** **Available from [channel context](https://getstream.github.io/stream-chat-react/#channel)** */
   messages?: Array<Client.MessageResponse>;
   /** **Available from [channel context](https://getstream.github.io/stream-chat-react/#channel)** */


### PR DESCRIPTION
This PR introduces the `disableDateSeparator` property for the virtual message list. To avoid breaking changes, the default value of the property is `true`. 