### PR TITLE
CRS-441 customizable message mentions

### DIFF
--- a/src/styles/Message.scss
+++ b/src/styles/Message.scss
@@ -444,12 +444,6 @@
   }
 
   &-mention {
-    margin: 0;
-    padding: 0;
-    background: none;
-    border: none;
-    font-size: 16px;
-    color: $primary-color;
     font-weight: $heavy-font-weight;
   }
 

--- a/src/styles/MessageCommerce.scss
+++ b/src/styles/MessageCommerce.scss
@@ -183,16 +183,6 @@
     text-decoration: none;
   }
 
-  &-mention {
-    margin: 0;
-    padding: 0;
-    background: none;
-    border: none;
-    font-size: 16px;
-    color: $primary-color;
-    font-weight: $heavy-font-weight;
-  }
-
   &--inner {
     display: flex;
     flex-direction: column;

--- a/src/styles/MessageLivestream.scss
+++ b/src/styles/MessageLivestream.scss
@@ -33,16 +33,6 @@
       margin: 0;
     }
 
-    .str-chat__message-mention {
-      font-size: 13px;
-      line-height: 20px;
-      margin: 0;
-
-      &:focus {
-        outline: 1;
-      }
-    }
-
     p {
       margin: 0;
       white-space: pre-line;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -8,7 +8,7 @@ import ReactMarkdown from 'react-markdown/with-html';
 
 import type { UserResponse } from 'stream-chat';
 
-import type { DefaultUserType, UnknownType } from '../types/types';
+import type { UnknownType } from '../types/types';
 
 export const isOnlyEmojis = (text?: string) => {
   if (!text) return false;
@@ -107,11 +107,7 @@ const emojiMarkdownPlugin = () => {
   return transform;
 };
 
-type MentionedUser<
-  Us extends DefaultUserType<Us> = DefaultUserType
-> = UserResponse<Us>;
-
-const mentionsMarkdownPlugin = (mentioned_users: MentionedUser[]) => () => {
+const mentionsMarkdownPlugin = (mentioned_users: UserResponse[]) => () => {
   const mentioned_usernames = mentioned_users
     .map((user) => user.name || user.id)
     .filter(Boolean)
@@ -142,7 +138,7 @@ const mentionsMarkdownPlugin = (mentioned_users: MentionedUser[]) => () => {
   return transform;
 };
 
-type MentionProps = { mentioned_user: MentionedUser };
+type MentionProps = { mentioned_user: UserResponse };
 
 const Mention: React.FC<MentionProps> = ({ children }) => (
   <span className='str-chat__message-mention'>{children}</span>
@@ -150,7 +146,7 @@ const Mention: React.FC<MentionProps> = ({ children }) => (
 
 export const renderText = (
   text?: string,
-  mentioned_users?: MentionedUser[],
+  mentioned_users?: UserResponse[],
   MentionComponent: React.ComponentType<MentionProps> = Mention,
 ) => {
   // take the @ mentions and turn them into markdown?

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import emojiRegex from 'emoji-regex';
 import * as linkify from 'linkifyjs';
 //@ts-expect-error
@@ -8,7 +8,7 @@ import ReactMarkdown from 'react-markdown/with-html';
 
 import type { UserResponse } from 'stream-chat';
 
-import type { UnknownType } from '../types/types';
+import type { DefaultUserType, UnknownType } from '../types/types';
 
 export const isOnlyEmojis = (text?: string) => {
   if (!text) return false;
@@ -107,7 +107,11 @@ const emojiMarkdownPlugin = () => {
   return transform;
 };
 
-const mentionsMarkdownPlugin = (mentioned_users: UserResponse[]) => () => {
+const mentionsMarkdownPlugin = <
+  Us extends DefaultUserType<Us> = DefaultUserType
+>(
+  mentioned_users: UserResponse<Us>[],
+) => () => {
   const mentioned_usernames = mentioned_users
     .map((user) => user.name || user.id)
     .filter(Boolean)
@@ -138,16 +142,18 @@ const mentionsMarkdownPlugin = (mentioned_users: UserResponse[]) => () => {
   return transform;
 };
 
-type MentionProps = { mentioned_user: UserResponse };
+type MentionProps<Us extends DefaultUserType<Us> = DefaultUserType> = {
+  mentioned_user: UserResponse<Us>;
+};
 
-const Mention: React.FC<MentionProps> = ({ children }) => (
-  <span className='str-chat__message-mention'>{children}</span>
-);
+const Mention = <Us extends DefaultUserType<Us> = DefaultUserType>(
+  props: PropsWithChildren<Us>,
+) => <span className='str-chat__message-mention'>{props.children}</span>;
 
-export const renderText = (
+export const renderText = <Us extends DefaultUserType<Us> = DefaultUserType>(
   text?: string,
-  mentioned_users?: UserResponse[],
-  MentionComponent: React.ComponentType<MentionProps> = Mention,
+  mentioned_users?: UserResponse<Us>[],
+  MentionComponent: React.ComponentType<MentionProps<Us>> = Mention,
 ) => {
   // take the @ mentions and turn them into markdown?
   // translate links


### PR DESCRIPTION
Renders mentions as span with `str-chat__message-mention` class instead of just wrapping it in a `<strong>`. Also allows users to override the wrapping component for mentions by supplying a custom mentions component to the `renderText` function.

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
