### PR TITLE
Fix image attachment bugs

### DIFF
--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -39,7 +39,6 @@ const UnMemoizedGallery = <
     () =>
       images.map((image) => ({
         source: image.image_url || image.thumb_url || '',
-        src: image.image_url || image.thumb_url || '',
       })),
     [images],
   );

--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -80,7 +80,7 @@ const UnMemoizedGallery = <
         images={formattedArray}
         index={index}
         modalIsOpen={modalOpen}
-        toggleModal={() => toggleModal}
+        toggleModal={() => setModalOpen(!modalOpen)}
       />
     </div>
   );

--- a/src/components/Gallery/ModalImage.tsx
+++ b/src/components/Gallery/ModalImage.tsx
@@ -5,14 +5,14 @@ import React from 'react';
  */
 export type ModalImageProps = {
   /** The src attribute for the image element */
-  data: { src: string };
+  data: { source: string };
 };
 
 export const ModalImage: React.FC<ModalImageProps> = (props) => {
   const { data } = props;
   return (
     <div className='str-chat__modal-image__wrapper' data-testid='modal-image'>
-      <img className='str-chat__modal-image__image' src={data.src} />
+      <img className='str-chat__modal-image__image' src={data.source} />
     </div>
   );
 };


### PR DESCRIPTION
Found two bugs with image attachments:

 - single-attachment images didn't show up in the lightbox
    - (found out that we were setting both `source` and `src` for multiple-image galleries, but only `source` for single-attachment galleries, the latter seems to correspond to `react-images` types)
 - after clicking a thumbnail in a gallery with multiple images, it was impossible to close the lightbox



# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
