### PR TITLE
Connect on user click

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -19,6 +19,8 @@ export type AvatarProps = {
   size?: number;
 };
 
+const noop = () => undefined;
+
 /**
  * Avatar - A round avatar image with fallback to username's first letter.
  * @example ./Avatar.md
@@ -27,8 +29,8 @@ export const Avatar: React.FC<AvatarProps> = (props) => {
   const {
     image,
     name,
-    onClick = () => undefined,
-    onMouseOver = () => undefined,
+    onClick = noop,
+    onMouseOver = noop,
     shape = 'circle',
     size = 32,
   } = props;
@@ -43,9 +45,11 @@ export const Avatar: React.FC<AvatarProps> = (props) => {
 
   const initials = (name || '').charAt(0);
 
+  const clickableClass = onClick !== noop ? 'str-chat__avatar--clickable' : '';
+
   return (
     <div
-      className={`str-chat__avatar str-chat__avatar--${shape}`}
+      className={`str-chat__avatar str-chat__avatar--${shape} ${clickableClass}`}
       data-testid='avatar'
       onClick={onClick}
       onMouseOver={onMouseOver}

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -1,4 +1,5 @@
 import React, {
+  MouseEvent,
   PropsWithChildren,
   useCallback,
   useEffect,
@@ -25,6 +26,7 @@ import {
   Channel as StreamChannel,
   StreamChat,
   UpdatedMessage,
+  UserResponse,
 } from 'stream-chat';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -172,6 +174,20 @@ export type ChannelProps<
    * Handle for hover on @mention in message, user object
    */
   onMentionsHover?: OnMentionAction<Us>;
+  /**
+   * Callback invoked when the user clicks on an avatar
+   */
+  onUserClick?: (
+    event: MouseEvent<HTMLElement>,
+    user?: UserResponse<Us>,
+  ) => void;
+  /**
+   * Callback invoked when the user hovers over an avatar
+   */
+  onUserHover?: (
+    event: MouseEvent<HTMLElement>,
+    user?: UserResponse<Us>,
+  ) => void;
 };
 
 const UnMemoizedChannel = <
@@ -239,6 +255,8 @@ const ChannelInner = <
     multipleUploads = true,
     onMentionsClick,
     onMentionsHover,
+    onUserClick,
+    onUserHover,
   } = props;
 
   const { client, mutes, theme } = useChatContext<At, Ch, Co, Ev, Me, Re, Us>();
@@ -706,6 +724,8 @@ const ChannelInner = <
     mutes,
     onMentionsClick: onMentionsHoverOrClick,
     onMentionsHover: onMentionsHoverOrClick,
+    onUserClick,
+    onUserHover,
     openThread,
     removeMessage,
     retrySendMessage,

--- a/src/context/ChannelContext.tsx
+++ b/src/context/ChannelContext.tsx
@@ -170,6 +170,14 @@ export type ChannelContextValue<
     event: React.MouseEvent<HTMLElement>,
     user: UserResponse<Us>[],
   ) => void;
+  onUserClick?: (
+    event: React.MouseEvent<HTMLElement>,
+    user: UserResponse<Us>,
+  ) => void;
+  onUserHover?: (
+    event: React.MouseEvent<HTMLElement>,
+    user: UserResponse<Us>,
+  ) => void;
   openThread?: (
     message: StreamMessage<At, Ch, Co, Ev, Me, Re, Us>,
     event: React.SyntheticEvent,

--- a/src/styles/Avatar.scss
+++ b/src/styles/Avatar.scss
@@ -36,6 +36,10 @@
   &-fallback {
     background-color: $secondary-color;
   }
+
+  &--clickable {
+    cursor: pointer;
+  }
 }
 
 .str-chat__message {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

The `Avatar` component accepts `onClick` and `onMouseOver` props which are set in the `Message` components to the props `onUserClick` and `onUserHover`. It appears these are expected to come from the `ChannelContext` - or at least from the `MessageList` - but they don't.

This pull request connects the `Channel` and `MessageList` and passes `onUserClick` and `onUserHover` down so that it's possible to detect a click event on the `Avatar` in the `MessageList`.

Note that this does not affect other usages of the `Avatar`, where it's unlikely the click event would be useful, or that it would be interpreted as a "user click". E.g. in the channel header you'd probably want to invoke different behavior when the user clicks on the avatar.