### PR TITLE
CRS-479 force close autocomplete suggestions on submit

### DIFF
--- a/src/components/AutoCompleteTextarea/Textarea.js
+++ b/src/components/AutoCompleteTextarea/Textarea.js
@@ -130,6 +130,7 @@ class ReactTextareaAutocomplete extends React.Component {
         this.textareaRef.selectionEnd = 0;
       }
       this.props.handleSubmit(event);
+      this._closeAutocomplete();
     }
   };
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
This fixes a bug where the list of suggestions would sometimes open after a message had already been submitting because the promise needed to populate that list would only resolve after the user had submitted the message. `_closeAutocomplete` takes care of all the cleanup that is needed in this case.