### PR TITLE
Filter out any falsy values of emojiIndex.search result

### DIFF
--- a/src/components/ChatAutoComplete/ChatAutoComplete.tsx
+++ b/src/components/ChatAutoComplete/ChatAutoComplete.tsx
@@ -386,8 +386,8 @@ const UnMemoizedChatAutoComplete = <
               return [];
             }
             const emojis = emojiIndex?.search(query) || [];
-            const result = emojis.slice(0, 10);
-
+            // emojiIndex.search sometimes returns undefined values, so filter those out first
+            const result = emojis.filter(Boolean).slice(0, 10);
             if (onReady) onReady(result, query);
 
             return result;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
We use a custom dataset for emoji-mart to reduce the bundle size. For this reason, we left out the skin color variations and only ship the bright yellow emojis. It turns out that there is one code path inside emoji-mart's `NimbleEmojiIndex` that expects these skin color variations to be present: https://github.com/missive/emoji-mart/blob/ccd591dd5af5ea21455e65b16c233f4876447b80/src/utils/emoji-index/nimble-emoji-index.js#L99. This causes it to return `undefined` only when a user searches for `-` or `-1` inside our Autocomplete Textarea.

This PR contains a small workaround, which just filters out these falsy values. That does mean that users cannot search for the "thumbs down" emoji by typing `-` or `-1`, but it still works if you search e.g. `thumbs down`. We can talk to the folks who created emoji-mart if we do want to provide support for this, this might be something they want to consider as well.