### PR TITLE
Remove unused css that caused Gatsby to error

### DIFF
--- a/src/styles/MessageActions.scss
+++ b/src/styles/MessageActions.scss
@@ -94,31 +94,3 @@
 .str-chat__message-actions-options:hover svg {
   fill: $primary-color;
 }
-
-.str-chat__message-reactions-box {
-  position: absolute;
-  visibility: hidden;
-  bottom: 30px;
-  left: -20px;
-  background: rgba(0, 0, 0, 0.81);
-  background-image: linear-gradient(
-    -180deg,
-    rgba(0, 0, 0, 0) 0%,
-    rgba(0, 0, 0, 0.5) 100%
-  );
-  border-radius: 50px;
-  padding: 16px;
-  z-index: 100;
-}
-
-.str-chat__message-reactions-box--open {
-  visibility: visible;
-}
-
-.str-chat__message-reactions-box::after {
-  top: 97%;
-  left: 30px;
-  content: url('data:image/svg+xml; utf8, <svg width="36" height="19" viewBox="0 0 36 19" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="b"><stop stop-opacity="0" offset="0%"/><stop stop-opacity=".5" offset="100%"/></linearGradient><path d="M35.284.378A15.125 15.125 0 0 0 22.81 6.946L14.55 19a14.422 14.422 0 0 0-2.223-12.786A14.456 14.456 0 0 0 .723.378h34.561z" id="a"/></defs><g fill-rule="nonzero" fill="none"><use fill="%231E1E1E" xlink:href="%23a"/><use fill="url(%23b)" xlink:href="%23a"/></g></svg>');
-  position: absolute;
-  z-index: 99;
-}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
See https://github.com/GetStream/stream-chat-react/issues/845

This PR removes some old css that was not used anywhere in the actual components. It includes an inline svg icon that caused Gatsby to throw an error.
