### PR TITLE
update team, commerce, livestream message components firstGroupStyle …

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,3 +235,10 @@ Please read this docs on i18n for more details and further customizations - <htt
 ## Contributing
 
 We welcome code changes that improve this library or fix a problem. Please make sure to follow all best practices and add tests if applicable before submitting a Pull Request on Github. We are pleased to merge your code into the official repository. Make sure to sign our [Contributor License Agreement (CLA)](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) first. See our license file for more details.
+
+## We are hiring
+
+We've recently closed a [\$38 million Series B funding round](https://techcrunch.com/2021/03/04/stream-raises-38m-as-its-chat-and-activity-feed-apis-power-communications-for-1b-users/) and we keep actively growing.
+Our APIs are used by more than a billion end-users, and you'll have a chance to make a huge impact on the product within a team of the strongest engineers all over the world.
+
+Check out our current openings and apply via [Stream's website](https://getstream.io/team/#jobs).

--- a/src/components/Message/MessageCommerce.tsx
+++ b/src/components/Message/MessageCommerce.tsx
@@ -84,7 +84,7 @@ const MessageCommerceWithContext = <
   const hasAttachment = messageHasAttachments(message);
   const hasReactions = messageHasReactions(message);
 
-  const firstGroupStyle = groupStyles ? groupStyles[0] : '';
+  const firstGroupStyle = groupStyles ? groupStyles[0] : 'single';
 
   const messageClasses = `str-chat__message-commerce str-chat__message-commerce--${
     isMyMessage() ? 'right' : 'left'

--- a/src/components/Message/MessageLivestream.tsx
+++ b/src/components/Message/MessageLivestream.tsx
@@ -111,7 +111,7 @@ const MessageLivestreamWithContext = <
     messageTextToRender,
   ]);
 
-  const firstGroupStyle = groupStyles ? groupStyles[0] : '';
+  const firstGroupStyle = groupStyles ? groupStyles[0] : 'single';
 
   if (message.type === 'message.read' || message.type === 'message.date') {
     return null;

--- a/src/components/Message/MessageTeam.tsx
+++ b/src/components/Message/MessageTeam.tsx
@@ -86,7 +86,7 @@ const MessageTeamWithContext = <
     getMessageActions,
     getMuteUserErrorNotification,
     getMuteUserSuccessNotification,
-    groupStyles = ['single'],
+    groupStyles,
     handleAction,
     handleEdit,
     handleFlag,
@@ -142,7 +142,7 @@ const MessageTeamWithContext = <
     messageTextToRender,
   ]);
 
-  const firstGroupStyle = groupStyles ? groupStyles[0] : '';
+  const firstGroupStyle = groupStyles ? groupStyles[0] : 'single';
 
   if (message.type === 'message.read') {
     return null;


### PR DESCRIPTION
…assignment

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
This PR fixes the Avatar and message author name conditionally rendering in MessageTeam, MessageCommerce, and MessageLivestream. MessageList (via MessageInner) will correctly calculate the groupStyles prop to then give to the Message UI component. 

If one were to not use the MessageList component, but did use the Message prop on the Message component with one of the above UI Components, the Avatar and message author would not render due to groupStyles not being set, and then either no default is set for the optional prop or the default string is overridden before the conditional as empty string (MessageTeam).
