### PR TITLE
Fix trigger regex

### DIFF
--- a/src/components/AutoCompleteTextarea/Textarea.js
+++ b/src/components/AutoCompleteTextarea/Textarea.js
@@ -487,7 +487,13 @@ class ReactTextareaAutocomplete extends React.Component {
       currentTrigger = '/';
       lastToken = value;
     } else {
-      const tokenMatch = value.slice(0, selectionEnd).match(/(?!^|\W)?[:@][^\s]*\s?[^\s]*$/g);
+      const triggerTokens = ':@';
+      const triggerNorWhitespace = `[^\\s${triggerTokens}]*`;
+      const regex = new RegExp(
+        `(?!^|\\W)?[${triggerTokens}]${triggerNorWhitespace}\\s?${triggerNorWhitespace}$`,
+        'g',
+      );
+      const tokenMatch = value.slice(0, selectionEnd).match(regex);
 
       lastToken = tokenMatch && tokenMatch[tokenMatch.length - 1].trim();
 


### PR DESCRIPTION

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
fix trigger regex: no match if any of the subsequent parts are the contain a new trigger token, needed to support subsequent triggers

Previously, if a user tried to use multiple triggers in the same message (e.g. mentioning multiple users), the second trigger didn't work. This was due to the regex, which matched everything starting from the first trigger's token until the position of the cursor. This updated regex prevents that from happening.