### PR TITLE
CRS-268 Fix messed up url parsing when you add the same URL twice

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -198,9 +198,7 @@ export const renderText = <Us extends DefaultUserType<Us> = DefaultUserType>(
 
     const displayLink = type === 'email' ? value : value.replace(detectHttp, '');
 
-    const valueRegex = new RegExp(escapeRegExp(value), 'g');
-
-    newText = newText.replace(valueRegex, `[${displayLink}](${encodeURI(href)})`);
+    newText = newText.replaceAll(value, `[${displayLink}](${encodeURI(href)})`);
   });
 
   const plugins = [emojiMarkdownPlugin];

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -5,6 +5,7 @@ import * as linkify from 'linkifyjs';
 import findAndReplace from 'mdast-util-find-and-replace';
 import RootReactMarkdown, { NodeType } from 'react-markdown';
 import ReactMarkdown from 'react-markdown/with-html';
+import uniqBy from 'lodash.uniqby';
 
 import type { UserResponse } from 'stream-chat';
 
@@ -178,7 +179,7 @@ export const renderText = <Us extends DefaultUserType<Us> = DefaultUserType>(
   const detectHttp = /(http(s?):\/\/)?(www\.)?/;
 
   // extract all valid links/emails within text and replace it with proper markup
-  linkify.find(newText).forEach(({ href, type, value }) => {
+  uniqBy(linkify.find(newText), 'value').forEach(({ href, type, value }) => {
     const linkIsInBlock = codeBlocks.some((block) => block?.includes(value));
 
     // check if message is already  markdown
@@ -197,7 +198,9 @@ export const renderText = <Us extends DefaultUserType<Us> = DefaultUserType>(
 
     const displayLink = type === 'email' ? value : value.replace(detectHttp, '');
 
-    newText = newText.replace(value, `[${displayLink}](${encodeURI(href)})`);
+    const valueRegex = new RegExp(escapeRegExp(value), 'g');
+
+    newText = newText.replace(valueRegex, `[${displayLink}](${encodeURI(href)})`);
   });
 
   const plugins = [emojiMarkdownPlugin];


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
filter out non-unique links, and replace all instances in the message text at the same time to prevent buggy behaviour with duplicate links
