### PR TITLE
fix: Wrong "stream-chat" peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "peerDependencies": {
     "react": "^17.0.0 || ^16.8.0",
     "react-dom": "^17.0.0 || ^16.8.0",
-    "stream-chat": "3.1.x"
+    "stream-chat": "^3.1.0"
   },
   "files": [
     "built",


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
The peerDependency was declaring `stream-chat@3.1.x` which block us installing `stream-chat@3.7.0` when we use npm@7 in strict mode

Using `^3.1.0` should fix the issue as it would allow all `v3` major version that are above `3.1.0`
