### PR TITLE
use assetPath variable instead of hard-coded relative path

### DIFF
--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -74,7 +74,7 @@ $emoji-flag-unicode-range: U+1F1E6-1F1FF;
 /* png based woff for most browsers */
 @font-face {
   font-family: ReplaceFlagEmojiPNG;
-  src: url("../assets/NotoColorEmoji-flags.woff2") format("woff2");
+  src: url("#{$assetsPath}/NotoColorEmoji-flags.woff2") format("woff2");
   /* using the unicode-range attribute to limit the reach of the Flag Emoji web font to only flags */
   unicode-range: $emoji-flag-unicode-range;
 }
@@ -82,7 +82,7 @@ $emoji-flag-unicode-range: U+1F1E6-1F1FF;
 /* svg based for firefox */
 @font-face {
   font-family: ReplaceFlagEmojiSVG;
-  src: url("../assets/EmojiOneColor.woff2") format("woff2");
+  src: url("#{$assetsPath}/EmojiOneColor.woff2") format("woff2");
   unicode-range: $emoji-flag-unicode-range;
 }
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

This hard-coded relative path was causing issues for me when trying to import the SASS into my project to extend the base styles. I believe this should reference the `assetsPath` variable.
