### PR TITLE
Virtualized list improvements

### DIFF
--- a/docusaurus/docs/React/core-components/virtualized-list.mdx
+++ b/docusaurus/docs/React/core-components/virtualized-list.mdx
@@ -60,6 +60,16 @@ const customMessages = [
 </Chat>;
 ```
 
+## Scroll Behavior Optimization
+
+By default, the virtualized message list uses the latest message (which gets rendered first) in the list as the default item size. 
+This can lead to inaccurate scroll thumb size or scroll jumps if the last item is unusually tall (for example, an attachment). 
+To improve this behavior, set the `defaultItemHeight` property to a value close (or equal to) the height of the usual messages. 
+
+```jsx
+<VirtualizedMessageList messages={customMessages} defaultItemHeight={76} />
+```
+
 ## Props
 
 ### customMessageRenderer

--- a/docusaurus/docs/React/core-components/virtualized-list.mdx
+++ b/docusaurus/docs/React/core-components/virtualized-list.mdx
@@ -62,9 +62,9 @@ const customMessages = [
 
 ## Scroll Behavior Optimization
 
-By default, the virtualized message list uses the latest message (which gets rendered first) in the list as the default item size. 
-This can lead to inaccurate scroll thumb size or scroll jumps if the last item is unusually tall (for example, an attachment). 
-To improve this behavior, set the `defaultItemHeight` property to a value close (or equal to) the height of the usual messages. 
+By default, the virtualized message list uses the latest message (which gets rendered first) in the list as the default item size.
+This can lead to inaccurate scroll thumb size or scroll jumps if the last item is unusually tall (for example, an attachment).
+To improve this behavior, set the `defaultItemHeight` property to a value close (or equal to) the height of the usual messages.
 
 ```jsx
 <VirtualizedMessageList messages={customMessages} defaultItemHeight={76} />
@@ -79,6 +79,14 @@ Custom message render function, overrides the default `messageRenderer` function
 | Type                                                               |
 | ------------------------------------------------------------------ |
 | ( messages: StreamMessage[], index: number ) => React.ReactElement |
+
+### defaultItemHeight
+
+If set, the default item height is used for the calculation of the total list height. Use if you expect messages with a lot of height variance.
+
+| Type   |
+| ------ |
+| number |
 
 ### disableDateSeparator
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-markdown": "^5.0.3",
     "react-player": "^2.7.0",
     "react-textarea-autosize": "^8.3.0",
-    "react-virtuoso": "^1.10.4",
+    "react-virtuoso": "^1.10.6",
     "textarea-caret": "^3.1.0",
     "uuid": "^8.3.1"
   },

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -73,6 +73,7 @@ const VirtualizedMessageListWithContext = <
   const {
     channel,
     customMessageRenderer,
+    defaultItemHeight,
     disableDateSeparator = true,
     hasMore,
     hideDeletedMessages = false,
@@ -291,6 +292,7 @@ const VirtualizedMessageListWithContext = <
           style={{ overflowX: 'hidden' }}
           totalCount={processedMessages.length}
           {...(scrollSeekPlaceHolder ? { scrollSeek: scrollSeekPlaceHolder } : {})}
+          {...(defaultItemHeight ? { defaultItemHeight } : {})}
         />
         <div className='str-chat__list-notifications'>
           <MessageNotification onClick={scrollToBottom} showNotification={newMessagesNotification}>
@@ -317,6 +319,8 @@ export type VirtualizedMessageListProps<
     messageList: StreamMessage<At, Ch, Co, Ev, Me, Re, Us>[],
     index: number,
   ) => React.ReactElement;
+  /** If set, the default item height is used for the calculation of the total list height. Use if you expect messages with a lot of height variance */
+  defaultItemHeight?: number;
   /** Disables the injection of date separator components, defaults to `true` */
   disableDateSeparator?: boolean;
   /** Whether or not the list has more items to load */

--- a/src/components/MessageList/hooks/useNewMessageNotification.ts
+++ b/src/components/MessageList/hooks/useNewMessageNotification.ts
@@ -22,6 +22,10 @@ export function useNewMessageNotification<
   Us extends DefaultUserType<Us> = DefaultUserType
 >(messages: StreamMessage<At, Ch, Co, Ev, Me, Re, Us>[], currentUserId?: string) {
   const [newMessagesNotification, setNewMessagesNotification] = useState(false);
+  /**
+   * use the flag to avoid the initial "new messages" quick blink
+   */
+  const didMount = useRef(false);
 
   const lastMessageId = useRef('');
   const atBottom = useRef(false);
@@ -41,10 +45,11 @@ export function useNewMessageNotification<
     if (atBottom.current) return;
 
     /* if the new message belongs to current user scroll to bottom */
-    if (lastMessage.user?.id !== currentUserId) {
+    if (lastMessage.user?.id !== currentUserId && didMount.current) {
       /* otherwise just show newMessage notification  */
       setNewMessagesNotification(true);
     }
+    didMount.current = true;
   }, [currentUserId, messages]);
 
   return { atBottom, newMessagesNotification, setNewMessagesNotification };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9441,10 +9441,10 @@ react-view-pager@^0.6.0:
     resize-observer-polyfill "1.5.0"
     tabbable "1.1.2"
 
-react-virtuoso@^1.10.4:
-  version "1.10.4"
-  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-1.10.4.tgz#c7ec91f98c3e65f3d98a41df1e01d305b523ba0a"
-  integrity sha512-rWXr61gASl+KDEwakwgxoSL+uwuevSsu1wQyDzeCdIN+PgbGfLOcvEsFoTt96E4+VWQ5BawZYkh8iNUgQpucXw==
+react-virtuoso@^1.10.6:
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-1.10.6.tgz#f20bed0040c29253a7be9f104a900c40384f6a17"
+  integrity sha512-cEv6QiYwChHV2ozTWP6UMaopKaJBAuvHdzIxuZ2Wow71Ka6EZRLvwkYOqCmWSprWiueOiwr7TK+zrosjH2CtzQ==
   dependencies:
     "@virtuoso.dev/react-urx" "^0.2.5"
     "@virtuoso.dev/urx" "^0.2.5"


### PR DESCRIPTION
- Expose `defaultItemHeight` prop to smooth out long uneven lists
- Fix quick "new messages" blink when loaded or switching channels