### PR TITLE
Allow Textarea to grow

### DIFF
--- a/src/components/AutoCompleteTextarea/Textarea.js
+++ b/src/components/AutoCompleteTextarea/Textarea.js
@@ -459,7 +459,6 @@ export class ReactTextareaAutocomplete extends React.Component {
       'disableMentions',
       'dropdownClassName',
       'dropdownStyle',
-      'grow',
       'handleSubmit',
       'innerRef',
       'itemClassName',
@@ -718,12 +717,8 @@ export class ReactTextareaAutocomplete extends React.Component {
 
   render() {
     const { className, containerClassName, containerStyle, style } = this.props;
-
-    let { maxRows } = this.props;
-
+    const { maxRows } = this.props;
     const { dataLoading, value } = this.state;
-
-    if (!this.props.grow) maxRows = 1;
 
     return (
       <div


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

This adds back the ability for `<Textarea>` (and all the components who internally use it) to grow using the props `grow` and `maxRows`, as described in #1142
