### PR TITLE
Message options updates

### DIFF
--- a/src/components/Message/MessageOptions.tsx
+++ b/src/components/Message/MessageOptions.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
-import { ReactionIcon, ThreadIcon } from './icons';
+import {
+  ActionsIcon as DefaultActionsIcon,
+  ReactionIcon as DefaultReactionIcon,
+  ThreadIcon as DefaultThreadIcon,
+} from './icons';
 import { MESSAGE_ACTIONS, showMessageActionsBox } from './utils';
 
 import { MessageActions } from '../MessageActions';
@@ -26,10 +30,13 @@ export type MessageOptionsProps<
   Re extends DefaultReactionType = DefaultReactionType,
   Us extends DefaultUserType<Us> = DefaultUserType
 > = Partial<Pick<MessageContextValue<At, Ch, Co, Ev, Me, Re, Us>, 'handleOpenThread'>> & {
+  ActionsIcon?: React.FunctionComponent;
   displayLeft?: boolean;
   displayReplies?: boolean;
   messageWrapperRef?: React.RefObject<HTMLDivElement>;
+  ReactionIcon?: React.FunctionComponent;
   theme?: string;
+  ThreadIcon?: React.FunctionComponent;
 };
 
 const UnMemoizedMessageOptions = <
@@ -44,11 +51,14 @@ const UnMemoizedMessageOptions = <
   props: MessageOptionsProps<At, Ch, Co, Ev, Me, Re, Us>,
 ) => {
   const {
+    ActionsIcon = DefaultActionsIcon,
     displayLeft = true,
     displayReplies = true,
     handleOpenThread: propHandleOpenThread,
     messageWrapperRef,
+    ReactionIcon = DefaultReactionIcon,
     theme = 'simple',
+    ThreadIcon = DefaultThreadIcon,
   } = props;
 
   const {
@@ -85,7 +95,9 @@ const UnMemoizedMessageOptions = <
   if (isMyMessage() && displayLeft) {
     return (
       <div className={`str-chat__message-${theme}__actions`} data-testid='message-options-left'>
-        {showActionsBox && <MessageActions messageWrapperRef={messageWrapperRef} />}
+        {showActionsBox && (
+          <MessageActions ActionsIcon={ActionsIcon} messageWrapperRef={messageWrapperRef} />
+        )}
         {shouldShowReplies && (
           <div
             className={`str-chat__message-${theme}__actions__action str-chat__message-${theme}__actions__action--thread`}
@@ -128,7 +140,9 @@ const UnMemoizedMessageOptions = <
           <ThreadIcon />
         </div>
       )}
-      {showActionsBox && <MessageActions messageWrapperRef={messageWrapperRef} />}
+      {showActionsBox && (
+        <MessageActions ActionsIcon={ActionsIcon} messageWrapperRef={messageWrapperRef} />
+      )}
     </div>
   );
 };

--- a/src/components/Message/icons.tsx
+++ b/src/components/Message/icons.tsx
@@ -12,6 +12,15 @@ import type {
   DefaultUserType,
 } from '../../types/types';
 
+export const ActionsIcon = () => (
+  <svg height='4' viewBox='0 0 11 4' width='11' xmlns='http://www.w3.org/2000/svg'>
+    <path
+      d='M1.5 3a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z'
+      fillRule='nonzero'
+    />
+  </svg>
+);
+
 export const ReplyIcon = () => (
   <svg height='15' width='18' xmlns='http://www.w3.org/2000/svg'>
     <path

--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -25,6 +25,15 @@ type MessageContextPropsToPick =
   | 'handlePin'
   | 'message';
 
+export const ActionsEmoji: React.FC = () => (
+  <svg height='4' viewBox='0 0 11 4' width='11' xmlns='http://www.w3.org/2000/svg'>
+    <path
+      d='M1.5 3a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z'
+      fillRule='nonzero'
+    />
+  </svg>
+);
+
 export type MessageActionsProps<
   At extends DefaultAttachmentType = DefaultAttachmentType,
   Ch extends DefaultChannelType = DefaultChannelType,
@@ -34,6 +43,7 @@ export type MessageActionsProps<
   Re extends DefaultReactionType = DefaultReactionType,
   Us extends DefaultUserType<Us> = DefaultUserType
 > = Partial<Pick<MessageContextValue<At, Ch, Co, Ev, Me, Re, Us>, MessageContextPropsToPick>> & {
+  CustomActionsEmoji?: React.FunctionComponent;
   customWrapperClass?: string;
   inline?: boolean;
   messageWrapperRef?: React.RefObject<HTMLDivElement>;
@@ -52,6 +62,7 @@ export const MessageActions = <
   props: MessageActionsProps<At, Ch, Co, Ev, Me, Re, Us>,
 ) => {
   const {
+    CustomActionsEmoji = ActionsEmoji,
     customWrapperClass = '',
     getMessageActions: propGetMessageActions,
     handleDelete: propHandleDelete,
@@ -133,12 +144,7 @@ export const MessageActions = <
         mine={mine ? mine() : isMyMessage()}
         open={actionsBoxOpen}
       />
-      <svg height='4' viewBox='0 0 11 4' width='11' xmlns='http://www.w3.org/2000/svg'>
-        <path
-          d='M1.5 3a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z'
-          fillRule='nonzero'
-        />
-      </svg>
+      <CustomActionsEmoji />
     </MessageActionsWrapper>
   );
 };

--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { ActionsIcon as DefaultActionsIcon } from '../Message/icons';
-
 import { MessageActionsBox } from './MessageActionsBox';
+
+import { ActionsIcon as DefaultActionsIcon } from '../Message/icons';
 
 import { isUserMuted } from '../Message/utils';
 
@@ -55,7 +55,7 @@ export const MessageActions = <
   props: MessageActionsProps<At, Ch, Co, Ev, Me, Re, Us>,
 ) => {
   const {
-    ActionsIcon,
+    ActionsIcon = DefaultActionsIcon,
     customWrapperClass = '',
     getMessageActions: propGetMessageActions,
     handleDelete: propHandleDelete,
@@ -92,7 +92,6 @@ export const MessageActions = <
   const isMuted = useCallback(() => isUserMuted(message, mutes), [message, mutes]);
 
   const hideOptions = useCallback(() => setActionsBoxOpen(false), []);
-  const Icon = ActionsIcon || DefaultActionsIcon;
   const messageActions = getMessageActions();
   const messageDeletedAt = !!message?.deleted_at;
 
@@ -137,7 +136,7 @@ export const MessageActions = <
         mine={mine ? mine() : isMyMessage()}
         open={actionsBoxOpen}
       />
-      <Icon />
+      <ActionsIcon />
     </MessageActionsWrapper>
   );
 };

--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
+import { ActionsIcon as DefaultActionsIcon } from '../Message/icons';
+
 import { MessageActionsBox } from './MessageActionsBox';
 
 import { isUserMuted } from '../Message/utils';
@@ -25,15 +27,6 @@ type MessageContextPropsToPick =
   | 'handlePin'
   | 'message';
 
-export const ActionsEmoji: React.FC = () => (
-  <svg height='4' viewBox='0 0 11 4' width='11' xmlns='http://www.w3.org/2000/svg'>
-    <path
-      d='M1.5 3a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z'
-      fillRule='nonzero'
-    />
-  </svg>
-);
-
 export type MessageActionsProps<
   At extends DefaultAttachmentType = DefaultAttachmentType,
   Ch extends DefaultChannelType = DefaultChannelType,
@@ -43,7 +36,7 @@ export type MessageActionsProps<
   Re extends DefaultReactionType = DefaultReactionType,
   Us extends DefaultUserType<Us> = DefaultUserType
 > = Partial<Pick<MessageContextValue<At, Ch, Co, Ev, Me, Re, Us>, MessageContextPropsToPick>> & {
-  CustomActionsEmoji?: React.FunctionComponent;
+  ActionsIcon?: React.FunctionComponent;
   customWrapperClass?: string;
   inline?: boolean;
   messageWrapperRef?: React.RefObject<HTMLDivElement>;
@@ -62,7 +55,7 @@ export const MessageActions = <
   props: MessageActionsProps<At, Ch, Co, Ev, Me, Re, Us>,
 ) => {
   const {
-    CustomActionsEmoji = ActionsEmoji,
+    ActionsIcon,
     customWrapperClass = '',
     getMessageActions: propGetMessageActions,
     handleDelete: propHandleDelete,
@@ -99,6 +92,8 @@ export const MessageActions = <
   const isMuted = useCallback(() => isUserMuted(message, mutes), [message, mutes]);
 
   const hideOptions = useCallback(() => setActionsBoxOpen(false), []);
+
+  const Icon = ActionsIcon || DefaultActionsIcon;
 
   const messageActions = getMessageActions();
   const messageDeletedAt = !!message?.deleted_at;
@@ -144,7 +139,7 @@ export const MessageActions = <
         mine={mine ? mine() : isMyMessage()}
         open={actionsBoxOpen}
       />
-      <CustomActionsEmoji />
+      <Icon />
     </MessageActionsWrapper>
   );
 };

--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -92,9 +92,7 @@ export const MessageActions = <
   const isMuted = useCallback(() => isUserMuted(message, mutes), [message, mutes]);
 
   const hideOptions = useCallback(() => setActionsBoxOpen(false), []);
-
   const Icon = ActionsIcon || DefaultActionsIcon;
-
   const messageActions = getMessageActions();
   const messageDeletedAt = !!message?.deleted_at;
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '6.5.1';
+export const version = '6.6.0';


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Added `ActionsIcon`, `ReactionIcon`, `ThreadIcon` props to the `MessageOptions` component to override the SVGs within.
