### PR TITLE
fix mentions list to not include muted users

### DIFF
--- a/src/components/MessageInput/hooks/useUserTrigger.ts
+++ b/src/components/MessageInput/hooks/useUserTrigger.ts
@@ -126,7 +126,7 @@ export const useUserTrigger = <
 
       const filterMutes = (data: UserResponse<Us>[]) => {
         if (!mutes.length) return data;
-        return data.filter((suggestion) => mutes.some((mute) => mute.target.id === suggestion.id));
+        return data.filter((suggestion) => mutes.some((mute) => mute.target.id !== suggestion.id));
       };
 
       if (mentionAllAppUsers) {


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Fix a bug that actually incorrectly only included muted users as mention options instead of the reverse.

### 🛠 Implementation details

Updated the conditional in the `filterMutes` method.

### 🎨 UI Changes

None