### PR TITLE
add setText to message input context

### DIFF
--- a/docusaurus/docs/React/contexts/message-input-context.mdx
+++ b/docusaurus/docs/React/contexts/message-input-context.mdx
@@ -202,8 +202,8 @@ Opens the `EmojiPicker` component on Enter or Spacebar key down.
 
 Function that runs onSubmit to the underlying `textarea` component.
 
-| Type                                                                  |
-| --------------------------------------------------------------------- |
+| Type                                                                   |
+| ---------------------------------------------------------------------- |
 | (event: React.BaseSyntheticEvent, customMessageData?: Message) => void |
 
 ### imageOrder
@@ -400,6 +400,14 @@ React state hook function that sets the `cooldownRemaining` value.
 | Type                                          |
 | --------------------------------------------- |
 | React.Dispatch<React.SetStateAction<number\>> |
+
+### setText
+
+Function that overrides and sets the text value of the underlying `textarea` component.
+
+| Type                   |
+| ---------------------- |
+| (text: string) => void |
 
 ### showCommandsList
 

--- a/src/components/MessageInput/hooks/useMessageInputState.ts
+++ b/src/components/MessageInput/hooks/useMessageInputState.ts
@@ -63,6 +63,7 @@ export type MessageInputState<
   imageOrder: string[];
   imageUploads: { [id: string]: ImageUpload };
   mentioned_users: UserResponse<Us>[];
+  setText: (text: string) => void;
   text: string;
 };
 
@@ -177,6 +178,7 @@ const initState = <
       imageOrder: [],
       imageUploads: { ...emptyImageUploads },
       mentioned_users: [],
+      setText: () => null,
       text: '',
     };
   }
@@ -233,6 +235,7 @@ const initState = <
     imageOrder,
     imageUploads,
     mentioned_users,
+    setText: () => null,
     text: message.text || '',
   };
 };
@@ -418,6 +421,10 @@ export const useMessageInputState = <
     dispatch({ type: 'addMentionedUser', user: item });
   }, []);
 
+  const setText = useCallback((text: string) => {
+    dispatch({ getNewText: () => text, type: 'setText' });
+  }, []);
+
   return {
     ...state,
     closeCommandsList,
@@ -442,6 +449,7 @@ export const useMessageInputState = <
     openEmojiPicker,
     removeFile,
     removeImage,
+    setText,
     showCommandsList,
     textareaRef,
     uploadFile,


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Provide a function that easily overrides and sets the MessageInput text value

### 🛠 Implementation details

Add `setText` function that dispatches an action on our MessageInput reducer

### 🎨 UI Changes

None
