### PR TITLE
attachment type documentation

### DIFF
--- a/docusaurus/docs/React/contexts/message-input-context.mdx
+++ b/docusaurus/docs/React/contexts/message-input-context.mdx
@@ -299,7 +299,7 @@ If provided, the existing message will be edited on submit.
 
 ### noFiles
 
-If true, disables file uploads.
+If true, disables file uploads for all attachments except for those with type 'image'.
 
 | Type    | Default |
 | ------- | ------- |

--- a/docusaurus/docs/React/message-components/attachment.mdx
+++ b/docusaurus/docs/React/message-components/attachment.mdx
@@ -7,13 +7,13 @@ title: Attachments
 The `Attachment` component takes a list of message attachments and conditionally renders the UI of each individual attachment based
 upon its type. The following table shows the attachment UI components that will be rendered for various attachment types:
 
-| Attachment Type | UI Component                                                                                                    |
-| --------------- | --------------------------------------------------------------------------------------------------------------- |
-| `audio`         | [Audio](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Attachment/Audio.tsx)         |
-| `file`          | [File](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Attachment/FileAttachment.tsx) |
-| `gallery`       | [Gallery](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Gallery/Gallery.tsx)        |
-| `image`         | [Image](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Gallery/Image.tsx)            |
-| `video`         | [ReactPlayer](https://github.com/cookpete/react-player/blob/master/src/ReactPlayer.js)                          |
+| Attachment Type | UI Component                                                                                                    |  File type(s) (non-exhaustive)                         |
+| --------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `audio`         | [Audio](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Attachment/Audio.tsx)         | MP3, WAV, M4A, FLAC, AAC                               |
+| `file`          | [File](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Attachment/FileAttachment.tsx) | DOC, DOCX, PDF, PPT, PPTX, TXT, XLS, XLSX              |
+| `gallery`       | [Gallery](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Gallery/Gallery.tsx)        | when a message has more than 1 'image' type attachment |
+| `image`         | [Image](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Gallery/Image.tsx)            | HEIC, GIF, JPEG, JPG, PNG, TIFF, BMP                   |
+| `video`         | [ReactPlayer](https://github.com/cookpete/react-player/blob/master/src/ReactPlayer.js)                          | MP4, OGG, WEBM, Quicktime(QTFF, QT, or MOV)            |
 
 Message attachments that do not conform to one of the above types are rendered with the
 [Card](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Attachment/Card.tsx) component.

--- a/docusaurus/docs/React/message-input-components/message-input.mdx
+++ b/docusaurus/docs/React/message-input-components/message-input.mdx
@@ -161,7 +161,7 @@ If provided, the existing message will be edited on submit.
 
 ### noFiles
 
-If true, disables file uploads.
+If true, disables file uploads for all attachments except for those with type 'image'.
 
 | Type    | Default |
 | ------- | ------- |

--- a/src/components/MessageInput/MessageInput.tsx
+++ b/src/components/MessageInput/MessageInput.tsx
@@ -81,7 +81,7 @@ export type MessageInputProps<
   mentionQueryParams?: SearchQueryParams<Us>['userFilters'];
   /** If provided, the existing message will be edited on submit */
   message?: StreamMessage<At, Ch, Co, Ev, Me, Re, Us>;
-  /** If true, disables file uploads. Default: false */
+  /** If true, disables file uploads for all attachments except for those with type 'image'. Default: false */
   noFiles?: boolean;
   /** Function to override the default submit handler */
   overrideSubmitHandler?: (


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Provide clarification to Attachment documentation.

### 🛠 Implementation details

Add Attachment file types to documentation, as well as more info for `noFiles` `MessageInput` prop.

### 🎨 UI Changes

None.
