### PR TITLE
support emoji as first character in avatar name

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -48,7 +48,16 @@ export const Avatar = <Us extends DefaultUserType<Us> = DefaultUserType>(
     setLoaded(false);
   }, [image]);
 
-  const initials = (name?.toString() || '').charAt(0);
+  function containsUnicodeCodePoints(name: string) {
+    // eslint-disable-next-line no-control-regex
+    return /[^\u0000-\u00ff]/.test(name);
+  }
+
+  const nameStr = name?.toString() || '';
+
+  const initials = containsUnicodeCodePoints(nameStr.slice(0, 2))
+    ? nameStr.slice(0, 2)
+    : nameStr.charAt(0);
 
   return (
     <div

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '6.7.2';
+export const version = '6.8.0';


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Allow the Avatar fallback logic to display an emoji if one is the first character in a user's name

### 🛠 Implementation details

Add a regex check that tests to see if the first two characters comprise a unicode emoji

### 🎨 UI Changes

None
