### PR TITLE
prevent user watch events from updating channel state

### DIFF
--- a/examples/typescript/yarn.lock
+++ b/examples/typescript/yarn.lock
@@ -10063,15 +10063,6 @@ react-view-pager@^0.6.0:
     resize-observer-polyfill "1.5.0"
     tabbable "1.1.2"
 
-react-virtuoso@^1.10.8:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-1.11.1.tgz#350dc88866b3f42cb396bf8f40b90efc6daaadde"
-  integrity sha512-NH8eLLmoowdq0x7/AEfXxOY9OY4PDpLuPPmCc8F2IoBQLvIcMait3A2TnR0fT9UT+gl8n7GHoORzeGqF5Ka0MA==
-  dependencies:
-    "@virtuoso.dev/react-urx" "^0.2.5"
-    "@virtuoso.dev/urx" "^0.2.5"
-    resize-observer-polyfill "^1.5.1"
-
 react-virtuoso@^1.5.8:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-1.9.1.tgz#e59b9b05e35152e0797dcd66b9aca457a2023407"
@@ -10081,6 +10072,14 @@ react-virtuoso@^1.5.8:
     "@virtuoso.dev/urx" "^0.2.5"
     react-app-polyfill "^1.0.6"
     resize-observer-polyfill "^1.5.1"
+
+react-virtuoso@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.2.1.tgz#a15dbd864745011a011ac5ee75be3c523fcb8ded"
+  integrity sha512-kS+9mns4slmpsUSQA/sIUjDwf9cA17Il8dvslHTuS5SpxCo7iRJIKJpjZd1ilLpvX3wYAYObbHVR3BxnUWRPfg==
+  dependencies:
+    "@virtuoso.dev/react-urx" "^0.2.5"
+    "@virtuoso.dev/urx" "^0.2.5"
 
 "react@link:../../node_modules/react":
   version "0.0.0"

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -363,6 +363,8 @@ const ChannelInner = <
       });
     }
 
+    if (event.type === 'user.watching.start' || event.type === 'user.watching.stop') return;
+
     if (event.type === 'typing.start' || event.type === 'typing.stop') {
       return dispatch({ channel, type: 'setTyping' });
     }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '6.8.0';
+export const version = '6.9.0';


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Prevent the message list from re-rendering when users join/leave a channel

### 🛠 Implementation details

Do not initiate an action to update the state returned from the channel reducer when user watch events are received

### 🎨 UI Changes

None
