### PR TITLE
add error messages to context consumer hooks

### DIFF
--- a/src/context/ChannelActionContext.tsx
+++ b/src/context/ChannelActionContext.tsx
@@ -92,8 +92,8 @@ export type ChannelActionContextValue<
   updateMessage: (message: StreamMessage<At, Ch, Co, Ev, Me, Re, Us>) => void;
 };
 
-export const ChannelActionContext = React.createContext<ChannelActionContextValue>(
-  {} as ChannelActionContextValue,
+export const ChannelActionContext = React.createContext<ChannelActionContextValue | undefined>(
+  undefined,
 );
 
 export const ChannelActionProvider = <
@@ -123,16 +123,21 @@ export const useChannelActionContext = <
   Me extends DefaultMessageType = DefaultMessageType,
   Re extends DefaultReactionType = DefaultReactionType,
   Us extends DefaultUserType<Us> = DefaultUserType
->() =>
-  (useContext(ChannelActionContext) as unknown) as ChannelActionContextValue<
-    At,
-    Ch,
-    Co,
-    Ev,
-    Me,
-    Re,
-    Us
-  >;
+>() => {
+  const contextValue = useContext(ChannelActionContext);
+
+  if (!contextValue) {
+    if (process.env.NODE_ENV === 'test') {
+      return {} as ChannelActionContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+    }
+
+    throw new Error(
+      'The useChannelActionContext hook was called outside of the ChannelActionContext provider. Make sure this hook is called within a child of the Channel component.',
+    );
+  }
+
+  return (contextValue as unknown) as ChannelActionContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+};
 
 /**
  * Typescript currently does not support partial inference, so if ChannelActionContext

--- a/src/context/ChannelStateContext.tsx
+++ b/src/context/ChannelStateContext.tsx
@@ -83,8 +83,8 @@ export type ChannelStateContextValue<
   watcher_count?: number;
 };
 
-export const ChannelStateContext = React.createContext<ChannelStateContextValue>(
-  {} as ChannelStateContextValue,
+export const ChannelStateContext = React.createContext<ChannelStateContextValue | undefined>(
+  undefined,
 );
 
 export const ChannelStateProvider = <
@@ -114,16 +114,21 @@ export const useChannelStateContext = <
   Me extends DefaultMessageType = DefaultMessageType,
   Re extends DefaultReactionType = DefaultReactionType,
   Us extends DefaultUserType<Us> = DefaultUserType
->() =>
-  (useContext(ChannelStateContext) as unknown) as ChannelStateContextValue<
-    At,
-    Ch,
-    Co,
-    Ev,
-    Me,
-    Re,
-    Us
-  >;
+>() => {
+  const contextValue = useContext(ChannelStateContext);
+
+  if (!contextValue) {
+    if (process.env.NODE_ENV === 'test') {
+      return {} as ChannelStateContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+    }
+
+    throw new Error(
+      'The useChannelStateContext hook was called outside of the ChannelStateContext provider. Make sure this hook is called within a child of the Channel component.',
+    );
+  }
+
+  return (contextValue as unknown) as ChannelStateContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+};
 
 /**
  * Typescript currently does not support partial inference, so if ChannelStateContext

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -53,7 +53,7 @@ export type ChatContextValue<
   navOpen?: boolean;
 };
 
-export const ChatContext = React.createContext({} as ChatContextValue);
+export const ChatContext = React.createContext<ChatContextValue | undefined>(undefined);
 
 export const ChatProvider = <
   At extends DefaultAttachmentType = DefaultAttachmentType,
@@ -82,7 +82,21 @@ export const useChatContext = <
   Me extends DefaultMessageType = DefaultMessageType,
   Re extends DefaultReactionType = DefaultReactionType,
   Us extends DefaultUserType<Us> = DefaultUserType
->() => (useContext(ChatContext) as unknown) as ChatContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+>() => {
+  const contextValue = useContext(ChatContext);
+
+  if (!contextValue) {
+    if (process.env.NODE_ENV === 'test') {
+      return {} as ChatContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+    }
+
+    throw new Error(
+      'The useChatContext hook was called outside of the ChatContext provider. Make sure this hook is called within a child of the Chat component.',
+    );
+  }
+
+  return (contextValue as unknown) as ChatContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+};
 
 /**
  * Typescript currently does not support partial inference so if ChatContext

--- a/src/context/ComponentContext.tsx
+++ b/src/context/ComponentContext.tsx
@@ -90,9 +90,7 @@ export type ComponentContextValue<
   VirtualMessage?: React.ComponentType<FixedHeightMessageProps<At, Ch, Co, Ev, Me, Re, Us>>;
 };
 
-export const ComponentContext = React.createContext<ComponentContextValue>(
-  {} as ComponentContextValue,
-);
+export const ComponentContext = React.createContext<ComponentContextValue | undefined>(undefined);
 
 export const ComponentProvider = <
   At extends DefaultAttachmentType = DefaultAttachmentType,
@@ -123,8 +121,21 @@ export const useComponentContext = <
   Re extends DefaultReactionType = DefaultReactionType,
   Us extends DefaultUserType<Us> = DefaultUserType,
   V extends CustomTrigger = CustomTrigger
->() =>
-  (useContext(ComponentContext) as unknown) as ComponentContextValue<At, Ch, Co, Ev, Me, Re, Us, V>;
+>() => {
+  const contextValue = useContext(ComponentContext);
+
+  if (!contextValue) {
+    if (process.env.NODE_ENV === 'test') {
+      return {} as ComponentContextValue<At, Ch, Co, Ev, Me, Re, Us, V>;
+    }
+
+    throw new Error(
+      'The useComponentContext hook was called outside of the ComponentContext provider. Make sure this hook is called within a child of the Channel component.',
+    );
+  }
+
+  return contextValue as ComponentContextValue<At, Ch, Co, Ev, Me, Re, Us, V>;
+};
 
 /**
  * Typescript currently does not support partial inference, so if ComponentContext

--- a/src/context/EmojiContext.tsx
+++ b/src/context/EmojiContext.tsx
@@ -61,7 +61,7 @@ const DefaultEmojiPicker = React.lazy(async () => {
   return { default: emojiPicker.default };
 });
 
-export const EmojiContext = React.createContext<EmojiContextValue>({} as EmojiContextValue);
+export const EmojiContext = React.createContext<EmojiContextValue | undefined>(undefined);
 
 export const EmojiProvider = ({
   children,
@@ -86,8 +86,19 @@ export const EmojiProvider = ({
   return <EmojiContext.Provider value={emojiContextValue}>{children}</EmojiContext.Provider>;
 };
 
-export const useEmojiContext = () =>
-  (useContext(EmojiContext) as unknown) as Required<EmojiContextValue>;
+export const useEmojiContext = () => {
+  const contextValue = useContext(EmojiContext);
+
+  if (!contextValue) {
+    if (process.env.NODE_ENV === 'test') return {} as Required<EmojiContextValue>;
+
+    throw new Error(
+      'The useEmojiContext hook was called outside of the EmojiContext provider. Make sure this hook is called within a child of the Channel component.',
+    );
+  }
+
+  return contextValue as Required<EmojiContextValue>;
+};
 
 /**
  * Typescript currently does not support partial inference, so if EmojiContext

--- a/src/context/MessageContext.tsx
+++ b/src/context/MessageContext.tsx
@@ -137,7 +137,7 @@ export type MessageContextValue<
   unsafeHTML?: boolean;
 };
 
-export const MessageContext = React.createContext<MessageContextValue>({} as MessageContextValue);
+export const MessageContext = React.createContext<MessageContextValue | undefined>(undefined);
 
 export const MessageProvider = <
   At extends DefaultAttachmentType = DefaultAttachmentType,
@@ -166,7 +166,21 @@ export const useMessageContext = <
   Me extends DefaultMessageType = DefaultMessageType,
   Re extends DefaultReactionType = DefaultReactionType,
   Us extends DefaultUserType<Us> = DefaultUserType
->() => (useContext(MessageContext) as unknown) as MessageContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+>() => {
+  const contextValue = useContext(MessageContext);
+
+  if (!contextValue) {
+    if (process.env.NODE_ENV === 'test') {
+      return {} as MessageContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+    }
+
+    throw new Error(
+      "The useMessageContext hook was called outside of the MessageContext provider. Make sure this hook is called within the Message's UI component.",
+    );
+  }
+
+  return (contextValue as unknown) as MessageContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+};
 
 /**
  * Typescript currently does not support partial inference, so if MessageContext

--- a/src/context/MessageInputContext.tsx
+++ b/src/context/MessageInputContext.tsx
@@ -57,9 +57,6 @@ export const MessageInputContextProvider = <
   </MessageInputContext.Provider>
 );
 
-/**
- * hook for MessageInput context
- */
 export const useMessageInputContext = <
   At extends DefaultAttachmentType = DefaultAttachmentType,
   Ch extends DefaultChannelType = DefaultChannelType,
@@ -71,9 +68,14 @@ export const useMessageInputContext = <
   V extends CustomTrigger = CustomTrigger
 >() => {
   const contextValue = useContext(MessageInputContext);
-  if (contextValue === undefined) {
-    console.warn(
-      'Empty MessageInputContext consumed. Make sure you wrap every component that uses MessageInputContext with a MessageInputContextProvider',
+
+  if (!contextValue) {
+    if (process.env.NODE_ENV === 'test') {
+      return {} as MessageInputContextValue<At, Ch, Co, Ev, Me, Re, Us, V>;
+    }
+
+    throw new Error(
+      "The useMessageInputContext hook was called outside of the MessageInputContext provider. Make sure this hook is called within the MessageInput's UI component.",
     );
   }
 

--- a/src/context/TranslationContext.tsx
+++ b/src/context/TranslationContext.tsx
@@ -66,7 +66,17 @@ export const TranslationProvider: React.FC<{
   <TranslationContext.Provider value={value}>{children}</TranslationContext.Provider>
 );
 
-export const useTranslationContext = () => useContext(TranslationContext);
+export const useTranslationContext = () => {
+  const contextValue = useContext(TranslationContext);
+
+  if (!contextValue) {
+    throw new Error(
+      'The useTranslationContext hook was called outside of the TranslationContext provider. Make sure this hook is called within a child of the Chat component.',
+    );
+  }
+
+  return contextValue;
+};
 
 export const withTranslationContext = <P extends UnknownType>(
   Component: React.ComponentType<P>,

--- a/src/context/TypingContext.tsx
+++ b/src/context/TypingContext.tsx
@@ -25,7 +25,7 @@ export type TypingContextValue<
   typing?: StreamChannelState<At, Ch, Co, Ev, Me, Re, Us>['typing'];
 };
 
-export const TypingContext = React.createContext<TypingContextValue>({} as TypingContextValue);
+export const TypingContext = React.createContext<TypingContextValue | undefined>(undefined);
 
 export const TypingProvider = <
   At extends DefaultAttachmentType = DefaultAttachmentType,
@@ -54,7 +54,21 @@ export const useTypingContext = <
   Me extends DefaultMessageType = DefaultMessageType,
   Re extends DefaultReactionType = DefaultReactionType,
   Us extends DefaultUserType<Us> = DefaultUserType
->() => (useContext(TypingContext) as unknown) as TypingContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+>() => {
+  const contextValue = useContext(TypingContext);
+
+  if (!contextValue) {
+    if (process.env.NODE_ENV === 'test') {
+      return {} as TypingContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+    }
+
+    throw new Error(
+      'The useTypingContext hook was called outside of the TypingContext provider. Make sure this hook is called within a child of the Channel component.',
+    );
+  }
+
+  return contextValue as TypingContextValue<At, Ch, Co, Ev, Me, Re, Us>;
+};
 
 /**
  * Typescript currently does not support partial inference, so if TypingContext

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '6.8.0';
+export const version = '6.9.0';


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Provide better error messaging when clients call our context hooks outside of the context provider

### 🛠 Implementation details

Throw an error for each hook if the context value is undefined

### 🎨 UI Changes

<img width="1080" alt="Screen Shot 2021-09-27 at 1 58 25 PM" src="https://user-images.githubusercontent.com/43552931/134983189-10c81669-f3a8-4d19-93b0-2a9f61fadeae.png">

