### PR TITLE
add cooldowninterval to input memoization

### DIFF
--- a/src/components/MessageInput/hooks/useCreateMessageInputContext.ts
+++ b/src/components/MessageInput/hooks/useCreateMessageInputContext.ts
@@ -151,6 +151,7 @@ export const useCreateMessageInputContext = <
       useMentionsTransliteration,
     }),
     [
+      cooldownInterval,
       editing,
       emojiPickerIsOpen,
       fileUploadsValue,

--- a/src/components/MessageInput/hooks/useCreateMessageInputContext.ts
+++ b/src/components/MessageInput/hooks/useCreateMessageInputContext.ts
@@ -32,6 +32,7 @@ export const useCreateMessageInputContext = <
     closeCommandsList,
     closeEmojiPicker,
     cooldownInterval,
+    cooldownRemaining,
     disabled,
     disableMentions,
     doFileUploadRequest,
@@ -102,6 +103,7 @@ export const useCreateMessageInputContext = <
       closeCommandsList,
       closeEmojiPicker,
       cooldownInterval,
+      cooldownRemaining,
       disabled,
       disableMentions,
       doFileUploadRequest,
@@ -152,6 +154,7 @@ export const useCreateMessageInputContext = <
     }),
     [
       cooldownInterval,
+      cooldownRemaining,
       editing,
       emojiPickerIsOpen,
       fileUploadsValue,


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Add `CooldownInterval` to the `MessageInput` memoization hook.

### 🛠 Implementation details

Add `CooldownInterval` to the `MessageInput` memoization hook.

### 🎨 UI Changes

None.
