### PR TITLE
update user info in messages when subscribe to presence events

### DIFF
--- a/src/components/Channel/hooks/useCreateChannelStateContext.ts
+++ b/src/components/Channel/hooks/useCreateChannelStateContext.ts
@@ -75,27 +75,27 @@ export const useCreateChannelStateContext = <
     ? messages
     : messages
         .map(
-          ({ deleted_at, latest_reactions, pinned, reply_count, status, updated_at }) =>
+          ({ deleted_at, latest_reactions, pinned, reply_count, status, updated_at, user }) =>
             `${deleted_at}${
               latest_reactions ? latest_reactions.map(({ type }) => type).join() : ''
             }${pinned}${reply_count}${status}${
               updated_at && (isDayOrMoment(updated_at) || isDate(updated_at))
                 ? updated_at.toISOString()
                 : updated_at || ''
-            }`,
+            }${user?.image}${user?.name}`,
         )
         .join();
 
   const memoizedThreadMessageData = threadMessages
     .map(
-      ({ deleted_at, latest_reactions, pinned, status, updated_at }) =>
+      ({ deleted_at, latest_reactions, pinned, status, updated_at, user }) =>
         `${deleted_at}${
           latest_reactions ? latest_reactions.map(({ type }) => type).join() : ''
         }${pinned}${status}${
           updated_at && (isDayOrMoment(updated_at) || isDate(updated_at))
             ? updated_at.toISOString()
             : updated_at || ''
-        }`,
+        }${user?.image}${user?.name}`,
     )
     .join();
 

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -253,7 +253,9 @@ export const areMessagePropsEqual = <
     prevMessage.status === nextMessage.status &&
     prevMessage.text === nextMessage.text &&
     prevMessage.type === nextMessage.type &&
-    prevMessage.updated_at === nextMessage.updated_at;
+    prevMessage.updated_at === nextMessage.updated_at &&
+    prevMessage.user?.image === nextMessage.user?.image &&
+    prevMessage.user?.name === nextMessage.user?.name;
 
   if (!messagesAreEqual) return false;
 
@@ -314,7 +316,9 @@ export const areMessageUIPropsEqual = <
     prevMessage.status === nextMessage.status &&
     prevMessage.text === nextMessage.text &&
     prevMessage.type === nextMessage.type &&
-    prevMessage.updated_at === nextMessage.updated_at;
+    prevMessage.updated_at === nextMessage.updated_at &&
+    prevMessage.user?.image === nextMessage.user?.image &&
+    prevMessage.user?.name === nextMessage.user?.name;
 
   if (!messagesAreEqual) return false;
 


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Update user info in real time when clients are subscribed to presence events

### 🛠 Implementation details

Ensure memoization cases don't prevent messages from re-rendering when user name or image changes
