### PR TITLE
Also allow stream-chat 4.0.0 and up

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "peerDependencies": {
     "react": "^17.0.0 || ^16.8.0",
     "react-dom": "^17.0.0 || ^16.8.0",
-    "stream-chat": "^3.8.0"
+    "stream-chat": "^4.0.0 || ^3.8.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Allow stream-chat 4.0.0 to be used with this library.

### 🛠 Implementation details

I saw the newest api being used in examples so I assumed it should work. Not keeping peer dependencies up to date gives errors from npm v7 and up.
