### PR TITLE
fix: check for already encoded url

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -192,7 +192,7 @@ export const renderText = <Us extends DefaultUserType<Us> = DefaultUserType>(
 
     newText = newText.replace(
       new RegExp(escapeRegExp(value), 'g'),
-      `[${displayLink}](${encodeURI(href)})`,
+      `[${displayLink}](${encodeURI(decodeURI(href))})`,
     );
   });
 


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

To prevent already encoded uri from being double encoded 

### 🛠 Implementation details

decode the URI before encoding 
