### PR TITLE
focus input after emoji and attachment selection

### DIFF
--- a/docusaurus/docs/React/contexts/chat-context.mdx
+++ b/docusaurus/docs/React/contexts/chat-context.mdx
@@ -17,14 +17,6 @@ const { client, setActiveChannel } = useChatContext();
 
 ## Values
 
-### appSettings
-
-The available client-side app settings, includes image and file upload config.
-
-| Type   |
-| ------ |
-| object |
-
 ### client
 
 The `StreamChat` client instance. Any methods from the `stream-chat-js` API interface can be run off this object.
@@ -57,6 +49,14 @@ for implementation assistance.
 | Type   |
 | ------ |
 | object |
+
+### getAppSettings
+
+The callback function used to get available client-side app settings, includes image and file upload config.
+
+| Type     |
+| -------- |
+| function |
 
 ### mutes
 

--- a/docusaurus/docs/React/message-input-components/message-input.mdx
+++ b/docusaurus/docs/React/message-input-components/message-input.mdx
@@ -52,6 +52,14 @@ Function to clear the editing state while editing a message.
 | ---------- |
 | () => void |
 
+### closeEmojiPickerOnClick
+
+If true, picking an emoji from the `EmojiPicker` component will close the picker.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
 ### disabled
 
 If true, disables the text input.

--- a/src/components/MessageInput/MessageInput.tsx
+++ b/src/components/MessageInput/MessageInput.tsx
@@ -41,6 +41,8 @@ export type MessageInputProps<
   additionalTextareaProps?: React.TextareaHTMLAttributes<HTMLTextAreaElement>;
   /** Function to clear the editing state while editing a message */
   clearEditingState?: () => void;
+  /** If true, picking an emoji from the `EmojiPicker` component will close the picker */
+  closeEmojiPickerOnClick?: boolean;
   /** If true, disables the text input */
   disabled?: boolean;
   /** If true, the suggestion list will not display and autocomplete @mentions. Default: false. */

--- a/src/components/MessageInput/hooks/useAttachments.ts
+++ b/src/components/MessageInput/hooks/useAttachments.ts
@@ -37,6 +37,7 @@ export const useAttachments = <
   props: MessageInputProps<At, Ch, Co, Ev, Me, Re, Us, V>,
   state: MessageInputState<At, Us>,
   dispatch: React.Dispatch<MessageInputReducerAction<Us>>,
+  textareaRef: React.MutableRefObject<HTMLTextAreaElement | undefined>,
 ) => {
   const { noFiles } = props;
   const { fileUploads, imageUploads } = state;
@@ -84,12 +85,8 @@ export const useAttachments = <
             dispatch({ file, id, state: 'uploading', type: 'setFileUpload' });
           }
         });
-      const elements = document.getElementsByClassName('str-chat__textarea__textarea');
-      const textarea = elements.item(0);
 
-      if (textarea instanceof HTMLTextAreaElement) {
-        textarea.focus();
-      }
+      textareaRef?.current?.focus();
     },
     [maxFilesLeft, noFiles],
   );

--- a/src/components/MessageInput/hooks/useAttachments.ts
+++ b/src/components/MessageInput/hooks/useAttachments.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import { useCallback } from 'react';
 
 import { useImageUploads } from './useImageUploads';

--- a/src/components/MessageInput/hooks/useAttachments.ts
+++ b/src/components/MessageInput/hooks/useAttachments.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { useCallback } from 'react';
 
 import { useImageUploads } from './useImageUploads';
@@ -84,6 +85,12 @@ export const useAttachments = <
             dispatch({ file, id, state: 'uploading', type: 'setFileUpload' });
           }
         });
+      const elements = document.getElementsByClassName('str-chat__textarea__textarea');
+      const textarea = elements.item(0);
+
+      if (textarea instanceof HTMLTextAreaElement) {
+        textarea.focus();
+      }
     },
     [maxFilesLeft, noFiles],
   );

--- a/src/components/MessageInput/hooks/useEmojiPicker.ts
+++ b/src/components/MessageInput/hooks/useEmojiPicker.ts
@@ -68,10 +68,6 @@ export const useEmojiPicker = <
     };
   }, [closeEmojiPicker, state.emojiPickerIsOpen]);
 
-  // const onSelectEmoji = useCallback((emoji: EmojiData) => insertText((emoji as BaseEmoji).native), [
-  //   insertText,
-  // ]);
-
   const onSelectEmoji = useCallback(
     (emoji: EmojiData) => {
       insertText((emoji as BaseEmoji).native);

--- a/src/components/MessageInput/hooks/useEmojiPicker.ts
+++ b/src/components/MessageInput/hooks/useEmojiPicker.ts
@@ -12,6 +12,7 @@ export const useEmojiPicker = <
   state: MessageInputState<At, Us>,
   dispatch: React.Dispatch<MessageInputReducerAction<Us>>,
   insertText: (textToInsert: string) => void,
+  textareaRef: React.MutableRefObject<HTMLTextAreaElement | undefined>,
   closeEmojiPickerOnClick?: boolean,
 ) => {
   const emojiPickerRef = useRef<HTMLDivElement>(null);
@@ -78,12 +79,8 @@ export const useEmojiPicker = <
           value: false,
         });
       }
-      const elements = document.getElementsByClassName('str-chat__textarea__textarea');
-      const textarea = elements.item(0);
 
-      if (textarea instanceof HTMLTextAreaElement) {
-        textarea.focus();
-      }
+      textareaRef?.current?.focus();
     },
     [insertText],
   );

--- a/src/components/MessageInput/hooks/useEmojiPicker.ts
+++ b/src/components/MessageInput/hooks/useEmojiPicker.ts
@@ -12,6 +12,7 @@ export const useEmojiPicker = <
   state: MessageInputState<At, Us>,
   dispatch: React.Dispatch<MessageInputReducerAction<Us>>,
   insertText: (textToInsert: string) => void,
+  closeEmojiPickerOnClick?: boolean,
 ) => {
   const emojiPickerRef = useRef<HTMLDivElement>(null);
 
@@ -71,10 +72,12 @@ export const useEmojiPicker = <
   const onSelectEmoji = useCallback(
     (emoji: EmojiData) => {
       insertText((emoji as BaseEmoji).native);
-      dispatch({
-        type: 'setEmojiPickerIsOpen',
-        value: false,
-      });
+      if (closeEmojiPickerOnClick) {
+        dispatch({
+          type: 'setEmojiPickerIsOpen',
+          value: false,
+        });
+      }
       const elements = document.getElementsByClassName('str-chat__textarea__textarea');
       const textarea = elements.item(0);
 

--- a/src/components/MessageInput/hooks/useEmojiPicker.ts
+++ b/src/components/MessageInput/hooks/useEmojiPicker.ts
@@ -68,9 +68,26 @@ export const useEmojiPicker = <
     };
   }, [closeEmojiPicker, state.emojiPickerIsOpen]);
 
-  const onSelectEmoji = useCallback((emoji: EmojiData) => insertText((emoji as BaseEmoji).native), [
-    insertText,
-  ]);
+  // const onSelectEmoji = useCallback((emoji: EmojiData) => insertText((emoji as BaseEmoji).native), [
+  //   insertText,
+  // ]);
+
+  const onSelectEmoji = useCallback(
+    (emoji: EmojiData) => {
+      insertText((emoji as BaseEmoji).native);
+      dispatch({
+        type: 'setEmojiPickerIsOpen',
+        value: false,
+      });
+      const elements = document.getElementsByClassName('str-chat__textarea__textarea');
+      const textarea = elements.item(0);
+
+      if (textarea instanceof HTMLTextAreaElement) {
+        textarea.focus();
+      }
+    },
+    [insertText],
+  );
 
   return {
     closeEmojiPicker,

--- a/src/components/MessageInput/hooks/useFileUploads.ts
+++ b/src/components/MessageInput/hooks/useFileUploads.ts
@@ -45,7 +45,6 @@ export const useFileUploads = <
   const { t } = useTranslationContext('useFileUploads');
 
   const uploadFile = useCallback((id) => {
-    console.log('uploadFile');
     dispatch({ id, state: 'uploading', type: 'setFileUpload' });
   }, []);
 

--- a/src/components/MessageInput/hooks/useFileUploads.ts
+++ b/src/components/MessageInput/hooks/useFileUploads.ts
@@ -45,6 +45,7 @@ export const useFileUploads = <
   const { t } = useTranslationContext('useFileUploads');
 
   const uploadFile = useCallback((id) => {
+    console.log('uploadFile');
     dispatch({ id, state: 'uploading', type: 'setFileUpload' });
   }, []);
 

--- a/src/components/MessageInput/hooks/useMessageInputState.ts
+++ b/src/components/MessageInput/hooks/useMessageInputState.ts
@@ -428,7 +428,7 @@ export const useMessageInputState = <
     handleEmojiKeyDown,
     onSelectEmoji,
     openEmojiPicker,
-  } = useEmojiPicker<At, Us>(state, dispatch, insertText, closeEmojiPickerOnClick);
+  } = useEmojiPicker<At, Us>(state, dispatch, insertText, textareaRef, closeEmojiPickerOnClick);
 
   const {
     maxFilesLeft,
@@ -438,7 +438,7 @@ export const useMessageInputState = <
     uploadFile,
     uploadImage,
     uploadNewFiles,
-  } = useAttachments<At, Ch, Co, Ev, Me, Re, Us, V>(props, state, dispatch);
+  } = useAttachments<At, Ch, Co, Ev, Me, Re, Us, V>(props, state, dispatch, textareaRef);
 
   const { handleSubmit } = useSubmitHandler<At, Ch, Co, Ev, Me, Re, Us, V>(
     props,

--- a/src/components/MessageInput/hooks/useMessageInputState.ts
+++ b/src/components/MessageInput/hooks/useMessageInputState.ts
@@ -370,7 +370,7 @@ export const useMessageInputState = <
   MessageInputHookProps<At, Me, Us> &
   CommandsListState &
   MentionsListState => {
-  const { message } = props;
+  const { closeEmojiPickerOnClick, message } = props;
 
   const { channelCapabilities = {}, channelConfig } = useChannelStateContext<
     At,
@@ -428,7 +428,7 @@ export const useMessageInputState = <
     handleEmojiKeyDown,
     onSelectEmoji,
     openEmojiPicker,
-  } = useEmojiPicker<At, Us>(state, dispatch, insertText);
+  } = useEmojiPicker<At, Us>(state, dispatch, insertText, closeEmojiPickerOnClick);
 
   const {
     maxFilesLeft,


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Focus input after emoji and attachment selection. Close emoji selector upon selection if closeEmojiPickerOnClick prop is true.

### 🛠 Implementation details

Update useEmojiPicker's onSelectEmoji method and useAttachment's uploadNewFiles method to focus. Add `closeEmojiPickerOnClick` prop to `MessageInput` to optionally close the picker on select.
