### PR TITLE
docs: Fix broken links in the docusaurus docs

### DIFF
--- a/docusaurus/docs/React/contexts/chat-context.mdx
+++ b/docusaurus/docs/React/contexts/chat-context.mdx
@@ -93,7 +93,7 @@ You can override the default behavior by pulling it from context and then utiliz
 
 ### theme
 
-Deprecated and to be removed in a future major release. Use the `customStyles` prop to adjust CSS variables and [customize the theme](../customization/css_and_theming.mdx#css-variables) of your app.
+Deprecated and to be removed in a future major release. Use the `customStyles` prop to adjust CSS variables and [customize the theme](../customization/css-and-theming.mdx#css-variables) of your app.
 
 | Type  |
 | ----- |

--- a/docusaurus/docs/React/core-components/chat.mdx
+++ b/docusaurus/docs/React/core-components/chat.mdx
@@ -111,7 +111,7 @@ When the screen width is at a mobile breakpoint, whether or not the mobile navig
 
 ### theme
 
-Deprecated and to be removed in a future major release. Use the `customStyles` prop to adjust CSS variables and [customize the theme](../customization/css_and_theming.mdx#css-variables) of your app.
+Deprecated and to be removed in a future major release. Use the `customStyles` prop to adjust CSS variables and [customize the theme](../customization/css-and-theming.mdx#css-variables) of your app.
 
 | Type  |
 | ----- |

--- a/docusaurus/docs/React/custom-code-examples/channel-search.mdx
+++ b/docusaurus/docs/React/custom-code-examples/channel-search.mdx
@@ -8,11 +8,11 @@ import CustomChannelSearch from '../assets/CustomChannelSearch.png';
 
 ## How-to Guide for Customizing ChannelSearch
 
-In this example, we will customize the [`ChannelSearch`](../core-components/channel_list/#channelsearch) component. Though this component can be used standalone, we will do our customization when it's established in the `ChannelList`. Here is a guide that outlines how to
+In this example, we will customize the [`ChannelSearch`](../core-components/channel-list.mdx#channelsearch) component. Though this component can be used standalone, we will do our customization when it's established in the `ChannelList`. Here is a guide that outlines how to
 override the default `DropdownContainer` and `SearchResultItem` components, as well as use several other useful props.
 
 :::note
-A complete override of this component is possible by utilizing the [`ChannelSearch`](../core-components/channel_list/#channelsearch) prop on `ChannelList`.
+A complete override of this component is possible by utilizing the [`ChannelSearch`](../core-components/channel-list.mdx#channelsearch) prop on `ChannelList`.
 :::
 
 ### Step 1 - Setting Up For Success

--- a/docusaurus/docs/React/custom-code-examples/override-submit-handler.mdx
+++ b/docusaurus/docs/React/custom-code-examples/override-submit-handler.mdx
@@ -32,7 +32,7 @@ type MessageToSend = {
 ```
 
 :::important
-Call the `sendMessage` function from the [`ChannelActionContext`](../contexts/channel_action_context#sendmessage) within
+Call the `sendMessage` function from the [`ChannelActionContext`](../contexts/channel-action-context.mdx#sendmessage) within
 your custom function to ensure a message is sent to the active channel.
 :::
 

--- a/docusaurus/docs/React/troubleshooting/troubleshooting.mdx
+++ b/docusaurus/docs/React/troubleshooting/troubleshooting.mdx
@@ -8,11 +8,11 @@ For information regarding some common troubleshooting and support issues, please
 
 ### Context Providers
 
-The Stream Chat React SDK uses a variety of [Context Providers](../contexts/chat_context) that share values and data to all their children. This is instead of prop drilling through many levels of components.
+The Stream Chat React SDK uses a variety of [Context Providers](../contexts/chat-context.mdx) that share values and data to all their children. This is instead of prop drilling through many levels of components.
 If you're creating a custom component, utilizing our contexts via our custom hooks makes this process very straightforward.
 
 A common issue is when one of the exposed hooks from a context provider is being utilized, but not within the related Context. Each value you pull will be undefined.
-A good resource for knowing which of our components are Context Providers is within [Core Components](../core-components/chat).
+A good resource for knowing which of our components are Context Providers is within [Core Components](../core-components/chat.mdx).
 
 ### User Roles and Permission Policies
 

--- a/docusaurus/docs/React/utility-components/channel-preview-ui.mdx
+++ b/docusaurus/docs/React/utility-components/channel-preview-ui.mdx
@@ -13,7 +13,7 @@ This UI component is set via the `Preview` prop on `ChannelList`, and if nothing
 ## Basic Usage
 
 This UI component is very customizable; below is an example of how to use the `Preview` prop, and for a more involved step-by-step guide, using the many provided props,
-see [ChannelPreview Code Example](../custom-code-examples/channel_list_preview#the-preview-prop-component).
+see [ChannelPreview Code Example](../custom-code-examples/channel-list-preview.mdx#the-preview-prop-component).
 
 ```tsx
 const YourCustomChannelPreview = (props) => {

--- a/examples/website-demos/social-messaging/src/components/ChannelPreview/SocialPreviewActions.tsx
+++ b/examples/website-demos/social-messaging/src/components/ChannelPreview/SocialPreviewActions.tsx
@@ -25,7 +25,7 @@ export const SocialPreviewActions = (props: Props<SocialUserType>) => {
   const [isUserMuted, setIsUserMuted] = useState(false);
 
   const handleAction = (action: UserActions) => {
-    const user = members[0].user?.id;    
+    const user = members[0].user?.id;
     if (user) setActionId(user);
     setActionsModalOpenId(channelId!);
     setDropdownOpen(false);


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Docusaurus complained about some broken links, this should fix it.

### 🛠 Implementation details

For the relevant ones, link to the mdx file as is done (seemingly) everywhere else to not confuse the resolver in docusaurus. Linking to files also ensures that the CLI will give information about the link if it can't be resolved in the future.

A couple links seemed to have missed an update, or something.

Tested the changes out locally to make sure they worked fine after the changes.

### 🎨 UI Changes

No UI changes (except less 404 :D)


*NOTE*: I had to skip the hooks when making the commit as the python script checking for large files broke cause of "bogus GIT_CONFIG_PARAMETERS", but that should not matter in this case.
