### PR TITLE
Set ImagePreviewer to disabled if multiple upload is not allowed

### DIFF
--- a/src/components/MessageInput/UploadsPreview.tsx
+++ b/src/components/MessageInput/UploadsPreview.tsx
@@ -65,7 +65,7 @@ export const UploadsPreview = <
     <>
       {imageOrder.length > 0 && (
         <ImagePreviewer
-          disabled={maxNumberOfFiles !== undefined && numberOfUploads >= maxNumberOfFiles}
+          disabled={!multipleUploads || (maxNumberOfFiles !== undefined && numberOfUploads >= maxNumberOfFiles)}
           handleFiles={uploadNewFiles}
           handleRemove={removeImage}
           handleRetry={uploadImage}


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

The `ThumbnailPlaceholder` component should not be visible if multiple upload is disabled

### 🛠 Implementation details

We have to set the `disabled` prop of `ImagePreviewer` component to false if multiple upload is disabled

### 🎨 UI Changes


