### PR TITLE
fix: keep channel capabilities array

### DIFF
--- a/src/components/ChannelList/hooks/useChannelUpdatedListener.ts
+++ b/src/components/ChannelList/hooks/useChannelUpdatedListener.ts
@@ -39,7 +39,13 @@ export const useChannelUpdatedListener = <
 
         if (channelIndex > -1 && event.channel) {
           const newChannels = channels;
-          newChannels[channelIndex].data = event.channel;
+          newChannels[channelIndex].data = {
+            ...event.channel,
+            hidden: event.channel?.hidden ?? newChannels[channelIndex].data?.hidden,
+            own_capabilities:
+              event.channel?.own_capabilities ?? newChannels[channelIndex].data?.own_capabilities,
+          };
+
           return [...newChannels];
         }
 


### PR DESCRIPTION
### 🎯 Goal

After a channel.updated event is fired the own_capabilities array and hidden value are lost. 

### 🛠 Implementation details

This change adds those two values back to the channel.data object. 

