### PR TITLE
Add wordReplace prop to ChatAutoComplete to override default behavior

### DIFF
--- a/src/components/ChatAutoComplete/ChatAutoComplete.tsx
+++ b/src/components/ChatAutoComplete/ChatAutoComplete.tsx
@@ -7,7 +7,7 @@ import { useMessageInputContext } from '../../context/MessageInputContext';
 import { useTranslationContext } from '../../context/TranslationContext';
 import { useComponentContext } from '../../context/ComponentContext';
 
-import type { EmojiData } from 'emoji-mart';
+import type { EmojiData, NimbleEmojiIndex } from 'emoji-mart';
 import type { CommandResponse, UserResponse } from 'stream-chat';
 
 import type { TriggerSettings } from '../MessageInput/DefaultTriggerProvider';
@@ -94,6 +94,8 @@ export type ChatAutoCompleteProps = {
   rows?: number;
   /** The text value of the underlying `textarea` component */
   value?: string;
+  /** Function to override the default emojiReplace behavior on the `wordReplace` prop of the `textarea` component */
+  wordReplace?: (word: string, emojiIndex?: NimbleEmojiIndex) => string;
 };
 
 const UnMemoizedChatAutoComplete = <
@@ -119,15 +121,17 @@ const UnMemoizedChatAutoComplete = <
 
   const placeholder = props.placeholder || t('Type your message');
 
-  const emojiReplace = (word: string) => {
-    const found = emojiIndex?.search(word) || [];
-    const emoji = found
-      .filter(Boolean)
-      .slice(0, 10)
-      .find(({ emoticons }: EmojiData) => !!emoticons?.includes(word));
-    if (!emoji || !('native' in emoji)) return null;
-    return emoji.native;
-  };
+  const emojiReplace = props.wordReplace
+    ? (word: string) => props.wordReplace?.(word, emojiIndex)
+    : (word: string) => {
+        const found = emojiIndex?.search(word) || [];
+        const emoji = found
+          .filter(Boolean)
+          .slice(0, 10)
+          .find(({ emoticons }: EmojiData) => !!emoticons?.includes(word));
+        if (!emoji || !('native' in emoji)) return null;
+        return emoji.native;
+      };
 
   const updateInnerRef = useCallback(
     (ref) => {


### PR DESCRIPTION
### 🎯 Goal

Make it possible to override the default wordReplace functionality. Our product includes a number of custom emotes that don't have `.native` values that we'd like to handle in a different way using `ChatAutoComplete`, but currently we don't have access to change the behavior of the autocomplete selection.

### 🛠 Implementation details

Adds an optional prop that takes a function to apply custom autocomplete behavior.

### 🎨 UI Changes

No UI changes, change is backwards compatible and passes the existing tests.
