### PR TITLE
Support URLs with encoded components

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -188,11 +188,12 @@ export const renderText = <Us extends DefaultUserType<Us> = DefaultUserType>(
 
     if (noParsingNeeded.length > 0 || linkIsInBlock) return;
 
-    const displayLink = type === 'email' ? value : value.replace(detectHttp, '');
+    const displayLink =
+      type === 'email' ? value : decodeURIComponent(value).replace(detectHttp, '');
 
     newText = newText.replace(
       new RegExp(escapeRegExp(value), 'g'),
-      `[${displayLink}](${encodeURI(decodeURI(href))})`,
+      `[${displayLink}](${encodeURI(decodeURIComponent(href))})`,
     );
   });
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -64,6 +64,24 @@ type MarkDownRenderers = {
   href?: string;
 };
 
+const detectHttp = /(http(s?):\/\/)?(www\.)?/;
+
+function formatUrlForDisplay(url: string) {
+  try {
+    return decodeURIComponent(url).replace(detectHttp, '');
+  } catch (e) {
+    return url;
+  }
+}
+
+function encodeDecode(url: string) {
+  try {
+    return encodeURI(decodeURIComponent(url));
+  } catch (error) {
+    return url;
+  }
+}
+
 export const markDownRenderers: { [nodeType: string]: React.ElementType } = {
   // eslint-disable-next-line react/display-name
   link: (props: MarkDownRenderers) => {
@@ -168,7 +186,6 @@ export const renderText = <Us extends DefaultUserType<Us> = DefaultUserType>(
   let newText = text;
   const markdownLinks = matchMarkdownLinks(newText);
   const codeBlocks = messageCodeBlocks(newText);
-  const detectHttp = /(http(s?):\/\/)?(www\.)?/;
 
   // extract all valid links/emails within text and replace it with proper markup
   uniqBy(linkify.find(newText), 'value').forEach(({ href, type, value }) => {
@@ -188,13 +205,16 @@ export const renderText = <Us extends DefaultUserType<Us> = DefaultUserType>(
 
     if (noParsingNeeded.length > 0 || linkIsInBlock) return;
 
-    const displayLink =
-      type === 'email' ? value : decodeURIComponent(value).replace(detectHttp, '');
+    try {
+      const displayLink = type === 'email' ? value : formatUrlForDisplay(href);
 
-    newText = newText.replace(
-      new RegExp(escapeRegExp(value), 'g'),
-      `[${displayLink}](${encodeURI(decodeURIComponent(href))})`,
-    );
+      newText = newText.replace(
+        new RegExp(escapeRegExp(value), 'g'),
+        `[${displayLink}](${encodeDecode(href)})`,
+      );
+    } catch (e) {
+      console.log('meh');
+    }
   });
 
   const plugins = [emojiMarkdownPlugin];

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -213,7 +213,7 @@ export const renderText = <Us extends DefaultUserType<Us> = DefaultUserType>(
         `[${displayLink}](${encodeDecode(href)})`,
       );
     } catch (e) {
-      console.log('meh');
+      void e;
     }
   });
 


### PR DESCRIPTION
# Submit a pull request

Use decodeURIComponent, now correctly decoding URLs like
http://example.com/?orderBy%3D%5Ba%2Cb%2Cc%5D
