### PR TITLE
chore: add current text to openmentionslist method

### DIFF
--- a/src/components/MessageInput/hooks/useMessageInputState.ts
+++ b/src/components/MessageInput/hooks/useMessageInputState.ts
@@ -414,7 +414,7 @@ export const useMessageInputState = <
 
   const openMentionsList = () => {
     dispatch({
-      getNewText: () => '@',
+      getNewText: (currentText) => currentText + '@',
       type: 'setText',
     });
     setShowMentionsList(true);


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Add the current text to the insert dispatch method for `openMentionsList` so one can insert a mentioned user into the input while maintaining the existing text.

### 🛠 Implementation details

Add currentText as an argument to the method.