### PR TITLE
Hide onthread update

### DIFF
--- a/src/components/Window/Window.tsx
+++ b/src/components/Window/Window.tsx
@@ -41,10 +41,15 @@ const UnMemoizedWindow = <
 
   const { thread } = useChannelStateContext<At, Ch, Co, Me, Re, Us>('Window');
 
-  // If thread is active and window should hide on thread. Return null
-  if (thread && hideOnThread) return null;
-
-  return <div className={`str-chat__main-panel`}>{children}</div>;
+  return (
+    <div
+      className={`str-chat__main-panel   ${
+        hideOnThread && thread ? 'str-chat__main-panel--hideOnThread' : ''
+      }`}
+    >
+      {children}
+    </div>
+  );
 };
 
 /**

--- a/src/components/Window/__tests__/Window.test.js
+++ b/src/components/Window/__tests__/Window.test.js
@@ -29,18 +29,6 @@ describe('Window', () => {
     expect(getByText('bla')).toBeInTheDocument();
   });
 
-  it('should not render its children if hideOnThread is true and thread is truthy', () => {
-    const { queryByText } = renderComponent({
-      channelStateContextMock: {
-        thread,
-      },
-      children: [<div key='bla'>bla</div>],
-      props: { hideOnThread: true },
-    });
-
-    expect(queryByText('bla')).not.toBeInTheDocument();
-  });
-
   it('should render its children if hideOnThread is true and thread is falsy', () => {
     const { getByText } = renderComponent({
       channelStateContextMock: {


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Update the Window component so it doesn't remount the list components when using `hideOnThread` prop. Scenario: when scrolled up in the list and clicking on a thread, when closing the thread the list should be at the same spot instead of scrolled to the bottom.

### 🛠 Implementation details

A true value for the `hideOnThread` prop is now handled via CSS rather than by returning null in the Window component.

