### PR TITLE
fix: acount for channel capabilities when assigning canQuote value

### DIFF
--- a/src/components/Message/hooks/useUserRole.ts
+++ b/src/components/Message/hooks/useUserRole.ts
@@ -54,7 +54,7 @@ export const useUserRole = <
 
   const canFlag = !isMyMessage;
   const canMute = !isMyMessage && channelConfig?.mutes;
-  const canQuote = !disableQuotedMessages;
+  const canQuote = !disableQuotedMessages && channelCapabilities['quote-message'];
   const canReact = channelConfig?.reactions !== false && channelCapabilities['send-reaction'];
   const canReply = channelConfig?.replies !== false && channelCapabilities['send-reply'];
 


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Fix code so quotes (aka replies) are not still available in message options when quotes are disabled in configuration.

### 🛠 Implementation details

Account for channelCapabilities permissions when assigning `canQuote` value.
