### PR TITLE
chore: upgrade css

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@braintree/sanitize-url": "5.0.0",
-    "@stream-io/stream-chat-css": "2.2.0",
+    "@stream-io/stream-chat-css": "^2.2.1",
     "custom-event": "^1.0.1",
     "dayjs": "^1.10.4",
     "emoji-mart": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1719,10 +1719,10 @@
     crypto-browserify "^3.11.0"
     process-es6 "^0.11.2"
 
-"@stream-io/stream-chat-css@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@stream-io/stream-chat-css/-/stream-chat-css-2.2.0.tgz#d9f8dc2882e8042a810b227da1f4aa885b74f36b"
-  integrity sha512-y//FRdRvbfEpDcY+Onl8U6RFmMsr183Z/Sdx92kvf71UeF3ND/1Uiky1OBKT+vdNU0Lat4oXcNw0lY08d+x7Gg==
+"@stream-io/stream-chat-css@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@stream-io/stream-chat-css/-/stream-chat-css-2.2.1.tgz#23ce6ece96c2118340144191afe834234fb3f5d1"
+  integrity sha512-UJ/UM3wHCd3s1gqPIx2j2Vwpeoa1bbvISEarOlbioLphyHz7LC+E0+Hi81fSKMC9/mCa1ghugvolRKJgj3wwHQ==
 
 "@stream-io/transliterate@^1.5.5":
   version "1.5.5"


### PR DESCRIPTION
The latest version of stream-chat-css includes the removal of a font import and the changes necessary for the upcoming features in stream-chat-react.
