### PR TITLE
onBlur prop for ChatAutoComplete

### DIFF
--- a/docusaurus/docs/React/message-input-components/ui-components.mdx
+++ b/docusaurus/docs/React/message-input-components/ui-components.mdx
@@ -38,6 +38,14 @@ Function to override the default submit handler on the underlying `textarea` com
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | (event: React.BaseSyntheticEvent) => void | [MessageInputContextValue['handleSubmit']](../contexts/message-input-context.mdx#handlesubmit) |
 
+### onBlur
+
+Function to run on blur of the underlying `textarea` component.
+
+| Type                                          |
+| --------------------------------------------- |
+| React.FocusEventHandler<HTMLTextAreaElement\> |
+
 ### onChange
 
 Function to override the default onChange behavior on the underlying `textarea` component.

--- a/src/components/ChatAutoComplete/ChatAutoComplete.tsx
+++ b/src/components/ChatAutoComplete/ChatAutoComplete.tsx
@@ -82,6 +82,8 @@ export type SuggestionListProps<
 export type ChatAutoCompleteProps = {
   /** Function to override the default submit handler on the underlying `textarea` component */
   handleSubmit?: (event: React.BaseSyntheticEvent) => void;
+  /** Function to run on blur of the underlying `textarea` component */
+  onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
   /** Function to override the default onChange behavior on the underlying `textarea` component */
   onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
   /** Function to run on focus of the underlying `textarea` component */
@@ -162,6 +164,7 @@ const UnMemoizedChatAutoComplete = <
       loadingComponent={LoadingIndicator}
       maxRows={messageInput.maxRows}
       minChar={0}
+      onBlur={props.onBlur}
       onChange={props.onChange || messageInput.handleChange}
       onFocus={props.onFocus}
       onPaste={props.onPaste || messageInput.onPaste}


### PR DESCRIPTION
### 🎯 Goal

Adds the transitive `onBlur` prop to `ChatAutoComplete`, mirroring `onFocus`.

Fixes #1345.
