### PR TITLE
Improve default performance of VirtualizedMessageList

### DIFF
--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -66,6 +66,28 @@ type VirtualizedMessageListWithContextProps<
   notifications: ChannelNotifications;
 };
 
+function captureResizeObserverExceededError(e: ErrorEvent) {
+  if (
+    e.message === 'ResizeObserver loop completed with undelivered notifications.' ||
+    e.message === 'ResizeObserver loop limit exceeded'
+  ) {
+    e.stopImmediatePropagation();
+  }
+}
+
+function useCaptureResizeObserverExceededError() {
+  useEffect(() => {
+    window.addEventListener('error', captureResizeObserverExceededError);
+    return () => {
+      window.removeEventListener('error', captureResizeObserverExceededError);
+    };
+  }, []);
+}
+
+function fractionalItemSize(element: HTMLElement) {
+  return element.getBoundingClientRect().height;
+}
+
 const VirtualizedMessageListWithContext = <
   At extends DefaultAttachmentType = DefaultAttachmentType,
   Ch extends DefaultChannelType = DefaultChannelType,
@@ -101,6 +123,10 @@ const VirtualizedMessageListWithContext = <
     shouldGroupByUser = false,
     stickToBottomScrollBehavior = 'smooth',
   } = props;
+
+  // Stops errors generated from react-virtuoso to bubble up
+  // to Sentry or other tracking tools.
+  useCaptureResizeObserverExceededError();
 
   const {
     DateSeparator = DefaultDateSeparator,
@@ -315,8 +341,10 @@ const VirtualizedMessageListWithContext = <
           components={virtuosoComponents}
           firstItemIndex={PREPEND_OFFSET - numItemsPrepended}
           followOutput={followOutput}
+          increaseViewportBy={{ bottom: 200, top: 0 }}
           initialTopMostItemIndex={processedMessages.length ? processedMessages.length - 1 : 0}
           itemContent={(i) => messageRenderer(processedMessages, i)}
+          itemSize={fractionalItemSize}
           overscan={overscan}
           ref={virtuoso}
           startReached={startReached}


### PR DESCRIPTION
This PR sets some sensible defaults for react-virtuoso.

- Renders new messages instantly through `increaseViewportBy`, reducing jumps when new messages are received;
- Measures fractional heights, reducing the chance of rendering glitches in a zoomed-out state.
- Silences benign ResizeObserver errors.
