### PR TITLE
Dont hide message actions dialog on hover away

### DIFF
--- a/docusaurus/docs/React/message-components/ui-components.mdx
+++ b/docusaurus/docs/React/message-components/ui-components.mdx
@@ -5,7 +5,7 @@ title: UI Components
 ---
 
 As described in the [Message UI](./message-ui.mdx) section, our default [`MessageSimple`](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message/MessageSimple.tsx)
-component is a combination of various UI sub-components. We export all of the building blocks of `MessageSimple`, so a custom Message UI
+component is a combination of various UI sub-components. We export all the building blocks of `MessageSimple`, so a custom Message UI
 component can be built in a similar way. Check out the [Message UI Customization](../customization/message-ui.mdx) section for an example.
 
 The following UI components are available for use:
@@ -105,7 +105,7 @@ If true, renders the wrapper component as a `span`, not a `div`.
 
 ### messageWrapperRef
 
-React mutable ref to the message root `div` wrapping parent `MessageOptions` and forwarded down to `MessageActions` ([see the example](../customization/message-ui.mdx). `MessageActions` component uses this ref to register event listener `mouseleave` to hide `MessageActionsBox`. If not provided, then the listener is not registered and already opened `MessageActionsBox` is closed on user click only.
+React mutable ref to the message root `div` wrapping parent `MessageOptions` and forwarded down to `MessageActions` ([see the example](../customization/message-ui.mdx)). `MessageActions` component uses this ref to register event listener `mouseleave` to hide `MessageActionsBox`. If not provided, then the listener is not registered and already opened `MessageActionsBox` is closed on user click only.
 
 | Type                             |
 | -------------------------------- |
@@ -157,7 +157,7 @@ Function that opens a [`Thread`](../core-components/thread.mdx) on a message (ov
 
 ### messageWrapperRef
 
-React mutable ref that can be placed on the message root `div` wrapping `MessageOptions`. `MessageOptions` component forwards this prop to [`MessageActions`](#messageactions-props) component ([see the example](../customization/message-ui.mdx).
+React mutable ref that can be placed on the message root `div` wrapping `MessageOptions`. `MessageOptions` component forwards this prop to [`MessageActions`](#messageactions-props) component ([see the example](../customization/message-ui.mdx)).
 
 | Type                             |
 | -------------------------------- |

--- a/docusaurus/docs/React/message-components/ui-components.mdx
+++ b/docusaurus/docs/React/message-components/ui-components.mdx
@@ -105,7 +105,7 @@ If true, renders the wrapper component as a `span`, not a `div`.
 
 ### messageWrapperRef
 
-React mutable ref placed on the `div` wrapping the `MessageSimple` children.
+React mutable ref to the message root `div` wrapping parent `MessageOptions` and forwarded down to `MessageActions` ([see the example](../customization/message-ui.mdx). `MessageActions` component uses this ref to register event listener `mouseleave` to hide `MessageActionsBox`. If not provided, then the listener is not registered and already opened `MessageActionsBox` is closed on user click only.
 
 | Type                             |
 | -------------------------------- |
@@ -157,7 +157,7 @@ Function that opens a [`Thread`](../core-components/thread.mdx) on a message (ov
 
 ### messageWrapperRef
 
-React mutable ref placed on the `div` wrapping the `MessageSimple` children.
+React mutable ref that can be placed on the message root `div` wrapping `MessageOptions`. `MessageOptions` component forwards this prop to [`MessageActions`](#messageactions-props) component ([see the example](../customization/message-ui.mdx).
 
 | Type                             |
 | -------------------------------- |

--- a/docusaurus/docs/React/message-components/ui-components.mdx
+++ b/docusaurus/docs/React/message-components/ui-components.mdx
@@ -105,7 +105,7 @@ If true, renders the wrapper component as a `span`, not a `div`.
 
 ### messageWrapperRef
 
-React mutable ref to the message root `div` wrapping parent `MessageOptions` and forwarded down to `MessageActions` ([see the example](../customization/message-ui.mdx)). `MessageActions` component uses this ref to register event listener `mouseleave` to hide `MessageActionsBox`. If not provided, then the listener is not registered and already opened `MessageActionsBox` is closed on user click only.
+React mutable ref placed on the message root `div`. It is forwarded by `MessageOptions` down to `MessageActions` ([see the example](../customization/message-ui.mdx)).
 
 | Type                             |
 | -------------------------------- |
@@ -157,7 +157,7 @@ Function that opens a [`Thread`](../core-components/thread.mdx) on a message (ov
 
 ### messageWrapperRef
 
-React mutable ref that can be placed on the message root `div` wrapping `MessageOptions`. `MessageOptions` component forwards this prop to [`MessageActions`](#messageactions-props) component ([see the example](../customization/message-ui.mdx)).
+React mutable ref that can be placed on the message root `div`. `MessageOptions` component forwards this prop to [`MessageActions`](#messageactions-props) component ([see the example](../customization/message-ui.mdx)).
 
 | Type                             |
 | -------------------------------- |

--- a/src/components/Message/MessageSimple.tsx
+++ b/src/components/Message/MessageSimple.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 
 import { MessageDeleted as DefaultMessageDeleted } from './MessageDeleted';
 import { MessageOptions as DefaultMessageOptions } from './MessageOptions';
@@ -66,8 +66,6 @@ const MessageSimpleWithContext = <
     ReactionsList = DefaultReactionList,
   } = useComponentContext<StreamChatGenerics>('MessageSimple');
 
-  const messageWrapperRef = useRef<HTMLDivElement | null>(null);
-
   const hasAttachment = messageHasAttachments(message);
   const hasReactions = messageHasReactions(message);
 
@@ -110,7 +108,6 @@ const MessageSimpleWithContext = <
             ${endOfGroup ? 'str-chat__virtual-message__wrapper--end' : ''}
 					`.trim()}
           key={message.id}
-          ref={messageWrapperRef}
         >
           <MessageStatus />
           {message.user && (
@@ -137,7 +134,7 @@ const MessageSimpleWithContext = <
             }
           >
             <>
-              <MessageOptions messageWrapperRef={messageWrapperRef} />
+              <MessageOptions />
               {hasReactions && !showDetailedReactions && isReactionEnabled && (
                 <ReactionsList reverse />
               )}

--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -71,7 +71,12 @@ export const MessageActions = <
 
   const isMuted = useCallback(() => isUserMuted(message, mutes), [message, mutes]);
 
-  const hideOptions = useCallback(() => setActionsBoxOpen(false), []);
+  const hideOptions = useCallback((event: MouseEvent | KeyboardEvent) => {
+    if (event instanceof KeyboardEvent && event.key !== 'Escape') {
+      return;
+    }
+    setActionsBoxOpen(false);
+  }, []);
   const messageActions = getMessageActions();
   const messageDeletedAt = !!message?.deleted_at;
 
@@ -90,8 +95,10 @@ export const MessageActions = <
   useEffect(() => {
     if (actionsBoxOpen) {
       document.addEventListener('click', hideOptions);
+      document.addEventListener('keyup', hideOptions);
     } else {
       document.removeEventListener('click', hideOptions);
+      document.addEventListener('keyup', hideOptions);
     }
 
     return () => document.removeEventListener('click', hideOptions);
@@ -143,7 +150,7 @@ const MessageActionsWrapper: React.FC<MessageActionsWrapperProps> = (props) => {
 
   const onClickOptionsAction = (event: React.BaseSyntheticEvent) => {
     event.stopPropagation();
-    setActionsBoxOpen(true);
+    setActionsBoxOpen((prev) => !prev);
   };
 
   const wrapperProps = {

--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -93,15 +93,15 @@ export const MessageActions = <
   }, [hideOptions, messageDeletedAt]);
 
   useEffect(() => {
-    if (actionsBoxOpen) {
-      document.addEventListener('click', hideOptions);
-      document.addEventListener('keyup', hideOptions);
-    } else {
+    if (!actionsBoxOpen) return;
+
+    document.addEventListener('click', hideOptions);
+    document.addEventListener('keyup', hideOptions);
+
+    return () => {
       document.removeEventListener('click', hideOptions);
       document.addEventListener('keyup', hideOptions);
-    }
-
-    return () => document.removeEventListener('click', hideOptions);
+    };
   }, [actionsBoxOpen, hideOptions]);
 
   if (!messageActions.length && !customMessageActions) return null;

--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -100,7 +100,7 @@ export const MessageActions = <
 
     return () => {
       document.removeEventListener('click', hideOptions);
-      document.addEventListener('keyup', hideOptions);
+      document.removeEventListener('keyup', hideOptions);
     };
   }, [actionsBoxOpen, hideOptions]);
 

--- a/src/components/MessageActions/__tests__/MessageActions.test.js
+++ b/src/components/MessageActions/__tests__/MessageActions.test.js
@@ -188,12 +188,34 @@ describe('<MessageActions /> component', () => {
     );
   });
 
-  it('should remove event listener when unmounted', () => {
+  it('should not register click and keyup event listeners to close actions box until opened', () => {
+    const { getByRole } = renderMessageActions();
+    const addEventListener = jest.spyOn(document, 'addEventListener');
+    expect(document.addEventListener).not.toHaveBeenCalled();
+    fireEvent.click(getByRole('button'));
+    expect(document.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+    expect(document.addEventListener).toHaveBeenCalledWith('keyup', expect.any(Function));
+    addEventListener.mockClear();
+  });
+
+  it('should not remove click and keyup event listeners when unmounted if actions box not opened', () => {
     const { unmount } = renderMessageActions();
     const removeEventListener = jest.spyOn(document, 'removeEventListener');
     expect(document.removeEventListener).not.toHaveBeenCalled();
     unmount();
+    expect(document.removeEventListener).not.toHaveBeenCalledWith('click', expect.any(Function));
+    expect(document.removeEventListener).not.toHaveBeenCalledWith('keyup', expect.any(Function));
+    removeEventListener.mockClear();
+  });
+
+  it('should remove event listener when unmounted', () => {
+    const { getByRole, unmount } = renderMessageActions();
+    const removeEventListener = jest.spyOn(document, 'removeEventListener');
+    fireEvent.click(getByRole('button'));
+    expect(document.removeEventListener).not.toHaveBeenCalled();
+    unmount();
     expect(document.removeEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+    expect(document.removeEventListener).toHaveBeenCalledWith('keyup', expect.any(Function));
     removeEventListener.mockClear();
   });
 


### PR DESCRIPTION
### 🎯 Goal

The original behavior of actions box to disappear on hover away keeps being opt in by passing the `messageWrapperRef`. However the `MessageSimple` component does not pass neither create this ref anymore to `MessageOption` (and thus down to `MessagActions`). Moreover event listener for `keyup` event is now registered and hides message actions box on pressing `Escape` key only.

These changes then lead to the message actions box being hidden when user:
- clicks outside
- presses Escape key
- presses on an item in the menu

fixes #1401 
