### PR TITLE
Fix giphy usage inconsistencies

### DIFF
--- a/docusaurus/docs/React/core-components/channel.mdx
+++ b/docusaurus/docs/React/core-components/channel.mdx
@@ -264,11 +264,11 @@ Custom UI component to render a Giphy preview in the `VirtualizedMessageList`.
 
 ### giphyVersion
 
-The Giphy version to render - check the keys of the [Image Obect](https://developers.giphy.com/docs/api/schema#image-object) for possible values. 
+The Giphy version to render - check the keys of the [Image Object](https://developers.giphy.com/docs/api/schema#image-object) for possible values. 
 
-| Type      | Default    |
-| --------- | ---------- |
-| string    | 'original' |
+| Type      | Default        |
+| --------- | -------------- |
+| string    | 'fixed_height' |
 
 ### HeaderComponent
 

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -691,7 +691,7 @@ const ChannelInner = <
     channelCapabilitiesArray,
     channelConfig,
     dragAndDropWindow,
-    giphyVersion: props.giphyVersion || 'fixed_width',
+    giphyVersion: props.giphyVersion || 'fixed_height',
     maxNumberOfFiles,
     multipleUploads,
     mutes,

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -124,6 +124,8 @@ export type ChannelProps<
   EmptyStateIndicator?: ComponentContextValue<StreamChatGenerics>['EmptyStateIndicator'];
   /** Custom UI component for file upload icon, defaults to and accepts same props as: [FileUploadIcon](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageInput/icons.tsx) */
   FileUploadIcon?: ComponentContextValue<StreamChatGenerics>['FileUploadIcon'];
+  /** The giphy version to render - check the keys of the [Image Object](https://developers.giphy.com/docs/api/schema#image-object) for possible values. Uses 'fixed_height' by default */
+  giphyVersion?: GiphyVersions;
   /** Custom UI component to render a Giphy preview in the `VirtualizedMessageList` */
   GiphyPreviewMessage?: ComponentContextValue<StreamChatGenerics>['GiphyPreviewMessage'];
   /** Custom UI component to render at the top of the `MessageList` */
@@ -213,7 +215,6 @@ const ChannelInner = <
     ChannelProps<StreamChatGenerics, V> & {
       channel: StreamChannel<StreamChatGenerics>;
       key: string;
-      giphyVersion?: GiphyVersions;
     }
   >,
 ) => {

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -124,10 +124,10 @@ export type ChannelProps<
   EmptyStateIndicator?: ComponentContextValue<StreamChatGenerics>['EmptyStateIndicator'];
   /** Custom UI component for file upload icon, defaults to and accepts same props as: [FileUploadIcon](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageInput/icons.tsx) */
   FileUploadIcon?: ComponentContextValue<StreamChatGenerics>['FileUploadIcon'];
-  /** The giphy version to render - check the keys of the [Image Object](https://developers.giphy.com/docs/api/schema#image-object) for possible values. Uses 'fixed_height' by default */
-  giphyVersion?: GiphyVersions;
   /** Custom UI component to render a Giphy preview in the `VirtualizedMessageList` */
   GiphyPreviewMessage?: ComponentContextValue<StreamChatGenerics>['GiphyPreviewMessage'];
+  /** The giphy version to render - check the keys of the [Image Object](https://developers.giphy.com/docs/api/schema#image-object) for possible values. Uses 'fixed_height' by default */
+  giphyVersion?: GiphyVersions;
   /** Custom UI component to render at the top of the `MessageList` */
   HeaderComponent?: ComponentContextValue<StreamChatGenerics>['HeaderComponent'];
   /** Custom UI component handling how the message input is rendered, defaults to and accepts the same props as [MessageInputFlat](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageInput/MessageInputFlat.tsx) */


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

* Fix an inconsistency introduced in https://github.com/GetStream/stream-chat-react/pull/1374, where the default value in the doc was not the same as what was used in the code.
* Change the default giphyVersion to `fixed_height` to maintain parity across the component SDKs.
* Fix the incorrect removal of the documentation of giphyVersion prop in 5b88fff01d436d767876cc515b3b61c6fe542bee and fcad45d76a1aad841ec36309f22e855381fe284d

### 🛠 Implementation details

The giphy attachment payload includes several versions. By default, we use `fixed_height`. The Channel prop can be used to change the version name.

### 🎨 UI Changes

NA
