### PR TITLE
Move `UploadsPreview` outside textarea wrapper

### DIFF
--- a/src/components/MessageInput/MessageInputFlat.tsx
+++ b/src/components/MessageInput/MessageInputFlat.tsx
@@ -72,8 +72,8 @@ export const MessageInputFlat = <
           <QuotedMessagePreview quotedMessage={quotedMessage} />
         )}
         <div className='str-chat__input-flat-wrapper'>
+          {isUploadEnabled && <UploadsPreview />}
           <div className='str-chat__input-flat--textarea-wrapper'>
-            {isUploadEnabled && <UploadsPreview />}
             <div className='str-chat__emojiselect-wrapper'>
               <Tooltip>
                 {emojiPickerIsOpen ? t('Close emoji picker') : t('Open emoji picker')}


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Allign the send button with the `textarea` when there's an upload preview available.

### 🎨 UI Changes

Before (don't mind the input icons):
![image](https://user-images.githubusercontent.com/43254280/158635781-1a83ad27-6a95-4cc5-ae10-377c293d0109.png)
After:
![image](https://user-images.githubusercontent.com/43254280/158635982-7788bdba-eb5a-4524-9b39-b4c22e7f41de.png)

