### PR TITLE
Fix broken link in doc

### DIFF
--- a/docusaurus/docs/React/core-components/channel.mdx
+++ b/docusaurus/docs/React/core-components/channel.mdx
@@ -148,7 +148,7 @@ Custom UI component for date separators.
 
 | Type      | Default                                                                                                      |
 | --------- | ------------------------------------------------------------------------------------------------------------ |
-| component | [DateSeparator](https://github.com/GetStream/stream-chat-react/blob/master/src/components/DateSeparator.tsx) |
+| component | [DateSeparator](https://github.com/GetStream/stream-chat-react/blob/master/src/components/DateSeparator/DateSeparator.tsx) |
 
 ### doMarkReadRequest
 
@@ -264,7 +264,7 @@ Custom UI component to render a Giphy preview in the `VirtualizedMessageList`.
 
 ### giphyVersion
 
-The Giphy version to render - check the keys of the [Image Object](https://developers.giphy.com/docs/api/schema#image-object) for possible values. 
+The Giphy version to render - check the keys of the [Image Object](https://developers.giphy.com/docs/api/schema#image-object) for possible values.
 
 | Type      | Default        |
 | --------- | -------------- |


### PR DESCRIPTION
### 🎯 Goal

The "DateSeparator" link is broken in the [channel#DateSeparator](https://getstream.io/chat/docs/sdk/react/core-components/channel/#dateseparator) docs
