### PR TITLE
Fix german calendar translation strings

### DIFF
--- a/src/i18n/Streami18n.ts
+++ b/src/i18n/Streami18n.ts
@@ -52,9 +52,9 @@ Dayjs.extend(updateLocale);
 Dayjs.updateLocale('de', {
   calendar: {
     lastDay: '[gestern um] LT',
-    lastWeek: '[letzten] dddd [bei] LT',
-    nextDay: '[morgen zu] LT',
-    nextWeek: 'dddd [bei] LT',
+    lastWeek: '[letzten] dddd [um] LT',
+    nextDay: '[morgen um] LT',
+    nextWeek: 'dddd [um] LT',
     sameDay: '[heute um] LT',
     sameElse: 'L',
   },


### PR DESCRIPTION
Fixes #1467 - Bei is the wrong word to use in a time context. Same as zu

Signed the CLA

# Submit a pull request

### 🎯 Goal

To improve/fix German calendar translations

### 🛠 Implementation details
Just updating the translation strings

### 🎨 UI Changes
