### PR TITLE
Fix Portuguese timestamp translation

### DIFF
--- a/src/i18n/Streami18n.ts
+++ b/src/i18n/Streami18n.ts
@@ -171,9 +171,9 @@ Dayjs.updateLocale('nl', {
 Dayjs.updateLocale('pt', {
   calendar: {
     lastDay: '[ontem às] LT',
-    lastWeek: '[passado] dddd [para] LT',
+    lastWeek: 'dddd [passada às] LT',
     nextDay: '[amanhã às] LT',
-    nextWeek: 'dddd [para] LT',
+    nextWeek: 'dddd [às] LT',
     sameDay: '[hoje às] LT',
     sameElse: 'L',
   },


### PR DESCRIPTION
### 🎯 Goal

Fix Portuguese timestamp translations.

### 🛠 Implementation details

The previous translation didn't make much sense to Portuguese speakers, so this patch corrects it.

Note: Portuguese is a gendered language, so while this fixes the translation for the feminine week days (Monday to Friday), Saturday and Sunday will be slightly wrong. They're masculine and should be written "Sábado passado" and "Domingo passado", but I don't know how to fix this right away.