### PR TITLE
test: fix warnings in message input

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -65,6 +65,7 @@ import type { Data as EmojiMartData } from 'emoji-mart';
 import type { MessageInputProps } from '../MessageInput/MessageInput';
 
 import type { CustomTrigger, DefaultStreamChatGenerics, GiphyVersions } from '../../types/types';
+import { buildAddNotification } from './buildAddNotification';
 
 export type ChannelProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -411,25 +412,7 @@ const ChannelInner = <
   /** MESSAGE */
 
   // Adds a temporary notification to message list, will be removed after 5 seconds
-  const addNotification = (text: string, type: 'success' | 'error') => {
-    if (typeof text !== 'string' || (type !== 'success' && type !== 'error')) {
-      return;
-    }
-
-    const id = uuidv4();
-
-    setNotifications((prevNotifications) => [...prevNotifications, { id, text, type }]);
-
-    const timeout = setTimeout(
-      () =>
-        setNotifications((prevNotifications) =>
-          prevNotifications.filter((notification) => notification.id !== id),
-        ),
-      5000,
-    );
-
-    notificationTimeouts.push(timeout);
-  };
+  const addNotification = buildAddNotification(notificationTimeouts, setNotifications);
 
   const loadMoreFinished = debounce(
     (hasMore: boolean, messages: ChannelState<StreamChatGenerics>['messages']) => {

--- a/src/components/Channel/__mocks__/buildAddNotification.ts
+++ b/src/components/Channel/__mocks__/buildAddNotification.ts
@@ -1,0 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const buildAddNotification = () => () => {
+  void 0;
+};

--- a/src/components/Channel/buildAddNotification.ts
+++ b/src/components/Channel/buildAddNotification.ts
@@ -1,0 +1,25 @@
+import type { ChannelNotifications } from '../../context/ChannelStateContext';
+import { v4 as uuidv4 } from 'uuid';
+
+export const buildAddNotification = (
+  notificationTimeouts: ReturnType<typeof setTimeout>[],
+  setNotifications: (value: React.SetStateAction<ChannelNotifications>) => void,
+) => (text: string, type: 'success' | 'error') => {
+  if (typeof text !== 'string' || (type !== 'success' && type !== 'error')) {
+    return;
+  }
+
+  const id = uuidv4();
+
+  setNotifications((prevNotifications) => [...prevNotifications, { id, text, type }]);
+
+  const timeout = setTimeout(
+    () =>
+      setNotifications((prevNotifications) =>
+        prevNotifications.filter((notification) => notification.id !== id),
+      ),
+    5000,
+  );
+
+  notificationTimeouts.push(timeout);
+};


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

The changeset fixes the warnings caused by the test execution of `src/components/MessageInput/__tests__/MessageInput.test.js`

### 🛠 Impementation details

- initial rendering is wrapped in an async `act`, to capture the translations promise
- button click is wrapped in an async `act`
- Finally, one long timeout was extracted and mocked
