### PR TITLE
docs: Fix outdated links in generics guide

### DIFF
--- a/docusaurus/docs/React/customization/typescript.mdx
+++ b/docusaurus/docs/React/customization/typescript.mdx
@@ -52,13 +52,13 @@ type LocalUserType = {
 
 The seven customizable fields these generics extend are provided via `stream-chat`:
 
-1. [`Attachment`](https://github.com/GetStream/stream-chat-js/blob/534bcb09a971caea9f187f31b005e9e3b1413a67/src/types.ts#L1166)
-2. [`ChannelResponse`](https://github.com/GetStream/stream-chat-js/blob/534bcb09a971caea9f187f31b005e9e3b1413a67/src/types.ts#L104)
-3. [`CommandVariants`](https://github.com/GetStream/stream-chat-js/blob/534bcb09a971caea9f187f31b005e9e3b1413a67/src/types.ts#L1271)
-4. [`Event`](https://github.com/GetStream/stream-chat-js/blob/534bcb09a971caea9f187f31b005e9e3b1413a67/src/types.ts#L796)
-5. [`MessageBase`](https://github.com/GetStream/stream-chat-js/blob/534bcb09a971caea9f187f31b005e9e3b1413a67/src/types.ts#L1344)
-6. [`Reaction`](https://github.com/GetStream/stream-chat-js/blob/534bcb09a971caea9f187f31b005e9e3b1413a67/src/types.ts#L1401)
-7. [`User`](https://github.com/GetStream/stream-chat-js/blob/534bcb09a971caea9f187f31b005e9e3b1413a67/src/types.ts#L1465)
+1. [`Attachment`](https://github.com/GetStream/stream-chat-js/blob/master/src/types.ts)
+2. [`ChannelResponse`](https://github.com/GetStream/stream-chat-js/blob/master/src/types.ts)
+3. [`CommandVariants`](https://github.com/GetStream/stream-chat-js/blob/master/src/types.ts)
+4. [`Event`](https://github.com/GetStream/stream-chat-js/blob/master/src/types.ts)
+5. [`MessageBase`](https://github.com/GetStream/stream-chat-js/blob/master/src/types.ts)
+6. [`Reaction`](https://github.com/GetStream/stream-chat-js/blob/master/src/types.ts)
+7. [`User`](https://github.com/GetStream/stream-chat-js/blob/master/src/types.ts)
 
 All seven generics contain defaults in the component library that can be extended for custom types for Channel, Messages, etc.
 


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

The [typescript and generics guide ](https://getstream.io/chat/docs/sdk/react/customization/typescript_and_generics/) contains outdated links (the links point stream chat v5 code, when they should point to v6)

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

_Add relevant screenshots_
