### PR TITLE
fix: Upload preview overflow in thread

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@braintree/sanitize-url": "6.0.0",
-    "@stream-io/stream-chat-css": "^2.2.1",
+    "@stream-io/stream-chat-css": "^2.8.0",
     "dayjs": "^1.10.4",
     "emoji-mart": "3.0.1",
     "emoji-regex": "^9.2.0",

--- a/src/components/MessageInput/MessageInputSmall.tsx
+++ b/src/components/MessageInput/MessageInputSmall.tsx
@@ -73,8 +73,8 @@ export const MessageInputSmall = <
           {quotedMessage && quotedMessage.parent_id && (
             <QuotedMessagePreview quotedMessage={quotedMessage} />
           )}
+          {isUploadEnabled && <UploadsPreview />}
           <div className='str-chat__small-message-input--textarea-wrapper'>
-            {isUploadEnabled && <UploadsPreview />}
             <ChatAutoComplete />
             {cooldownRemaining ? (
               <div className='str-chat__input-small-cooldown'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2805,9 +2805,9 @@
     process-es6 "^0.11.2"
 
 "@stream-io/stream-chat-css@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@stream-io/stream-chat-css/-/stream-chat-css-2.2.1.tgz#23ce6ece96c2118340144191afe834234fb3f5d1"
-  integrity sha512-UJ/UM3wHCd3s1gqPIx2j2Vwpeoa1bbvISEarOlbioLphyHz7LC+E0+Hi81fSKMC9/mCa1ghugvolRKJgj3wwHQ==
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@stream-io/stream-chat-css/-/stream-chat-css-2.8.0.tgz#bff7a6ce53d10f3a6d6a1cab233be82d14e53601"
+  integrity sha512-0Jgo4ujw7vvUp8GI4UxqrWo/XpAhicHbcOmsEuTItcB+5N9/edJ+Tv/Z8Bm3xyKTN5ztnP2dEa9hDWF7U1A7Hw==
 
 "@stream-io/transliterate@^1.5.5":
   version "1.5.5"
@@ -11708,12 +11708,7 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-nanoid@^3.1.20, nanoid@^3.1.22:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
-  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
-
-nanoid@^3.3.1:
+nanoid@^3.1.20, nanoid@^3.1.22, nanoid@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
   integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2804,7 +2804,7 @@
     crypto-browserify "^3.11.0"
     process-es6 "^0.11.2"
 
-"@stream-io/stream-chat-css@^2.2.1":
+"@stream-io/stream-chat-css@^2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@stream-io/stream-chat-css/-/stream-chat-css-2.8.0.tgz#bff7a6ce53d10f3a6d6a1cab233be82d14e53601"
   integrity sha512-0Jgo4ujw7vvUp8GI4UxqrWo/XpAhicHbcOmsEuTItcB+5N9/edJ+Tv/Z8Bm3xyKTN5ztnP2dEa9hDWF7U1A7Hw==


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

1. Avoid file upload preview overflow in thread. 
2. Bump the @stream-io/stream-chat-css dependency to the latest version that fixes message overflows in thread.

### 🛠 Implementation details

Change the parent container by moving the preview one level higher.

### 🎨 UI Changes

Before:

![image](https://user-images.githubusercontent.com/32706194/161713017-d421e373-2592-4bd9-bc95-318e69469a1a.png)


After:

![image](https://user-images.githubusercontent.com/32706194/161712889-c46d88be-b839-4ca7-bb3b-f3ff6b32471e.png)

