### PR TITLE
fix: prevent duplicate message id generation in message list

### DIFF
--- a/docusaurus/docs/React/customization/typescript.mdx
+++ b/docusaurus/docs/React/customization/typescript.mdx
@@ -136,10 +136,12 @@ type DefaultCommandType = string & {};
 
 type DefaultEventType = Record<string, unknown>;
 
+export type CustomMessageType = 'channel.intro' | 'message.date';
+
 export type DefaultMessageType<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = UnknownType & {
-  customType?: 'channel.intro' | 'message.date';
+  customType?: CustomMessageType;
   date?: string | Date;
   errorStatusCode?: number;
   event?: Event<StreamChatGenerics>;

--- a/src/components/Message/MessageCommerce.tsx
+++ b/src/components/Message/MessageCommerce.tsx
@@ -8,7 +8,7 @@ import { MessageTimestamp as DefaultMessageTimestamp } from './MessageTimestamp'
 import { areMessageUIPropsEqual, messageHasAttachments, messageHasReactions } from './utils';
 
 import { Avatar as DefaultAvatar } from '../Avatar';
-import { CUSTOM_MESSAGE } from '../../constants/messageTypes';
+import { CUSTOM_MESSAGE_TYPE } from '../../constants/messageTypes';
 import { MML } from '../MML';
 import {
   ReactionSelector as DefaultReactionSelector,
@@ -74,7 +74,7 @@ const MessageCommerceWithContext = <
     return <MessageDeleted message={message} />;
   }
 
-  if (message.customType === CUSTOM_MESSAGE.date) {
+  if (message.customType === CUSTOM_MESSAGE_TYPE.date) {
     return null;
   }
 

--- a/src/components/Message/MessageCommerce.tsx
+++ b/src/components/Message/MessageCommerce.tsx
@@ -8,6 +8,7 @@ import { MessageTimestamp as DefaultMessageTimestamp } from './MessageTimestamp'
 import { areMessageUIPropsEqual, messageHasAttachments, messageHasReactions } from './utils';
 
 import { Avatar as DefaultAvatar } from '../Avatar';
+import { CUSTOM_MESSAGE } from '../../constants/messageTypes';
 import { MML } from '../MML';
 import {
   ReactionSelector as DefaultReactionSelector,
@@ -73,7 +74,7 @@ const MessageCommerceWithContext = <
     return <MessageDeleted message={message} />;
   }
 
-  if (message.customType === 'message.date') {
+  if (message.customType === CUSTOM_MESSAGE.date) {
     return null;
   }
 

--- a/src/components/Message/MessageLivestream.tsx
+++ b/src/components/Message/MessageLivestream.tsx
@@ -9,6 +9,7 @@ import { QuotedMessage as DefaultQuotedMessage } from './QuotedMessage';
 import { areMessageUIPropsEqual, MESSAGE_ACTIONS, showMessageActionsBox } from './utils';
 
 import { Avatar as DefaultAvatar } from '../Avatar';
+import { CUSTOM_MESSAGE } from '../../constants/messageTypes';
 import { MessageActions } from '../MessageActions';
 import { EditMessageForm as DefaultEditMessageForm, MessageInput } from '../MessageInput';
 import {
@@ -87,7 +88,7 @@ const MessageLivestreamWithContext = <
 
   const firstGroupStyle = groupStyles ? groupStyles[0] : 'single';
 
-  if (message.customType === 'message.date') {
+  if (message.customType === CUSTOM_MESSAGE.date) {
     return null;
   }
 

--- a/src/components/Message/MessageLivestream.tsx
+++ b/src/components/Message/MessageLivestream.tsx
@@ -9,7 +9,7 @@ import { QuotedMessage as DefaultQuotedMessage } from './QuotedMessage';
 import { areMessageUIPropsEqual, MESSAGE_ACTIONS, showMessageActionsBox } from './utils';
 
 import { Avatar as DefaultAvatar } from '../Avatar';
-import { CUSTOM_MESSAGE } from '../../constants/messageTypes';
+import { CUSTOM_MESSAGE_TYPE } from '../../constants/messageTypes';
 import { MessageActions } from '../MessageActions';
 import { EditMessageForm as DefaultEditMessageForm, MessageInput } from '../MessageInput';
 import {
@@ -88,7 +88,7 @@ const MessageLivestreamWithContext = <
 
   const firstGroupStyle = groupStyles ? groupStyles[0] : 'single';
 
-  if (message.customType === CUSTOM_MESSAGE.date) {
+  if (message.customType === CUSTOM_MESSAGE_TYPE.date) {
     return null;
   }
 

--- a/src/components/Message/MessageSimple.tsx
+++ b/src/components/Message/MessageSimple.tsx
@@ -9,6 +9,7 @@ import { MessageTimestamp as DefaultMessageTimestamp } from './MessageTimestamp'
 import { areMessageUIPropsEqual, messageHasAttachments, messageHasReactions } from './utils';
 
 import { Avatar as DefaultAvatar } from '../Avatar';
+import { CUSTOM_MESSAGE } from '../../constants/messageTypes';
 import { EditMessageForm as DefaultEditMessageForm, MessageInput } from '../MessageInput';
 import { MML } from '../MML';
 import { Modal } from '../Modal';
@@ -74,7 +75,7 @@ const MessageSimpleWithContext = <
     ? 'str-chat__message str-chat__message--me str-chat__message-simple str-chat__message-simple--me'
     : 'str-chat__message str-chat__message-simple';
 
-  if (message.customType === 'message.date') {
+  if (message.customType === CUSTOM_MESSAGE.date) {
     return null;
   }
 

--- a/src/components/Message/MessageSimple.tsx
+++ b/src/components/Message/MessageSimple.tsx
@@ -9,7 +9,7 @@ import { MessageTimestamp as DefaultMessageTimestamp } from './MessageTimestamp'
 import { areMessageUIPropsEqual, messageHasAttachments, messageHasReactions } from './utils';
 
 import { Avatar as DefaultAvatar } from '../Avatar';
-import { CUSTOM_MESSAGE } from '../../constants/messageTypes';
+import { CUSTOM_MESSAGE_TYPE } from '../../constants/messageTypes';
 import { EditMessageForm as DefaultEditMessageForm, MessageInput } from '../MessageInput';
 import { MML } from '../MML';
 import { Modal } from '../Modal';
@@ -75,7 +75,7 @@ const MessageSimpleWithContext = <
     ? 'str-chat__message str-chat__message--me str-chat__message-simple str-chat__message-simple--me'
     : 'str-chat__message str-chat__message-simple';
 
-  if (message.customType === CUSTOM_MESSAGE.date) {
+  if (message.customType === CUSTOM_MESSAGE_TYPE.date) {
     return null;
   }
 

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -17,6 +17,7 @@ import { MessageNotification as DefaultMessageNotification } from './MessageNoti
 import { MessageListNotifications as DefaultMessageListNotifications } from './MessageListNotifications';
 import { processMessages } from './utils';
 
+import { CUSTOM_MESSAGE } from '../../constants/messageTypes';
 import { DateSeparator as DefaultDateSeparator } from '../DateSeparator/DateSeparator';
 import { EmptyStateIndicator as DefaultEmptyStateIndicator } from '../EmptyStateIndicator/EmptyStateIndicator';
 import { EventComponent } from '../EventComponent/EventComponent';
@@ -291,7 +292,7 @@ const VirtualizedMessageListWithContext = <
 
       const message = messageList[streamMessageIndex];
 
-      if (message.customType === 'message.date' && message.date && isDate(message.date)) {
+      if (message.customType === CUSTOM_MESSAGE.date && message.date && isDate(message.date)) {
         return <DateSeparator date={message.date} unread={message.unread} />;
       }
 

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -17,7 +17,7 @@ import { MessageNotification as DefaultMessageNotification } from './MessageNoti
 import { MessageListNotifications as DefaultMessageListNotifications } from './MessageListNotifications';
 import { processMessages } from './utils';
 
-import { CUSTOM_MESSAGE } from '../../constants/messageTypes';
+import { CUSTOM_MESSAGE_TYPE } from '../../constants/messageTypes';
 import { DateSeparator as DefaultDateSeparator } from '../DateSeparator/DateSeparator';
 import { EmptyStateIndicator as DefaultEmptyStateIndicator } from '../EmptyStateIndicator/EmptyStateIndicator';
 import { EventComponent } from '../EventComponent/EventComponent';
@@ -292,7 +292,7 @@ const VirtualizedMessageListWithContext = <
 
       const message = messageList[streamMessageIndex];
 
-      if (message.customType === CUSTOM_MESSAGE.date && message.date && isDate(message.date)) {
+      if (message.customType === CUSTOM_MESSAGE_TYPE.date && message.date && isDate(message.date)) {
         return <DateSeparator date={message.date} unread={message.unread} />;
       }
 

--- a/src/components/MessageList/__tests__/utils.test.js
+++ b/src/components/MessageList/__tests__/utils.test.js
@@ -1,7 +1,7 @@
 import { generateMessage } from '../../../mock-builders';
 
 import { makeDateMessageId, processMessages } from '../utils';
-import { CUSTOM_MESSAGE } from '../../../constants/messageTypes';
+import { CUSTOM_MESSAGE_TYPE } from '../../../constants/messageTypes';
 
 const mockedUuid = 'e50bc6f4-bbdb-11ec-9180-a4bb6d26ac2f';
 jest.mock('uuid', () => ({
@@ -399,7 +399,7 @@ describe('processMessages', () => {
       enableDateSeparatorParams,
     );
     const customMessages = newMessageList.filter((m) =>
-      Object.values(CUSTOM_MESSAGE).includes(m.customType),
+      Object.values(CUSTOM_MESSAGE_TYPE).includes(m.customType),
     );
     const customMsgIDs = customMessages.map((m) => m.id);
     expect(customMessages).toHaveLength(new Set(customMsgIDs).size);

--- a/src/components/MessageList/__tests__/utils.test.js
+++ b/src/components/MessageList/__tests__/utils.test.js
@@ -1,12 +1,33 @@
-import { v4 as uuidV4 } from 'uuid';
-
 import { generateMessage } from '../../../mock-builders';
 
-import { processMessages } from '../utils';
+import { makeDateMessageId, processMessages } from '../utils';
+import { CUSTOM_MESSAGE } from '../../../constants/messageTypes';
 
-const myUserId = uuidV4();
-const otherUserId = uuidV4();
+const mockedUuid = 'e50bc6f4-bbdb-11ec-9180-a4bb6d26ac2f';
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => mockedUuid),
+}));
+
+const myUserId = 'myUserId';
+const otherUserId = 'otherUserId';
 const enableDateSeparatorParams = { enableDateSeparator: true };
+
+const msgCreationDatesSameDay = [
+  { created_at: new Date('1970-01-01'), updated_at: new Date('1970-01-01') },
+  { created_at: new Date('1970-01-01'), updated_at: new Date('1970-01-01') },
+];
+const msgCreationDatesDifferentDay = [
+  { created_at: new Date('1970-01-01'), updated_at: new Date('1970-01-01') },
+  { created_at: new Date('1970-01-02'), updated_at: new Date('1970-01-02') },
+];
+const msgCreationDatesFirstInvalid = [
+  { created_at: new Date('1970-01-00'), updated_at: new Date('1970-01-00') },
+  { created_at: new Date('1970-01-01'), updated_at: new Date('1970-01-01') },
+];
+const msgCreationDatesSecondInvalid = [
+  { created_at: new Date('1970-01-31'), updated_at: new Date('1970-01-31') },
+  { created_at: new Date('1970-02-00'), updated_at: new Date('1970-02-00') },
+];
 
 const runMessageProcessing = (msgData, processMsgParams = {}) => {
   const messages = msgData.map((msg) => generateMessage(msg));
@@ -19,7 +40,7 @@ const runMessageProcessing = (msgData, processMsgParams = {}) => {
 const makeDateSeparator = (message) => ({
   customType: 'message.date',
   date: message.created_at,
-  id: message.id,
+  id: makeDateMessageId(message.created_at),
 });
 
 const dateSeparatorInsertedAt = (expectedWhere, messages, newMessageList, unread) => {
@@ -54,6 +75,20 @@ const dateSeparatorInsertedAt = (expectedWhere, messages, newMessageList, unread
   }
 };
 
+describe('makeDateMessageId', () => {
+  it('takes a date string and generates string in format "message.date-<message.created_at>"', () => {
+    expect(makeDateMessageId('1970-01-01')).toBe('message.date-1970-01-01');
+  });
+  it('takes a Date object and generates string in format "message.date-<message.created_at-ISOstring>"', () => {
+    expect(makeDateMessageId(new Date('1970-01-01').toISOString())).toBe(
+      'message.date-1970-01-01T00:00:00.000Z',
+    );
+  });
+  it('generates string in format "message.date-<uuidV4>" if no date provided', () => {
+    expect(makeDateMessageId()).toBe(`message.date-${mockedUuid}`);
+  });
+});
+
 describe('processMessages', () => {
   it('returns empty list of messages', () => {
     expect(processMessages({ messages: [], userId: myUserId })).toHaveLength(0);
@@ -81,23 +116,6 @@ describe('processMessages', () => {
   });
 
   describe('date separator', () => {
-    const msgCreationDatesSameDay = [
-      { created_at: new Date('1970-01-01'), updated_at: new Date('1970-01-01') },
-      { created_at: new Date('1970-01-01'), updated_at: new Date('1970-01-01') },
-    ];
-    const msgCreationDatesDifferentDay = [
-      { created_at: new Date('1970-01-01'), updated_at: new Date('1970-01-01') },
-      { created_at: new Date('1970-01-02'), updated_at: new Date('1970-01-02') },
-    ];
-    const msgCreationDatesFirstInvalid = [
-      { created_at: new Date('1970-01-00'), updated_at: new Date('1970-01-00') },
-      { created_at: new Date('1970-01-01'), updated_at: new Date('1970-01-01') },
-    ];
-    const msgCreationDatesSecondInvalid = [
-      { created_at: new Date('1970-01-31'), updated_at: new Date('1970-01-31') },
-      { created_at: new Date('1970-02-00'), updated_at: new Date('1970-02-00') },
-    ];
-
     it('is disabled by default', () => {
       const { messages, newMessageList } = runMessageProcessing(msgCreationDatesSameDay);
       dateSeparatorInsertedAt([], messages, newMessageList);
@@ -373,5 +391,17 @@ describe('processMessages', () => {
       runMessageProcessing(messagesData, { setGiphyPreviewMessage: setGiphyPreviewMessageMock });
       expect(setGiphyPreviewMessageMock).toHaveBeenLastCalledWith(undefined);
     });
+  });
+
+  it('generates custom messages with unique id', () => {
+    const { newMessageList } = runMessageProcessing(
+      msgCreationDatesDifferentDay,
+      enableDateSeparatorParams,
+    );
+    const customMessages = newMessageList.filter((m) =>
+      Object.values(CUSTOM_MESSAGE).includes(m.customType),
+    );
+    const customMsgIDs = customMessages.map((m) => m.id);
+    expect(customMessages).toHaveLength(new Set(customMsgIDs).size);
   });
 });

--- a/src/components/MessageList/hooks/useMessageListElements.tsx
+++ b/src/components/MessageList/hooks/useMessageListElements.tsx
@@ -4,7 +4,7 @@ import React, { useMemo } from 'react';
 import { useLastReadData } from './useLastReadData';
 import { getLastReceived, GroupStyle } from '../utils';
 
-import { CUSTOM_MESSAGE } from '../../../constants/messageTypes';
+import { CUSTOM_MESSAGE_TYPE } from '../../../constants/messageTypes';
 import { DateSeparator as DefaultDateSeparator } from '../../DateSeparator/DateSeparator';
 import { EventComponent } from '../../EventComponent/EventComponent';
 import { Message } from '../../Message';
@@ -77,7 +77,11 @@ export const useMessageListElements = <
   return useMemo(
     () =>
       enrichedMessages.map((message) => {
-        if (message.customType === CUSTOM_MESSAGE.date && message.date && isDate(message.date)) {
+        if (
+          message.customType === CUSTOM_MESSAGE_TYPE.date &&
+          message.date &&
+          isDate(message.date)
+        ) {
           return (
             <li key={`${message.date.toISOString()}-i`}>
               <DateSeparator
@@ -89,7 +93,7 @@ export const useMessageListElements = <
           );
         }
 
-        if (message.customType === CUSTOM_MESSAGE.intro && HeaderComponent) {
+        if (message.customType === CUSTOM_MESSAGE_TYPE.intro && HeaderComponent) {
           return (
             <li key='intro'>
               <HeaderComponent />

--- a/src/components/MessageList/hooks/useMessageListElements.tsx
+++ b/src/components/MessageList/hooks/useMessageListElements.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
 import { useLastReadData } from './useLastReadData';
 import { getLastReceived, GroupStyle } from '../utils';
 
+import { CUSTOM_MESSAGE } from '../../../constants/messageTypes';
 import { DateSeparator as DefaultDateSeparator } from '../../DateSeparator/DateSeparator';
 import { EventComponent } from '../../EventComponent/EventComponent';
 import { Message } from '../../Message';
@@ -76,7 +77,7 @@ export const useMessageListElements = <
   return useMemo(
     () =>
       enrichedMessages.map((message) => {
-        if (message.customType === 'message.date' && message.date && isDate(message.date)) {
+        if (message.customType === CUSTOM_MESSAGE.date && message.date && isDate(message.date)) {
           return (
             <li key={`${message.date.toISOString()}-i`}>
               <DateSeparator
@@ -88,7 +89,7 @@ export const useMessageListElements = <
           );
         }
 
-        if (message.customType === 'channel.intro' && HeaderComponent) {
+        if (message.customType === CUSTOM_MESSAGE.intro && HeaderComponent) {
           return (
             <li key='intro'>
               <HeaderComponent />

--- a/src/components/MessageList/utils.ts
+++ b/src/components/MessageList/utils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-continue */
 import { v4 as uuidV4 } from 'uuid';
 
-import { CUSTOM_MESSAGE } from '../../constants/messageTypes';
+import { CUSTOM_MESSAGE_TYPE } from '../../constants/messageTypes';
 
 import { isDate } from '../../context/TranslationContext';
 
@@ -94,7 +94,7 @@ export const processMessages = <
       // do not show date separator for current user's messages
       if (enableDateSeparator && unread && message.user?.id !== userId) {
         newMessages.push({
-          customType: CUSTOM_MESSAGE.date,
+          customType: CUSTOM_MESSAGE_TYPE.date,
           date: message.created_at,
           id: makeDateMessageId(message.created_at),
           unread,
@@ -110,13 +110,13 @@ export const processMessages = <
         (hideDeletedMessages &&
           previousMessage?.type === 'deleted' &&
           lastDateSeparator !== messageDate)) &&
-      newMessages?.[newMessages.length - 1]?.customType !== CUSTOM_MESSAGE.date // do not show two date separators in a row)
+      newMessages?.[newMessages.length - 1]?.customType !== CUSTOM_MESSAGE_TYPE.date // do not show two date separators in a row)
     ) {
       lastDateSeparator = messageDate;
 
       newMessages.push(
         {
-          customType: CUSTOM_MESSAGE.date,
+          customType: CUSTOM_MESSAGE_TYPE.date,
           date: message.created_at,
           id: makeDateMessageId(message.created_at),
         } as StreamMessage<StreamChatGenerics>,
@@ -142,7 +142,7 @@ export const makeDateMessageId = (date?: string | Date) => {
   } catch (e) {
     idSuffix = uuidV4();
   }
-  return `${CUSTOM_MESSAGE.date}-${idSuffix}`;
+  return `${CUSTOM_MESSAGE_TYPE.date}-${idSuffix}`;
 };
 
 // fast since it usually iterates just the last few messages
@@ -212,7 +212,7 @@ export const insertIntro = <
 ) => {
   const newMessages = messages;
   const intro = ({
-    customType: CUSTOM_MESSAGE.intro,
+    customType: CUSTOM_MESSAGE_TYPE.intro,
   } as unknown) as StreamMessage<StreamChatGenerics>;
 
   // if no headerPosition is set, HeaderComponent will go at the top
@@ -243,7 +243,7 @@ export const insertIntro = <
     if (messageTime && messageTime < headerPosition) {
       // if header position is also smaller than message time continue;
       if (nextMessageTime && nextMessageTime < headerPosition) {
-        if (messages[i + 1] && messages[i + 1].customType === CUSTOM_MESSAGE.date) continue;
+        if (messages[i + 1] && messages[i + 1].customType === CUSTOM_MESSAGE_TYPE.date) continue;
         if (!nextMessageTime) {
           newMessages.push(intro);
           return newMessages;
@@ -268,15 +268,15 @@ export const getGroupStyles = <
   nextMessage: StreamMessage<StreamChatGenerics>,
   noGroupByUser: boolean,
 ): GroupStyle => {
-  if (message.customType === CUSTOM_MESSAGE.date) return '';
-  if (message.customType === CUSTOM_MESSAGE.intro) return '';
+  if (message.customType === CUSTOM_MESSAGE_TYPE.date) return '';
+  if (message.customType === CUSTOM_MESSAGE_TYPE.intro) return '';
 
   if (noGroupByUser || message.attachments?.length !== 0) return 'single';
 
   const isTopMessage =
     !previousMessage ||
-    previousMessage.customType === CUSTOM_MESSAGE.intro ||
-    previousMessage.customType === CUSTOM_MESSAGE.date ||
+    previousMessage.customType === CUSTOM_MESSAGE_TYPE.intro ||
+    previousMessage.customType === CUSTOM_MESSAGE_TYPE.date ||
     previousMessage.type === 'system' ||
     previousMessage.attachments?.length !== 0 ||
     message.user?.id !== previousMessage.user?.id ||
@@ -285,9 +285,9 @@ export const getGroupStyles = <
 
   const isBottomMessage =
     !nextMessage ||
-    nextMessage.customType === CUSTOM_MESSAGE.date ||
+    nextMessage.customType === CUSTOM_MESSAGE_TYPE.date ||
     nextMessage.type === 'system' ||
-    nextMessage.customType === CUSTOM_MESSAGE.intro ||
+    nextMessage.customType === CUSTOM_MESSAGE_TYPE.intro ||
     nextMessage.attachments?.length !== 0 ||
     message.user?.id !== nextMessage.user?.id ||
     nextMessage.type === 'error' ||

--- a/src/constants/messageTypes.ts
+++ b/src/constants/messageTypes.ts
@@ -1,6 +1,4 @@
-import type { CustomMessageType } from '../types/types';
-
-export const CUSTOM_MESSAGE_TYPE: Record<'date' | 'intro', CustomMessageType> = {
+export const CUSTOM_MESSAGE_TYPE = {
   date: 'message.date',
   intro: 'channel.intro',
-};
+} as const;

--- a/src/constants/messageTypes.ts
+++ b/src/constants/messageTypes.ts
@@ -1,0 +1,6 @@
+import type { CustomMessageType } from '../types/types';
+
+export const CUSTOM_MESSAGE: Record<'date' | 'intro', CustomMessageType> = {
+  date: 'message.date',
+  intro: 'channel.intro',
+};

--- a/src/constants/messageTypes.ts
+++ b/src/constants/messageTypes.ts
@@ -1,6 +1,6 @@
 import type { CustomMessageType } from '../types/types';
 
-export const CUSTOM_MESSAGE: Record<'date' | 'intro', CustomMessageType> = {
+export const CUSTOM_MESSAGE_TYPE: Record<'date' | 'intro', CustomMessageType> = {
   date: 'message.date',
   intro: 'channel.intro',
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -10,6 +10,8 @@ export type CustomTrigger = {
   };
 };
 
+export type CustomMessageType = 'channel.intro' | 'message.date';
+
 export type DefaultAttachmentType = UnknownType & {
   asset_url?: string;
   file_size?: number;
@@ -40,7 +42,7 @@ export type DefaultStreamChatGenerics = ExtendableGenerics & {
 export type DefaultMessageType<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = UnknownType & {
-  customType?: 'channel.intro' | 'message.date';
+  customType?: CustomMessageType;
   date?: string | Date;
   errorStatusCode?: number;
   event?: Event<StreamChatGenerics>;


### PR DESCRIPTION
### 🎯 Goal

Fix the bug that generated custom messages of type `'message.date'` with duplicate id as the message they preceded.

fixes #1510 

### 🛠 Implementation details

This PR adds a refactor to the use of custom message type values `'message.date'` and `'channel.intro'`. These values were scattered all around the code base. If they were to be changed, the maintainer would have to make sure those values are changed correctly in all the places. Now the values are referenced by a `CUSTOM_MESSAGE` constant dictionary in a new folder `src/constants`.

