### PR TITLE
ci: add dependabot & PR auto-merge

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,8 @@
+minApprovals:
+  NONE: 0
+requiredLabels:
+  - stream-dependencies
+updateBranch: true
+mergeMethod: rebase
+deleteBranchAfterMerge: true
+requiredTitleRegex: stream-chat-css

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    allow:
+      - dependency-name: '@stream-io/stream-chat-css'
+      - dependency-name: 'stream-chat'
+    labels:
+      - stream-dependencies


### PR DESCRIPTION
### 🎯 Goal

Streamline installation of `stream-chat*` dependencies by adding dependabot configuration. For automatic merging of PRs raised by dependabot I propose to use [probot-auto-merge bot](https://github.com/bobvanderlinden/probot-auto-merge) only for `@stream-io/stream-chat-css`. I believe that updates in the `@stream-io/stream-chat-css` package can be tested only with `stream-chat-react` and so there should not be any incompatibility. As the time goes, we may decide for auto-merge of `stream-chat` bump PRs too.

