### PR TITLE
fix: display overlay "X more" on Gallery only if more images uploaded than displayed

### DIFF
--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -31,6 +31,9 @@ const UnMemoizedGallery = <
 
   const { t } = useTranslationContext('Gallery');
 
+  const countImagesDisplayedInPreview = 4;
+  const lastImageIndexInPreview = countImagesDisplayedInPreview - 1;
+
   const toggleModal = (selectedIndex: number) => {
     if (modalOpen) {
       setModalOpen(false);
@@ -50,35 +53,41 @@ const UnMemoizedGallery = <
     [images],
   );
 
-  const renderImages = images.slice(0, 3).map((image, i) => (
-    <button
-      className='str-chat__gallery-image'
-      data-testid='gallery-image'
-      key={`gallery-image-${i}`}
-      onClick={() => toggleModal(i)}
-    >
-      <img alt='User uploaded content' src={image.image_url || image.thumb_url} />
-    </button>
-  ));
+  const renderImages = images.slice(0, countImagesDisplayedInPreview).map((image, i) =>
+    i === lastImageIndexInPreview && images.length > countImagesDisplayedInPreview ? (
+      <button
+        className='str-chat__gallery-placeholder'
+        key={`gallery-image-${i}`}
+        onClick={() => toggleModal(i)}
+        style={{
+          backgroundImage: `url(${images[lastImageIndexInPreview].image_url})`,
+        }}
+      >
+        <p>
+          {t('{{ imageCount }} more', {
+            imageCount: images.length - countImagesDisplayedInPreview,
+          })}
+        </p>
+      </button>
+    ) : (
+      <button
+        className='str-chat__gallery-image'
+        data-testid='gallery-image'
+        key={`gallery-image-${i}`}
+        onClick={() => toggleModal(i)}
+      >
+        <img alt='User uploaded content' src={image.image_url || image.thumb_url} />
+      </button>
+    ),
+  );
 
   return (
-    <div className={`str-chat__gallery ${images.length > 3 ? 'str-chat__gallery--square' : ''}`}>
+    <div
+      className={`str-chat__gallery ${
+        images.length > lastImageIndexInPreview ? 'str-chat__gallery--square' : ''
+      }`}
+    >
       {renderImages}
-      {images.length > 3 && (
-        <button
-          className='str-chat__gallery-placeholder'
-          onClick={() => toggleModal(3)}
-          style={{
-            backgroundImage: `url(${images[3].image_url})`,
-          }}
-        >
-          <p>
-            {t('{{ imageCount }} more', {
-              imageCount: images.length - 3,
-            })}
-          </p>
-        </button>
-      )}
       <ModalWrapper
         images={formattedArray}
         index={index}

--- a/src/components/Gallery/__tests__/Gallery.test.js
+++ b/src/components/Gallery/__tests__/Gallery.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { getTestClientWithUser } from '../../../mock-builders';
@@ -11,11 +11,6 @@ import { Gallery } from '../Gallery';
 let chatClient;
 
 const mockGalleryAssets = [
-  {
-    original: 'https://placeimg.com/640/480/any',
-    originalAlt: 'User uploaded content',
-    src: 'https://placeimg.com/640/480/any',
-  },
   {
     original: 'https://placeimg.com/640/480/any',
     originalAlt: 'User uploaded content',
@@ -61,7 +56,7 @@ describe('Gallery', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('should render component with 6 images', () => {
+  it('should render component with 5 images', () => {
     const tree = renderer.create(<Gallery images={mockGalleryAssets} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -85,7 +80,25 @@ describe('Gallery', () => {
       </Chat>,
     );
     await waitFor(() => {
-      expect(getByText('3 more')).toBeInTheDocument();
+      expect(getByText('1 more')).toBeInTheDocument();
+    });
+  });
+
+  it('should open the modal with image displayed under the "X more" overlay if clicked on the overlay', async () => {
+    chatClient = await getTestClientWithUser({ id: 'test' });
+    const { container, getByText } = render(
+      <Chat client={chatClient}>
+        <Gallery images={mockGalleryAssets} />,
+      </Chat>,
+    );
+
+    const overlay = await waitFor(() => getByText('1 more'));
+    act(() => {
+      fireEvent.click(overlay);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.image-gallery-index')).toHaveTextContent('4 / 5');
     });
   });
 });

--- a/src/components/Gallery/__tests__/__snapshots__/Gallery.test.js.snap
+++ b/src/components/Gallery/__tests__/__snapshots__/Gallery.test.js.snap
@@ -310,17 +310,13 @@ exports[`Gallery should render component with 4 images 1`] = `
     />
   </button>
   <button
-    className="str-chat__gallery-placeholder"
+    className="str-chat__gallery-image"
+    data-testid="gallery-image"
     onClick={[Function]}
-    style={
-      Object {
-        "backgroundImage": "url(undefined)",
-      }
-    }
   >
-    <p>
-      {{ imageCount }} more
-    </p>
+    <img
+      alt="User uploaded content"
+    />
   </button>
   <div
     className="str-chat__modal str-chat__modal--closed"
@@ -607,7 +603,7 @@ exports[`Gallery should render component with 4 images 1`] = `
 </div>
 `;
 
-exports[`Gallery should render component with 6 images 1`] = `
+exports[`Gallery should render component with 5 images 1`] = `
 <div
   className="str-chat__gallery str-chat__gallery--square"
 >
@@ -888,44 +884,6 @@ exports[`Gallery should render component with 6 images 1`] = `
                 </div>
                 <div
                   aria-label="Go to Slide 5"
-                  className="image-gallery-slide  "
-                  onClick={null}
-                  onFocus={null}
-                  onKeyUp={[Function]}
-                  onMouseLeave={null}
-                  onMouseOver={null}
-                  onTouchEnd={null}
-                  onTouchMove={null}
-                  onTouchStart={null}
-                  role="button"
-                  style={
-                    Object {
-                      "MozTransform": "translate3d(400%, 0, 0)",
-                      "OTransform": "translate3d(400%, 0, 0)",
-                      "WebkitTransform": "translate3d(400%, 0, 0)",
-                      "display": "inherit",
-                      "msTransform": "translate3d(400%, 0, 0)",
-                      "transform": "translate3d(400%, 0, 0)",
-                    }
-                  }
-                  tabIndex="-1"
-                >
-                  <img
-                    alt="User uploaded content"
-                    className="image-gallery-image"
-                    height=""
-                    onError={[Function]}
-                    onLoad={[Function]}
-                    sizes=""
-                    src=""
-                    srcSet=""
-                    title=""
-                    width=""
-                  />
-                  
-                </div>
-                <div
-                  aria-label="Go to Slide 6"
                   className="image-gallery-slide  left "
                   onClick={null}
                   onFocus={null}
@@ -1001,7 +959,7 @@ exports[`Gallery should render component with 6 images 1`] = `
               <span
                 className="image-gallery-index-total"
               >
-                6
+                5
               </span>
             </div>
           </div>


### PR DESCRIPTION
### 🎯 Goal

Display overlay "X more" on Gallery only if more images uploaded than displayed.

Fixes #1418 

### 🛠 Implementation details

If user clicks on:
1. image without the overlay -> the Gallery modal displays the clicked message
2. image with the overlay -> the Gallery modal displays the clicked message

### 🎨 UI Changes

#### Gallery variations main message list:

<details><summary>1 image</summary>

![image](https://user-images.githubusercontent.com/32706194/163753670-474a589f-2498-4d62-b00e-66379976e2c5.png)

</details>

<details><summary>2 images</summary>

![image](https://user-images.githubusercontent.com/32706194/163753690-3bba93d0-ee43-4613-b5ec-a21609183c70.png)

</details>

<details><summary>3 images</summary>

![image](https://user-images.githubusercontent.com/32706194/163753704-8b7b18e1-7207-48ce-9244-d298f6fbbd19.png)

</details>

<details><summary>4 images</summary>

![image](https://user-images.githubusercontent.com/32706194/163753715-8354671d-4e72-4641-9457-1a2f3c1ca610.png)

</details>

<details><summary>5 images</summary>

![image](https://user-images.githubusercontent.com/32706194/163753722-a4884d1f-cc7a-4324-b549-14b363a245e5.png)

</details>

<details><summary>6 images</summary>

![image](https://user-images.githubusercontent.com/32706194/163753733-e0b0f61f-0d3a-4f73-b380-5972833def54.png)

</details>

#### Gallery variations thread:

<details><summary>thread</summary>

![image](https://user-images.githubusercontent.com/32706194/163753982-e81bd25c-e163-4bde-a7f0-ac96c58a2499.png)

![image](https://user-images.githubusercontent.com/32706194/163753960-1ce3efa1-8b94-4410-95c6-6657b7cb3970.png)

</details>