### PR TITLE
test: fix client connect/disconnect issue

### DIFF
--- a/e2e/jump-to-message.test.ts
+++ b/e2e/jump-to-message.test.ts
@@ -2,15 +2,17 @@
 /* eslint-disable jest/require-top-level-describe */
 import { expect, test } from '@playwright/test';
 
-test.describe('jump to message', () => {
-  [
-    ['virtualized', 'jump-to-message--jump-in-virtualized-message-list'],
-    ['regular', 'jump-to-message--jump-in-regular-message-list'],
-  ].forEach(([mode, story]) => {
+const suiteArray = [
+  ['virtualized', 'jump-to-message--jump-in-virtualized-message-list'],
+  ['regular', 'jump-to-message--jump-in-regular-message-list'],
+];
+
+suiteArray.forEach(([mode, story]) => {
+  test.describe(`jump to message - ${mode}`, () => {
     test.beforeEach(async ({ baseURL, page }) => {
       await page.goto(`${baseURL}/?story=${story}`);
       await page.waitForSelector('[data-storyloaded]');
-      await page.waitForSelector('text=Message 149');
+      await page.waitForSelector('data-testid=message-text-inner-wrapper >> text=Message 149');
     });
 
     test(`${mode} jumps to message 29 and then back to bottom`, async ({ page }) => {
@@ -19,7 +21,9 @@ test.describe('jump to message', () => {
       await page.click('data-testid=jump-to-message');
       await expect(message29).toBeVisible();
       await page.click('text=Latest Messages');
-      await expect(page.locator('text=Message 149')).toBeVisible();
+      await expect(
+        page.locator('data-testid=message-text-inner-wrapper >> text=Message 149'),
+      ).toBeVisible();
     });
 
     test(`${mode} jumps to quoted message`, async ({ page }) => {
@@ -27,11 +31,13 @@ test.describe('jump to message', () => {
       await expect(page.locator('text=Message 20')).toBeVisible();
     });
   });
+});
 
+test.describe('jump to messsage - dataset', () => {
   test('only the current message set is loaded', async ({ baseURL, page }) => {
     await page.goto(`${baseURL}/?story=jump-to-message--jump-in-regular-message-list`);
     await page.waitForSelector('[data-storyloaded]');
-    await page.waitForSelector('text=Message 149');
+    await page.waitForSelector('data-testid=message-text-inner-wrapper >> text=Message 149');
     await page.click('data-testid=jump-to-message');
     await page.waitForSelector('text=Message 29');
     const listItems = page.locator('.str-chat__ul > li');

--- a/src/stories/connected-user.stories.tsx
+++ b/src/stories/connected-user.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import '@stream-io/stream-chat-css/dist/css/index.css';
 import React from 'react';
-import { ChannelSort, StreamChat } from 'stream-chat';
+import type { ChannelSort } from 'stream-chat';
 import {
   Channel,
   ChannelHeader,
@@ -10,7 +10,7 @@ import {
   useChannelStateContext,
   Window,
 } from '../index';
-import { apiKey, ConnectedUser, ConnectedUserProps, StreamChatGenerics } from './utils';
+import { ConnectedUser, ConnectedUserProps } from './utils';
 
 const channelId = import.meta.env.E2E_ADD_MESSAGE_CHANNEL;
 if (!channelId || typeof channelId !== 'string') {
@@ -42,10 +42,8 @@ const Controls = () => {
 // Sort in reverse order to avoid auto-selecting unread channel
 const sort: ChannelSort = { last_updated: 1 };
 
-const chatClient = StreamChat.getInstance<StreamChatGenerics>(apiKey);
-
 const WrappedConnectedUser = ({ token, userId }: Omit<ConnectedUserProps, 'children'>) => (
-  <ConnectedUser client={chatClient} token={token} userId={userId}>
+  <ConnectedUser token={token} userId={userId}>
     <ChannelList filters={{ members: { $in: [userId] } }} sort={sort} />
     <Channel>
       <Window>

--- a/src/stories/hello.stories.tsx
+++ b/src/stories/hello.stories.tsx
@@ -1,18 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import '@stream-io/stream-chat-css/dist/css/index.css';
-import React, { useEffect, useState } from 'react';
-import { ChannelFilters, ChannelOptions, ChannelSort, Event, StreamChat } from 'stream-chat';
+import React from 'react';
+import type { ChannelFilters, ChannelOptions, ChannelSort } from 'stream-chat';
 import {
   Channel,
   ChannelHeader,
   ChannelList,
-  Chat,
   MessageInput,
   MessageList,
   Thread,
   Window,
 } from '../index';
-import { apiKey, StreamChatGenerics } from './utils';
+import { ConnectedUser } from './utils';
 
 const channelId = import.meta.env.E2E_ADD_MESSAGE_CHANNEL;
 const userId = import.meta.env.E2E_TEST_USER_1 as string;
@@ -27,42 +26,16 @@ const sort: ChannelSort = { last_updated: 1 };
 const filters: ChannelFilters = { members: { $in: [userId] }, type: 'messaging' };
 const options: ChannelOptions = { limit: 10, presence: true, state: true };
 
-const chatClient = StreamChat.getInstance<StreamChatGenerics>(apiKey);
-let sharedPromise = Promise.resolve();
-
-export const BasicSetup = () => {
-  const [connected, setConnected] = useState(false);
-
-  useEffect(() => {
-    sharedPromise.then(() => chatClient.connectUser({ id: userId }, token));
-
-    const handleConnectionChange = ({ online = false }: Event) => {
-      setConnected(online);
-    };
-
-    chatClient.on('connection.changed', handleConnectionChange);
-
-    return () => {
-      chatClient.off('connection.changed', handleConnectionChange);
-      sharedPromise = chatClient.disconnectUser();
-    };
-  }, []);
-
-  if (!connected) {
-    return <p>Connecting {userId}...</p>;
-  }
-
-  return (
-    <Chat client={chatClient}>
-      <ChannelList filters={filters} options={options} showChannelSearch sort={sort} />
-      <Channel>
-        <Window>
-          <ChannelHeader />
-          <MessageList />
-          <MessageInput focus />
-        </Window>
-        <Thread />
-      </Channel>
-    </Chat>
-  );
-};
+export const BasicSetup = () => (
+  <ConnectedUser token={token} userId={userId}>
+    <ChannelList filters={filters} options={options} showChannelSearch sort={sort} />
+    <Channel>
+      <Window>
+        <ChannelHeader />
+        <MessageList />
+        <MessageInput focus />
+      </Window>
+      <Thread />
+    </Channel>
+  </ConnectedUser>
+);

--- a/src/stories/jump-to-message.stories.tsx
+++ b/src/stories/jump-to-message.stories.tsx
@@ -1,48 +1,27 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useEffect, useState } from 'react';
-import { StreamChat } from 'stream-chat';
+import React from 'react';
 import {
   Channel,
-  Chat,
+  ChannelList,
   MessageList,
   useChannelActionContext,
+  useChatContext,
   VirtualizedMessageList,
   Window,
 } from '../index';
 import '@stream-io/stream-chat-css/dist/css/index.css';
+import { ConnectedUser } from './utils';
 
 void MessageList;
 void VirtualizedMessageList;
 
-const apiKey = import.meta.env.E2E_APP_KEY;
 const userId = import.meta.env.E2E_TEST_USER_1;
 const userToken = import.meta.env.E2E_TEST_USER_1_TOKEN;
 const channelId = import.meta.env.E2E_JUMP_TO_MESSAGE_CHANNEL;
 
-type LocalAttachmentType = Record<string, unknown>;
-type LocalChannelType = Record<string, unknown>;
-type LocalCommandType = string;
-type LocalEventType = Record<string, unknown>;
-type LocalMessageType = Record<string, unknown>;
-type LocalReactionType = Record<string, unknown>;
-type LocalUserType = Record<string, unknown>;
-
-type StreamChatGenerics = {
-  attachmentType: LocalAttachmentType;
-  channelType: LocalChannelType;
-  commandType: LocalCommandType;
-  eventType: LocalEventType;
-  messageType: LocalMessageType;
-  reactionType: LocalReactionType;
-  userType: LocalUserType;
-};
-
-const chatClient = StreamChat.getInstance<StreamChatGenerics>(apiKey);
-
-chatClient.connectUser({ id: userId }, userToken);
-
 const JumpToMessage = () => {
   const { jumpToMessage } = useChannelActionContext();
+  const { client: chatClient } = useChatContext();
 
   return (
     <button
@@ -72,56 +51,32 @@ const StyleFix = () => (
   `}</style>
 );
 
-const useTheJumpChannel = () => {
-  const [channel, setChannel] = useState<any>(null);
+export const JumpInRegularMessageList = () => (
+  <div>
+    <StyleFix />
+    <ConnectedUser token={userToken} userId={userId}>
+      <ChannelList filters={{ id: { $eq: channelId } }} />
+      <Channel>
+        <JumpToMessage />
+        <Window>
+          <MessageList />
+        </Window>
+      </Channel>
+    </ConnectedUser>
+  </div>
+);
 
-  useEffect(() => {
-    (async () => {
-      const channels = await chatClient.queryChannels({ id: { $eq: channelId } });
-      setChannel(channels[0]);
-    })();
-  }, []);
-  return channel;
-};
-
-export const JumpInRegularMessageList = () => {
-  const channel = useTheJumpChannel();
-  if (!channel) {
-    return null;
-  }
-  return (
-    <div>
-      <StyleFix />
-      <Chat client={chatClient}>
-        <Channel channel={channel}>
-          <JumpToMessage />
-          <Window>
-            <MessageList />
-          </Window>
-        </Channel>
-      </Chat>
-    </div>
-  );
-};
-
-export const JumpInVirtualizedMessageList = () => {
-  const channel = useTheJumpChannel();
-
-  if (!channel) {
-    return null;
-  }
-
-  return (
-    <div>
-      <StyleFix />
-      <Chat client={chatClient}>
-        <Channel channel={channel}>
-          <JumpToMessage />
-          <Window>
-            <VirtualizedMessageList />
-          </Window>
-        </Channel>
-      </Chat>
-    </div>
-  );
-};
+export const JumpInVirtualizedMessageList = () => (
+  <div>
+    <StyleFix />
+    <ConnectedUser token={userToken} userId={userId}>
+      <ChannelList filters={{ id: { $eq: channelId } }} />
+      <Channel>
+        <JumpToMessage />
+        <Window>
+          <VirtualizedMessageList />
+        </Window>
+      </Channel>
+    </ConnectedUser>
+  </div>
+);

--- a/src/stories/mark-read.stories.tsx
+++ b/src/stories/mark-read.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import '@stream-io/stream-chat-css/dist/css/index.css';
 import React from 'react';
-import { ChannelSort, StreamChat } from 'stream-chat';
+import type { ChannelSort } from 'stream-chat';
 import { v4 as uuid } from 'uuid';
 import {
   Channel,
@@ -14,7 +14,7 @@ import {
   useChannelStateContext,
   Window,
 } from '../index';
-import { apiKey, ConnectedUser, ConnectedUserProps, StreamChatGenerics } from './utils';
+import { ConnectedUser, ConnectedUserProps } from './utils';
 
 const channelId = import.meta.env.E2E_ADD_MESSAGE_CHANNEL;
 if (!channelId || typeof channelId !== 'string') {
@@ -46,9 +46,7 @@ const Controls = () => {
 // Sort in reverse order to avoid auto-selecting unread channel
 const sort: ChannelSort = { last_updated: 1 };
 
-const chatClient = StreamChat.getInstance<StreamChatGenerics>(apiKey);
-
-const Custom = ({
+const CustomPreviewUI = ({
   activeChannel,
   channel,
   displayTitle,
@@ -71,11 +69,11 @@ const Custom = ({
 };
 
 const CustomPreview = (props: ChannelPreviewProps) => (
-  <ChannelPreview {...props} Preview={Custom} />
+  <ChannelPreview {...props} Preview={CustomPreviewUI} />
 );
 
 const WrappedConnectedUser = ({ token, userId }: Omit<ConnectedUserProps, 'children'>) => (
-  <ConnectedUser client={chatClient} token={token} userId={userId}>
+  <ConnectedUser token={token} userId={userId}>
     <ChannelList
       filters={{ members: { $in: [userId] }, name: { $autocomplete: 'mr-channel' } }}
       Preview={CustomPreview}

--- a/src/stories/utils.tsx
+++ b/src/stories/utils.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, useEffect, useState } from 'react';
 import { Chat } from '../';
-import type { Event, StreamChat } from 'stream-chat';
+import { Event, StreamChat } from 'stream-chat';
 
 const appKey = import.meta.env.E2E_APP_KEY;
 if (!appKey || typeof appKey !== 'string') {
@@ -26,36 +26,34 @@ export type StreamChatGenerics = {
   userType: LocalUserType;
 };
 
-// wait for disconnect to happen since there's only one shared
-// client and two separate Chat components using it to prevent crashes
-let sharedPromise = Promise.resolve();
-
 export type ConnectedUserProps = PropsWithChildren<{
   token: string;
   userId: string;
-  client?: StreamChat;
 }>;
 
-export const ConnectedUser = ({ children, client, token, userId }: ConnectedUserProps) => {
-  const [connected, setConnected] = useState(false);
+export const ConnectedUser = ({ children, token, userId }: ConnectedUserProps) => {
+  const [client, setClient] = useState<StreamChat | null>(null);
 
   useEffect(() => {
-    sharedPromise.then(() => client?.connectUser({ id: userId }, token));
+    const c = new StreamChat(apiKey);
+
+    c.connectUser({ id: userId }, token).then(() => setClient(c));
 
     const handleConnectionChange = ({ online = false }: Event) => {
-      setConnected(online);
+      if (!online) console.log('connection lost');
+      setClient(c);
     };
 
-    client?.on('connection.changed', handleConnectionChange);
+    c.on('connection.changed', handleConnectionChange);
 
     return () => {
-      client?.off('connection.changed', handleConnectionChange);
-      sharedPromise = client?.disconnectUser() ?? Promise.resolve();
+      c.off('connection.changed', handleConnectionChange);
+      c.disconnectUser().then(() => console.log('connection closed'));
     };
-  }, []);
+  }, [userId, token]);
 
-  if (!connected || !client) {
-    return <p>Connecting {userId}...</p>;
+  if (!client) {
+    return <p>Waiting for connection to be established with user: {userId}...</p>;
   }
 
   return (

--- a/src/stories/utils.tsx
+++ b/src/stories/utils.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, useEffect, useState } from 'react';
 import { Chat } from '../';
-import { Event, StreamChat } from 'stream-chat';
+import { DefaultGenerics, Event, StreamChat } from 'stream-chat';
 
 const appKey = import.meta.env.E2E_APP_KEY;
 if (!appKey || typeof appKey !== 'string') {
@@ -31,11 +31,15 @@ export type ConnectedUserProps = PropsWithChildren<{
   userId: string;
 }>;
 
-export const ConnectedUser = ({ children, token, userId }: ConnectedUserProps) => {
-  const [client, setClient] = useState<StreamChat | null>(null);
+export const ConnectedUser = <SCG extends DefaultGenerics = StreamChatGenerics>({
+  children,
+  token,
+  userId,
+}: ConnectedUserProps) => {
+  const [client, setClient] = useState<StreamChat<SCG> | null>(null);
 
   useEffect(() => {
-    const c = new StreamChat(apiKey);
+    const c = new StreamChat<SCG>(apiKey);
 
     c.connectUser({ id: userId }, token).then(() => setClient(c));
 


### PR DESCRIPTION
### 🎯 Goal

Connection issues due to previous setup caused problems to some of the tests which then failed.

### 🛠 Implementation details

- use of `new StreamChat()` instead of `StreamChat.getInstance` ensures new instance for each story, disconnection happens behind the scenes and is not intrusive
- fix double `beforeEach` call in `jump-to-message` test 