### PR TITLE
fix: remove `stream-chat-react-<version>` from client User-Agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,11 +183,10 @@
   },
   "scripts": {
     "analyze": "yarn build -- --stats && webpack-bundle-analyzer build/bundle-stats.json",
-    "build": "rm -rf dist && mkdir -p dist/assets assets && yarn --silent copy-version && yarn build-translations && yarn types && yarn bundle",
+    "build": "rm -rf dist && mkdir -p dist/assets assets && yarn build-translations && yarn types && yarn bundle",
     "bundle": "rollup -c",
     "bundle-size": "BUNDLE_SIZE=true yarn bundle",
     "build-translations": "i18next",
-    "copy-version": "echo '\u001b[34mℹ\u001b[0m Copying Version to \u001b[34msrc/version.ts\u001b[0m' && PACKAGE_VERSION=$(node -pe 'require(`./package.json`).version') && PACKAGE_STRING=\"'$PACKAGE_VERSION'\" && echo 'export const version = '$PACKAGE_STRING';' > ./src/version.ts && echo '\u001b[32m✓\u001b[0m Done Copying Version'",
     "coverage": "jest --collectCoverage && codecov",
     "eslint": "eslint '**/*.{js,md,ts,jsx,tsx}' --max-warnings 0",
     "lint": "prettier --list-different 'src/**/*.{js,ts,tsx,md,json}' .eslintrc.json .prettierrc babel.config.js && eslint 'src/**/*.{js,ts,tsx,md}' --max-warnings 0 && yarn validate-translations",

--- a/src/components/Chat/__tests__/Chat.test.js
+++ b/src/components/Chat/__tests__/Chat.test.js
@@ -12,8 +12,6 @@ import {
   getTestClientWithUser,
 } from '../../../mock-builders';
 
-import { version } from '../../../../package.json';
-
 const ChatContextConsumer = ({ fn }) => {
   fn(useContext(ChatContext));
   return <div data-testid='children' />;
@@ -27,7 +25,6 @@ const TranslationContextConsumer = ({ fn }) => {
 describe('Chat', () => {
   afterEach(cleanup);
   const chatClient = getTestClient();
-  const originalUserAgent = chatClient.getUserAgent();
 
   it('should render children without crashing', async () => {
     const { getByTestId } = render(
@@ -61,9 +58,6 @@ describe('Chat', () => {
       expect(context.setActiveChannel).toBeInstanceOf(Function);
       expect(context.openMobileNav).toBeInstanceOf(Function);
       expect(context.closeMobileNav).toBeInstanceOf(Function);
-      expect(context.client.getUserAgent()).toBe(
-        `stream-chat-react-${version}-${originalUserAgent}`,
-      );
     });
   });
 

--- a/src/components/Chat/hooks/useChat.ts
+++ b/src/components/Chat/hooks/useChat.ts
@@ -7,7 +7,6 @@ import {
   TranslationContextValue,
 } from '../../../context/TranslationContext';
 import { Streami18n } from '../../../i18n';
-import { version } from '../../../version';
 
 import type { AppSettingsAPIResponse, Channel, Event, Mute, StreamChat } from 'stream-chat';
 
@@ -55,16 +54,6 @@ export const useChat = <
     appSettings.current = client.getAppSettings();
     return appSettings.current;
   };
-
-  useEffect(() => {
-    if (client) {
-      const userAgent = client.getUserAgent();
-      if (!userAgent.includes('stream-chat-react')) {
-        // result looks like: 'stream-chat-react-2.3.2-stream-chat-javascript-client-browser-2.2.2'
-        client.setUserAgent(`stream-chat-react-${version}-${userAgent}`);
-      }
-    }
-  }, [client]);
 
   useEffect(() => {
     setMutes(clientMutes);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,0 @@
-export const version = '0.0.0-development';


### PR DESCRIPTION
### 🎯 Goal

Remove everything revolving around `version.ts` file which seems like it's not being properly used since PR #1250.