### PR TITLE
docs: `connect/disconnect(User)`/instantiation code snippets update

### DIFF
--- a/docusaurus/docs/React/basics/getting-started.mdx
+++ b/docusaurus/docs/React/basics/getting-started.mdx
@@ -42,7 +42,7 @@ Initialize the Stream Chat client:
 ```jsx
 import { StreamChat } from 'stream-chat';
 
-const client = StreamChat.getInstance('your_api_key');
+const client = new StreamChat('your_api_key');
 
 <Chat client={client}>{/** children of Chat component*/}</Chat>;
 ```
@@ -195,32 +195,34 @@ const filters = { type: 'messaging' };
 const options = { state: true, presence: true, limit: 10 };
 const sort = { last_message_at: -1 };
 
-const client = StreamChat.getInstance('your_api_key');
-
 const App = () => {
-  const [clientReady, setClientReady] = useState(false);
+  const [client, setClient] = useState(null);
 
   useEffect(() => {
-    const setupClient = async () => {
-      try {
-        await client.connectUser(
-          {
-            id: 'dave-matthews',
-            name: 'Dave Matthews',
-          },
-          'your_user_token',
-        );
+    const newClient = new StreamChat('your_api_key');
 
-        setClientReady(true);
-      } catch (err) {
-        console.log(err);
-      }
+    const handleConnectionChange = ({ online = false }) => {
+      if (!online) return console.log('connection lost');
+      setClient(newClient);
     };
 
-    setupClient();
+    newClient.on('connection.changed', handleConnectionChange);
+
+    newClient.connectUser(
+      {
+        id: 'dave-matthews',
+        name: 'Dave Matthews',
+      },
+      'your_user_token',
+    );
+
+    return () => {
+      newClient.off('connection.changed', handleConnectionChange);
+      newClient.disconnectUser().then(() => console.log('connection closed'));
+    };
   }, []);
 
-  if (!clientReady) return null;
+  if (!client) return null;
 
   return (
     <Chat client={client}>

--- a/docusaurus/docs/React/customization/typescript.mdx
+++ b/docusaurus/docs/React/customization/typescript.mdx
@@ -14,7 +14,7 @@ value's type. It is therefore important that the proper generics be applied to t
 The Stream Chat client takes a type with seven customizable fields that currently exist in `stream-chat`.
 
 ```tsx
-const client = StreamChat.getInstance<StreamChatGenerics>('YOUR_API_KEY');
+const client = new StreamChat<StreamChatGenerics>('YOUR_API_KEY');
 ```
 
 `StreamChatGenerics` can be defined as a type with the seven generics that correspond to the seven customizable fields as follows:
@@ -97,7 +97,7 @@ type StreamChatGenerics = {
 ```
 
 ```tsx
-const client = StreamChat.getInstance<StreamChatGenerics>('YOUR_API_KEY');
+const client = new StreamChat<StreamChatGenerics>('YOUR_API_KEY');
 ```
 
 Through this client instantiation, we have added type support for the following values:


### PR DESCRIPTION
### 🎯 Goal

Update documentation to use basic instantiation rather than using `StreamChat.getInstance` which causes connection issues for the users who tend to switch between user profiles within one application.