### PR TITLE
ci: change preactjs/compressed-size-action version to @latest

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: preactjs/compressed-size-action@v2.5
+      - uses: preactjs/compressed-size-action@latest
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           pattern: './dist/**/*.{js,css,json}'


### PR DESCRIPTION
### 🎯 Goal

Fix error in action Compressed Size:

```Unable to resolve action `preactjs/compressed-size-action@v2.5`, unable to find version `v2.5```
