### PR TITLE
ci(release): add releaseRules to commit-analyzer plugin

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,7 +8,13 @@
     }
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [{ "type": "chore", "scope": "deps", "release": "patch" }]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",


### PR DESCRIPTION
### 🎯 Goal

Add `releaseRules` key to the `.releaserc.json` configuration file to trigger release on commit of type `chore` with scope `deps`. 