### PR TITLE
fix: propagate user update data to UI

### DIFF
--- a/src/components/Channel/hooks/useCreateChannelStateContext.ts
+++ b/src/components/Channel/hooks/useCreateChannelStateContext.ts
@@ -73,7 +73,7 @@ export const useCreateChannelStateContext = <
               updated_at && (isDayOrMoment(updated_at) || isDate(updated_at))
                 ? updated_at.toISOString()
                 : updated_at || ''
-            }${user?.image}${user?.name}`,
+            }${user?.updated_at}`,
         )
         .join();
 
@@ -86,7 +86,7 @@ export const useCreateChannelStateContext = <
           updated_at && (isDayOrMoment(updated_at) || isDate(updated_at))
             ? updated_at.toISOString()
             : updated_at || ''
-        }${user?.image}${user?.name}`,
+        }${user?.updated_at}`,
     )
     .join();
 

--- a/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/src/components/ChannelPreview/ChannelPreview.tsx
@@ -112,15 +112,16 @@ export const ChannelPreview = <
 
   useEffect(() => {
     const handleEvent = () => {
-      const newDisplayTitle = getDisplayTitle(channel, client.user);
-      const newDisplayImage = getDisplayImage(channel, client.user);
-      if (newDisplayTitle !== displayTitle) {
-        setDisplayTitle(newDisplayTitle);
-      }
-      if (newDisplayImage !== displayImage) {
-        setDisplayImage(newDisplayImage);
-      }
+      setDisplayTitle((displayTitle) => {
+        const newDisplayTitle = getDisplayTitle(channel, client.user);
+        return displayTitle !== newDisplayTitle ? newDisplayTitle : displayTitle;
+      });
+      setDisplayImage((displayImage) => {
+        const newDisplayImage = getDisplayImage(channel, client.user);
+        return displayImage !== newDisplayImage ? newDisplayImage : displayImage;
+      });
     };
+
     client.on('user.updated', handleEvent);
     return () => {
       client.off('user.updated', handleEvent);

--- a/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/src/components/ChannelPreview/ChannelPreview.tsx
@@ -58,11 +58,12 @@ export const ChannelPreview = <
   props: ChannelPreviewProps<StreamChatGenerics>,
 ) => {
   const { channel, Preview = ChannelPreviewMessenger, channelUpdateCount } = props;
-
   const { channel: activeChannel, client, setActiveChannel } = useChatContext<StreamChatGenerics>(
     'ChannelPreview',
   );
   const { t, userLanguage } = useTranslationContext('ChannelPreview');
+  const [displayTitle, setDisplayTitle] = useState(getDisplayTitle(channel, client.user));
+  const [displayImage, setDisplayImage] = useState(getDisplayImage(channel, client.user));
 
   const [lastMessage, setLastMessage] = useState<StreamMessage<StreamChatGenerics>>(
     channel.state.messages[channel.state.messages.length - 1],
@@ -109,10 +110,25 @@ export const ChannelPreview = <
     };
   }, [refreshUnreadCount, channelUpdateCount]);
 
+  useEffect(() => {
+    const handleEvent = () => {
+      const newDisplayTitle = getDisplayTitle(channel, client.user);
+      const newDisplayImage = getDisplayImage(channel, client.user);
+      if (newDisplayTitle !== displayTitle) {
+        setDisplayTitle(newDisplayTitle);
+      }
+      if (newDisplayImage !== displayImage) {
+        setDisplayImage(newDisplayImage);
+      }
+    };
+    client.on('user.updated', handleEvent);
+    return () => {
+      client.off('user.updated', handleEvent);
+    };
+  }, []);
+
   if (!Preview) return null;
 
-  const displayImage = getDisplayImage(channel, client.user);
-  const displayTitle = getDisplayTitle(channel, client.user);
   const latestMessage = getLatestMessagePreview(channel, t, userLanguage);
 
   return (

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -246,8 +246,7 @@ export const areMessagePropsEqual = <
     prevMessage.text === nextMessage.text &&
     prevMessage.type === nextMessage.type &&
     prevMessage.updated_at === nextMessage.updated_at &&
-    prevMessage.user?.image === nextMessage.user?.image &&
-    prevMessage.user?.name === nextMessage.user?.name;
+    prevMessage.user?.updated_at === nextMessage.user?.updated_at;
 
   if (!messagesAreEqual) return false;
 
@@ -295,7 +294,7 @@ export const areMessageUIPropsEqual = <
     return false;
   }
 
-  const messagesAreEqual =
+  return (
     prevMessage.deleted_at === nextMessage.deleted_at &&
     prevMessage.latest_reactions?.length === nextMessage.latest_reactions?.length &&
     prevMessage.own_reactions?.length === nextMessage.own_reactions?.length &&
@@ -305,12 +304,8 @@ export const areMessageUIPropsEqual = <
     prevMessage.text === nextMessage.text &&
     prevMessage.type === nextMessage.type &&
     prevMessage.updated_at === nextMessage.updated_at &&
-    prevMessage.user?.image === nextMessage.user?.image &&
-    prevMessage.user?.name === nextMessage.user?.name;
-
-  if (!messagesAreEqual) return false;
-
-  return true;
+    prevMessage.user?.updated_at === nextMessage.user?.updated_at
+  );
 };
 
 export const messageHasReactions = <

--- a/src/mock-builders/event/index.js
+++ b/src/mock-builders/event/index.js
@@ -12,3 +12,4 @@ export { default as dispatchNotificationAddedToChannelEvent } from './notificati
 export { default as dispatchNotificationMessageNewEvent } from './notificationMessageNew';
 export { default as dispatchNotificationMutesUpdated } from './notificationMutesUpdated';
 export { default as dispatchNotificationRemovedFromChannel } from './notificationRemovedFromChannel';
+export { default as dispatchUserUpdatedEvent } from './userUpdated';

--- a/src/mock-builders/event/userUpdated.js
+++ b/src/mock-builders/event/userUpdated.js
@@ -1,0 +1,7 @@
+export default (client, user) => {
+  client.dispatchEvent({
+    created_at: new Date().toISOString(),
+    type: 'user.updated',
+    user,
+  });
+};


### PR DESCRIPTION
### 🎯 Goal

Reflect updates to user's data in:

* 2-members channel preview
* Avatar (in MessageList, Thread, ChannelPreview)

fixes #1565

### 🛠 Implementation details

#### `MessageList`
The change's are performed upon reception of WS event `user.updated`. The implementation takes into account that a user can have custom fields and therefore the memoization in `MessageList` takes this into account. Until now, the changes were propagated to the most bottom components only if user's `image` or `name` changed. Those are default attributes. Therefore if a custom `Avatar` component displays custom user data, their update would not be reflected until page is refreshed.

#### `ChannelPreview`
The `ChannelList` component neither its children were listening to `user.updated` event and therefore the event listener has been added to the `ChannelPreview`'s effect. 

#### Out of scope
`ChannelHeader` does not display image if the channel is DM channel (`channel.data.name === undefined`). This could be considered a bug or insufficiency. The `ChannelHeader` should probably behave the same way as `ChannelPreview` in terms of its title and displayed image to support consistency. This is out of scope of this PR, because it would introduced breaking changes in form of changed component behavior.
