### PR TITLE
chore: add "status: unconfirmed" label to a newly created issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: 'bug:'
-labels: bug
+labels: 'bug, status: unconfirmed'
 assignees: ''
 
 ---


### PR DESCRIPTION
### 🎯 Goal

Add a new default label on the bug issue template. It should provide a feedback to a requester about the actual status of the issue. The status then can be changed by labeling the issue "status: confirmed" once confirmed by a maintainer dev.