### PR TITLE
feat: use ResizeObserver to keep Channel scrolled to bottom on page load

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "dependencies": {
     "@braintree/sanitize-url": "6.0.0",
+    "@juggle/resize-observer": "^3.3.1",
     "@stream-io/stream-chat-css": "^2.8.0",
     "dayjs": "^1.10.4",
     "emoji-mart": "3.0.1",

--- a/src/components/ChannelList/__tests__/ChannelList.test.js
+++ b/src/components/ChannelList/__tests__/ChannelList.test.js
@@ -394,7 +394,7 @@ describe('ChannelList', () => {
       filters: {},
       List: ChannelListComponent,
       Preview: ChannelPreviewComponent,
-      renderChannels: renderChannels,
+      renderChannels,
     };
     const { container, getByRole } = render(
       <Chat client={chatClientUthred}>
@@ -408,7 +408,7 @@ describe('ChannelList', () => {
     });
 
     await waitFor(() => {
-      expect(renderChannels).toHaveBeenCalled();
+      expect(renderChannels).toHaveBeenCalledTimes(1);
     });
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/src/components/InfiniteScrollPaginator/InfiniteScroll.tsx
+++ b/src/components/InfiniteScrollPaginator/InfiniteScroll.tsx
@@ -81,10 +81,6 @@ export const InfiniteScroll = (props: PropsWithChildren<InfiniteScrollProps>) =>
     scrollElement.addEventListener('scroll', scrollListener, useCapture);
     scrollElement.addEventListener('resize', scrollListener, useCapture);
 
-    if (initialLoad) {
-      scrollListener();
-    }
-
     return () => {
       scrollElement.removeEventListener('scroll', scrollListener, useCapture);
       scrollElement.removeEventListener('resize', scrollListener, useCapture);

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -67,6 +67,8 @@ const MessageListWithContext = <
     jumpToLatestMessage = () => Promise.resolve(),
   } = props;
 
+  const ulRef = React.useRef<HTMLUListElement>(null);
+
   const { customClasses } = useChatContext<StreamChatGenerics>('MessageList');
 
   const {
@@ -88,6 +90,7 @@ const MessageListWithContext = <
     messages,
     scrolledUpThreshold: props.scrolledUpThreshold,
     suppressAutoscroll,
+    ulRef,
   });
 
   const { messageGroupStyles, messages: enrichedMessages } = useEnrichedMessages({
@@ -163,8 +166,6 @@ const MessageListWithContext = <
     }
   }, [scrollToBottom, hasMoreNewer]);
 
-  const ulRef = React.useRef<HTMLUListElement>(null);
-
   React.useLayoutEffect(() => {
     if (highlightedMessageId) {
       const element = ulRef.current?.querySelector(`[data-message-id='${highlightedMessageId}']`);
@@ -174,7 +175,12 @@ const MessageListWithContext = <
 
   return (
     <>
-      <div className={`${messageListClass} ${threadListClass}`} onScroll={onScroll} ref={listRef}>
+      <div
+        className={`${messageListClass} ${threadListClass}`}
+        onScroll={onScroll}
+        ref={listRef}
+        tabIndex={0}
+      >
         {!elements.length ? (
           <EmptyStateIndicator listType='message' />
         ) : (

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -67,6 +67,7 @@ const MessageListWithContext = <
     jumpToLatestMessage = () => Promise.resolve(),
   } = props;
 
+  const listRef = React.useRef<HTMLDivElement>(null);
   const ulRef = React.useRef<HTMLUListElement>(null);
 
   const { customClasses } = useChatContext<StreamChatGenerics>('MessageList');
@@ -80,13 +81,13 @@ const MessageListWithContext = <
 
   const {
     hasNewMessages,
-    listRef,
     onMessageLoadCaptured,
     onScroll,
     scrollToBottom,
     wrapperRect,
   } = useScrollLocationLogic({
     hasMoreNewer,
+    listRef,
     messages,
     scrolledUpThreshold: props.scrolledUpThreshold,
     suppressAutoscroll,

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -67,8 +67,8 @@ const MessageListWithContext = <
     jumpToLatestMessage = () => Promise.resolve(),
   } = props;
 
-  const listRef = React.useRef<HTMLDivElement>(null);
-  const ulRef = React.useRef<HTMLUListElement>(null);
+  const [listElement, setListElement] = React.useState<HTMLDivElement | null>(null);
+  const [ulElement, setUlElement] = React.useState<HTMLUListElement | null>(null);
 
   const { customClasses } = useChatContext<StreamChatGenerics>('MessageList');
 
@@ -87,11 +87,11 @@ const MessageListWithContext = <
     wrapperRect,
   } = useScrollLocationLogic({
     hasMoreNewer,
-    listRef,
+    listElement,
     messages,
     scrolledUpThreshold: props.scrolledUpThreshold,
     suppressAutoscroll,
-    ulRef,
+    ulElement,
   });
 
   const { messageGroupStyles, messages: enrichedMessages } = useEnrichedMessages({
@@ -169,7 +169,7 @@ const MessageListWithContext = <
 
   React.useLayoutEffect(() => {
     if (highlightedMessageId) {
-      const element = ulRef.current?.querySelector(`[data-message-id='${highlightedMessageId}']`);
+      const element = ulElement?.querySelector(`[data-message-id='${highlightedMessageId}']`);
       element?.scrollIntoView({ block: 'center' });
     }
   }, [highlightedMessageId]);
@@ -179,7 +179,7 @@ const MessageListWithContext = <
       <div
         className={`${messageListClass} ${threadListClass}`}
         onScroll={onScroll}
-        ref={listRef}
+        ref={setListElement}
         tabIndex={0}
       >
         {!elements.length ? (
@@ -200,7 +200,7 @@ const MessageListWithContext = <
             loadMoreNewer={loadMoreNewer}
             {...props.internalInfiniteScrollProps}
           >
-            <ul className='str-chat__ul' ref={ulRef}>
+            <ul className='str-chat__ul' ref={setUlElement}>
               {elements}
             </ul>
             <TypingIndicator threadList={threadList} />

--- a/src/components/MessageList/hooks/__tests__/useMessageListScrollManager.test.js
+++ b/src/components/MessageList/hooks/__tests__/useMessageListScrollManager.test.js
@@ -7,8 +7,10 @@ import { useMessageListScrollManager } from '../useMessageListScrollManager';
 import { ChatProvider } from '../../../../context/ChatContext';
 import { generateUser, getTestClientWithUser } from '../../../../mock-builders';
 
-const generateMessages = (length) =>
-  Array.from({ length }, (_, index) => ({ id: index.toString(), userId: '0' }));
+const myUserId = 'alice';
+
+const generateMessages = (length, userId = myUserId) =>
+  Array.from({ length }, (_, index) => ({ id: index.toString(), userId }));
 
 const defaultInputs = {
   messages: [],
@@ -21,7 +23,7 @@ const defaultInputs = {
   showNewMessages: () => {},
 };
 
-const alice = generateUser({ id: 'alice' });
+const alice = generateUser({ id: myUserId });
 let client;
 
 describe('useMessageListScrollManager', () => {
@@ -30,7 +32,7 @@ describe('useMessageListScrollManager', () => {
   });
   afterEach(cleanup);
 
-  it('emits scroll to bottom on mount', () => {
+  it('does not emit scroll to bottom on mount', () => {
     const scrollToBottom = jest.fn();
     const Comp = () => {
       useMessageListScrollManager({
@@ -52,7 +54,7 @@ describe('useMessageListScrollManager', () => {
       </ChatProvider>,
     );
 
-    expect(scrollToBottom).toHaveBeenCalledTimes(1);
+    expect(scrollToBottom).not.toHaveBeenCalled();
   });
 
   it('emits scrollTop delta when messages are prepended', () => {
@@ -118,7 +120,7 @@ describe('useMessageListScrollManager', () => {
       </ChatProvider>,
     );
 
-    expect(scrollToBottom).toHaveBeenCalledTimes(2);
+    expect(scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
   it('does not emit scroll to bottom when new messages arrive and user has scrolled up', () => {
@@ -202,7 +204,7 @@ describe('useMessageListScrollManager', () => {
     rerender(
       <ChatProvider value={{ client }}>
         <Comp
-          messages={messages.concat([{ id: 100, userId: client.userID }])}
+          messages={messages.concat([{ id: 100, user: { id: client.userID } }])}
           offsetHeight={100}
           scrollHeight={600}
           scrollTop={200}

--- a/src/components/MessageList/hooks/useMessageListScrollManager.ts
+++ b/src/components/MessageList/hooks/useMessageListScrollManager.ts
@@ -43,10 +43,6 @@ export function useMessageListScrollManager<
   const scrollTop = useRef(0);
 
   useEffect(() => {
-    scrollToBottom();
-  }, []);
-
-  useEffect(() => {
     const prevMeasures = measures.current;
     const prevMessages = messages.current;
     const newMessages = params.messages;

--- a/src/components/MessageList/hooks/useScrollLocationLogic.tsx
+++ b/src/components/MessageList/hooks/useScrollLocationLogic.tsx
@@ -54,10 +54,9 @@ export const useScrollLocationLogic = <
     setHasNewMessages(false);
   }, [listRef, hasMoreNewer, suppressAutoscroll]);
 
-  const [observer] = useState(() => new ResizeObserver(scrollToBottom));
-
   useEffect(() => {
     if (!listRef.current) return;
+    const observer = new ResizeObserver(scrollToBottom);
 
     const cancelObserverOnUserScroll = () => {
       scrollCounter.current.scroll += 1;
@@ -75,14 +74,13 @@ export const useScrollLocationLogic = <
     listRef.current.addEventListener('scroll', cancelObserverOnUserScroll);
 
     return () => {
-      if (ulRef.current) {
-        observer.unobserve(ulRef.current);
-      }
+      observer.disconnect();
+
       if (listRef.current) {
         listRef.current.removeEventListener('scroll', cancelObserverOnUserScroll);
       }
     };
-  }, [listRef.current, ulRef.current]);
+  }, [ulRef.current, scrollToBottom]);
 
   useLayoutEffect(() => {
     if (listRef?.current) {

--- a/src/components/MessageList/hooks/useScrollLocationLogic.tsx
+++ b/src/components/MessageList/hooks/useScrollLocationLogic.tsx
@@ -1,10 +1,13 @@
 import React, { RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { ResizeObserver as Polyfill } from '@juggle/resize-observer';
 
 import { useMessageListScrollManager } from './useMessageListScrollManager';
 
 import type { StreamMessage } from '../../../context/ChannelStateContext';
 
 import type { DefaultStreamChatGenerics } from '../../../types/types';
+
+const ResizeObserver = window.ResizeObserver || Polyfill;
 
 export type UseScrollLocationLogicParams<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
@@ -88,6 +91,7 @@ export const useScrollLocationLogic = <
   useLayoutEffect(() => {
     if (listRef?.current) {
       setWrapperRect(listRef.current.getBoundingClientRect());
+      scrollToBottom();
     }
   }, [listRef.current, hasMoreNewer]);
 

--- a/src/components/MessageList/hooks/useScrollLocationLogic.tsx
+++ b/src/components/MessageList/hooks/useScrollLocationLogic.tsx
@@ -48,7 +48,7 @@ export const useScrollLocationLogic = <
     }
 
     scrollCounter.current.autoScroll += 1;
-    listElement?.scrollTo({
+    listElement.scrollTo({
       top: listElement.scrollHeight,
     });
     setHasNewMessages(false);

--- a/src/components/MessageList/hooks/useScrollLocationLogic.tsx
+++ b/src/components/MessageList/hooks/useScrollLocationLogic.tsx
@@ -54,10 +54,7 @@ export const useScrollLocationLogic = <
     setHasNewMessages(false);
   }, [listRef, hasMoreNewer, suppressAutoscroll]);
 
-  const resizeObserverState = useRef({
-    observer: new ResizeObserver(scrollToBottom),
-    observing: false,
-  });
+  const [observer] = useState(() => new ResizeObserver(scrollToBottom));
 
   useEffect(() => {
     if (!listRef.current) return;
@@ -65,22 +62,21 @@ export const useScrollLocationLogic = <
     const cancelObserverOnUserScroll = () => {
       scrollCounter.current.scroll += 1;
       const userScrolled = scrollCounter.current.autoScroll < scrollCounter.current.scroll;
-      if (ulRef.current && userScrolled && resizeObserverState.current.observing) {
-        resizeObserverState.current.observer.unobserve(ulRef.current);
-        resizeObserverState.current.observing = false;
+      if (ulRef.current && userScrolled) {
+        observer.unobserve(ulRef.current);
+        listRef.current?.removeEventListener('scroll', cancelObserverOnUserScroll);
       }
     };
 
     if (ulRef.current) {
-      resizeObserverState.current.observer.observe(ulRef.current);
-      resizeObserverState.current.observing = true;
+      observer.observe(ulRef.current);
     }
 
     listRef.current.addEventListener('scroll', cancelObserverOnUserScroll);
 
     return () => {
       if (ulRef.current) {
-        resizeObserverState.current.observer.unobserve(ulRef.current);
+        observer.unobserve(ulRef.current);
       }
       if (listRef.current) {
         listRef.current.removeEventListener('scroll', cancelObserverOnUserScroll);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2359,6 +2359,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@juggle/resize-observer@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
+  integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
+
 "@ladle/react@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@ladle/react/-/react-0.11.0.tgz#275ef7a07dfaad1f19298ec994103653818277d5"
@@ -5578,9 +5583,9 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001181, caniuse-lite@^1.0.30001196, caniuse-lite@^1.0.30001317:
-  version "1.0.30001335"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz"
-  integrity sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==
+  version "1.0.30001344"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz"
+  integrity sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### 🎯 Goal

The logic, that assures the channel to be scrolled to the bottom on page load uses `scrollToBottom` function call in multiple places and multiple hook effects. The current logic does not handle the scroll behavior on message list `scrollHeight` change robustly. It just sets timeout 200ms to scroll to the bottom after the last invocation of `scrollToBottom` function. On slower network the may images load slower than that leaving the channel not scrolled to the bottom.

### 🛠 Implementation details

Use `ResizeObserver` to keep the channel scrolled to the bottom until the user initiates own scroll behavior. Once user starts scrolling, the resize observer is cancelled.
The heuristic used to infer that the scroll has been user-initiated compares the total number of calls to `scrollToBottom` function and the number of invocations of `scroll` event handler on the message list. The resize observer is cancelled once:

`the number of `scrollToBottom` calls < the number of invocations of scroll event handler on the message list `.

Package `stream-chat-react` supports browsers with > 0.2% market share. Among those browsers, [there are some](https://caniuse.com/resizeobserver), that do not support the `ResizeObserver` implementation. For that reason a resize observer [ponyfill](https://github.com/sindresorhus/ponyfill) is used (https://github.com/juggle/resize-observer). The `ResizeObserver` ponyfill is also needed for unit tests.

