### PR TITLE
fix: calculate jumped-to-message position correctly by keeping the loading indicator mounted

### DIFF
--- a/src/components/InfiniteScrollPaginator/InfiniteScroll.tsx
+++ b/src/components/InfiniteScrollPaginator/InfiniteScroll.tsx
@@ -106,9 +106,7 @@ export const InfiniteScroll = (props: PropsWithChildren<InfiniteScrollProps>) =>
     },
   };
 
-  const childrenArray = [children];
-  if (isLoading && loader) {
-    childrenArray.unshift(loader);
-  }
+  const childrenArray = [loader, children];
+
   return React.createElement(element, attributes, childrenArray);
 };

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -4,7 +4,6 @@ import { useEnrichedMessages } from './hooks/useEnrichedMessages';
 import { useMessageListElements } from './hooks/useMessageListElements';
 import { useScrollLocationLogic } from './hooks/useScrollLocationLogic';
 
-import { Center } from './Center';
 import { MessageNotification as DefaultMessageNotification } from './MessageNotification';
 import { MessageListNotifications as DefaultMessageListNotifications } from './MessageListNotifications';
 
@@ -192,9 +191,9 @@ const MessageListWithContext = <
             hasMoreNewer={props.hasMoreNewer}
             isLoading={props.loadingMore}
             loader={
-              <Center key='loadingindicator'>
-                <LoadingIndicator size={20} />
-              </Center>
+              <div className='str-chat__list__loading' key='loadingindicator'>
+                {props.loadingMore && <LoadingIndicator size={20} />}
+              </div>
             }
             loadMore={loadMore}
             loadMoreNewer={loadMoreNewer}


### PR DESCRIPTION
### 🎯 Goal

The jump-to-message logic in `MessageList` was broken because the browser could not calculate the correct target message position. This was due to the fact, that at the moment of the calculation, the `MessageList` was higher because of conditionally rendering the loading indicator. Once the indicator is positioned absolutely and is kept among the `MessageList` children, the calculation and scroll to the position are performed correctly.

Depends on https://github.com/GetStream/stream-chat-css/pull/116


