### PR TITLE
fix: add check if window is defined before using ResizeObserver

### DIFF
--- a/src/components/MessageList/hooks/useScrollLocationLogic.tsx
+++ b/src/components/MessageList/hooks/useScrollLocationLogic.tsx
@@ -7,7 +7,8 @@ import type { StreamMessage } from '../../../context/ChannelStateContext';
 
 import type { DefaultStreamChatGenerics } from '../../../types/types';
 
-const ResizeObserver = window.ResizeObserver || Polyfill;
+const isBrowser = typeof window !== 'undefined';
+const ResizeObserver = (isBrowser && window.ResizeObserver) || Polyfill;
 
 export type UseScrollLocationLogicParams<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Solves open Issue #1623. Build will fail with Gatsby and Next.js if window is undefined.

### 🛠 Implementation details

Add check if window is defined

### 🎨 UI Changes
