### PR TITLE
fix: correct calculation of scrollback with date separators

### DIFF
--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -251,7 +251,7 @@ const VirtualizedMessageListWithContext = <
     };
   }, [scrollToBottomIfConfigured]);
 
-  const numItemsPrepended = usePrependedMessagesCount(processedMessages);
+  const numItemsPrepended = usePrependedMessagesCount(processedMessages, !disableDateSeparator);
 
   /**
    * Logic to update the key of the virtuoso component when the list jumps to a new location.
@@ -260,8 +260,7 @@ const VirtualizedMessageListWithContext = <
   const firstMessageId = useRef<string | undefined>();
 
   useEffect(() => {
-    const continuousSet =
-      messages && messages.find((message) => message.id === firstMessageId.current);
+    const continuousSet = messages?.find((message) => message.id === firstMessageId.current);
     if (!continuousSet) {
       setMessageSetKey(+new Date());
     }

--- a/src/components/MessageList/hooks/usePrependMessagesCount.ts
+++ b/src/components/MessageList/hooks/usePrependMessagesCount.ts
@@ -6,8 +6,9 @@ import type { DefaultStreamChatGenerics } from '../../../types/types';
 
 export function usePrependedMessagesCount<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
->(messages: StreamMessage<StreamChatGenerics>[]) {
-  const currentFirstMessageId = messages?.[0]?.id;
+>(messages: StreamMessage<StreamChatGenerics>[], hasDateSeparator: boolean) {
+  const firstRealMessageIndex = hasDateSeparator ? 1 : 0;
+  const currentFirstMessageId = messages?.[firstRealMessageIndex]?.id;
   const firstMessageId = useRef(currentFirstMessageId);
   const earliestMessageId = useRef(currentFirstMessageId);
   const previousNumItemsPrepended = useRef(0);

--- a/src/stories/hello.stories.tsx
+++ b/src/stories/hello.stories.tsx
@@ -9,6 +9,7 @@ import {
   MessageInput,
   MessageList,
   Thread,
+  VirtualizedMessageList,
   Window,
 } from '../index';
 import { ConnectedUser } from './utils';
@@ -33,6 +34,21 @@ export const BasicSetup = () => (
       <Window>
         <ChannelHeader />
         <MessageList />
+        <MessageInput focus />
+      </Window>
+      <Thread />
+    </Channel>
+  </ConnectedUser>
+);
+
+// basic setup with virtualized list
+export const VirtualizedSetup = () => (
+  <ConnectedUser token={token} userId={userId}>
+    <ChannelList filters={filters} options={options} showChannelSearch sort={sort} />
+    <Channel>
+      <Window>
+        <ChannelHeader />
+        <VirtualizedMessageList disableDateSeparator={false} messageLimit={16} />
         <MessageInput focus />
       </Window>
       <Thread />


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

A customer discovered that scrolling back through a virtualized message list does not work as expected. 
Upon closer investigation, it turned out that our logic for prepend item count does not work with date separators.

### 🛠 Implmentation details

The fix ignores the date message. 

We need to add E2E tests for that, but we need to populate a channel with messages in multiple days. This is semi-possible now.
