### PR TITLE
fix: respect updates to messageActions prop, support messageActions overrides in Thread

### DIFF
--- a/docusaurus/docs/React/core-components/thread.mdx
+++ b/docusaurus/docs/React/core-components/thread.mdx
@@ -167,3 +167,11 @@ Custom thread message UI component used to override the default `Message` value 
 | Type      | Default                                                                  |
 | --------- | ------------------------------------------------------------------------ |
 | component | [ComponentContext['Message']](../contexts/component-context.mdx#message) |
+
+### messageActions
+
+Array of allowed message actions (ex: 'edit', 'delete', 'reply'). To disable all actions, provide an empty array.
+
+| Type  | Default                                                              |
+|-------|----------------------------------------------------------------------|
+| array | ['edit', 'delete', 'flag', 'mute', 'pin', 'quote', 'react', 'reply'] |

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -17,13 +17,15 @@ import {
 } from './hooks';
 import { areMessagePropsEqual, getMessageActions, MESSAGE_ACTIONS } from './utils';
 
-import { useChannelActionContext } from '../../context/ChannelActionContext';
-import { useChannelStateContext } from '../../context/ChannelStateContext';
-import { useComponentContext } from '../../context/ComponentContext';
-import { MessageContextValue, MessageProvider } from '../../context/MessageContext';
+import {
+  MessageContextValue,
+  MessageProvider,
+  useChannelActionContext,
+  useChannelStateContext,
+  useComponentContext,
+} from '../../context';
 
 import type { MessageProps } from './types';
-
 import type { DefaultStreamChatGenerics } from '../../types/types';
 
 type MessagePropsToOmit = 'onMentionsClick' | 'onMentionsHover' | 'openThread' | 'retrySendMessage';
@@ -104,7 +106,7 @@ const MessageWithContext = <
         canReact,
         canReply,
       }),
-    [canDelete, canEdit, canFlag, canMute, canPin, canQuote, canReact, canReply],
+    [messageActions, canDelete, canEdit, canFlag, canMute, canPin, canQuote, canReact, canReply],
   );
 
   const {

--- a/src/components/Message/__tests__/utils.test.js
+++ b/src/components/Message/__tests__/utils.test.js
@@ -199,6 +199,28 @@ describe('Message utils', () => {
       expect(arePropsEqual).toBe(false);
       expect(shouldUpdate).toBe(true);
     });
+
+    it('should update when messageActions change', () => {
+      const message = generateMessage();
+      const prevMessageActions = ['edit', 'delete'];
+      const nextMessageActions = ['edit', 'delete', 'reply'];
+      const shouldUpdate = !areMessagePropsEqual(
+        { message, messageActions: prevMessageActions },
+        { message, messageActions: nextMessageActions },
+      );
+      expect(shouldUpdate).toBe(true);
+    });
+
+    it('should not update when messageActions stay same', () => {
+      const message = generateMessage();
+      const prevMessageActions = ['edit', 'delete'];
+      const nextMessageActions = ['edit', 'delete'];
+      const shouldUpdate = !areMessagePropsEqual(
+        { message, messageActions: prevMessageActions },
+        { message, messageActions: nextMessageActions },
+      );
+      expect(shouldUpdate).toBe(false);
+    });
   });
 
   describe('messageHasReactions', () => {

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -2,13 +2,9 @@ import deepequal from 'react-fast-compare';
 
 import type { TFunction } from 'i18next';
 import type { MessageResponse, Mute, StreamChat, UserResponse } from 'stream-chat';
-
 import type { PinPermissions } from './hooks';
 import type { MessageProps } from './types';
-
-import type { StreamMessage } from '../../context/ChannelStateContext';
-import type { MessageContextValue } from '../../context/MessageContext';
-
+import type { MessageContextValue, StreamMessage } from '../../context';
 import type { DefaultStreamChatGenerics } from '../../types/types';
 
 /**
@@ -214,6 +210,23 @@ export const showMessageActionsBox = (
   return true;
 };
 
+const areMessagesEqual = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>(
+  prevMessage: StreamMessage<StreamChatGenerics>,
+  nextMessage: StreamMessage<StreamChatGenerics>,
+) =>
+  prevMessage.deleted_at === nextMessage.deleted_at &&
+  prevMessage.latest_reactions?.length === nextMessage.latest_reactions?.length &&
+  prevMessage.own_reactions?.length === nextMessage.own_reactions?.length &&
+  prevMessage.pinned === nextMessage.pinned &&
+  prevMessage.reply_count === nextMessage.reply_count &&
+  prevMessage.status === nextMessage.status &&
+  prevMessage.text === nextMessage.text &&
+  prevMessage.type === nextMessage.type &&
+  prevMessage.updated_at === nextMessage.updated_at &&
+  prevMessage.user?.updated_at === nextMessage.user?.updated_at;
+
 export const areMessagePropsEqual = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 >(
@@ -236,21 +249,11 @@ export const areMessagePropsEqual = <
     return false;
   }
 
-  const messagesAreEqual =
-    prevMessage.deleted_at === nextMessage.deleted_at &&
-    prevMessage.latest_reactions?.length === nextMessage.latest_reactions?.length &&
-    prevMessage.own_reactions?.length === nextMessage.own_reactions?.length &&
-    prevMessage.pinned === nextMessage.pinned &&
-    prevMessage.reply_count === nextMessage.reply_count &&
-    prevMessage.status === nextMessage.status &&
-    prevMessage.text === nextMessage.text &&
-    prevMessage.type === nextMessage.type &&
-    prevMessage.updated_at === nextMessage.updated_at &&
-    prevMessage.user?.updated_at === nextMessage.user?.updated_at;
-
+  const messagesAreEqual = areMessagesEqual(prevMessage, nextMessage);
   if (!messagesAreEqual) return false;
 
   const deepEqualProps =
+    deepequal(nextProps.messageActions, prevProps.messageActions) &&
     deepequal(nextProps.readBy, prevProps.readBy) &&
     deepequal(nextProps.highlighted, prevProps.highlighted) &&
     deepequal(nextProps.groupStyles, prevProps.groupStyles) && // last 3 messages can have different group styles
@@ -294,18 +297,7 @@ export const areMessageUIPropsEqual = <
     return false;
   }
 
-  return (
-    prevMessage.deleted_at === nextMessage.deleted_at &&
-    prevMessage.latest_reactions?.length === nextMessage.latest_reactions?.length &&
-    prevMessage.own_reactions?.length === nextMessage.own_reactions?.length &&
-    prevMessage.pinned === nextMessage.pinned &&
-    prevMessage.reply_count === nextMessage.reply_count &&
-    prevMessage.status === nextMessage.status &&
-    prevMessage.text === nextMessage.text &&
-    prevMessage.type === nextMessage.type &&
-    prevMessage.updated_at === nextMessage.updated_at &&
-    prevMessage.user?.updated_at === nextMessage.user?.updated_at
-  );
+  return areMessagesEqual(prevMessage, nextMessage);
 };
 
 export const messageHasReactions = <

--- a/src/components/Thread/Thread.tsx
+++ b/src/components/Thread/Thread.tsx
@@ -1,22 +1,24 @@
 import React, { useEffect, useRef } from 'react';
 
-import { FixedHeightMessage } from '../Message/FixedHeightMessage';
-import { Message } from '../Message/Message';
-import { MessageInput, MessageInputProps } from '../MessageInput/MessageInput';
-import { MessageInputSmall } from '../MessageInput/MessageInputSmall';
-import { MessageList, MessageListProps } from '../MessageList/MessageList';
+import type { MessageActionsArray, MessageProps, MessageUIComponentProps } from '../Message';
+import { FixedHeightMessage, Message, MESSAGE_ACTIONS } from '../Message';
+import { MessageInput, MessageInputProps, MessageInputSmall } from '../MessageInput';
 import {
+  MessageList,
+  MessageListProps,
   VirtualizedMessageList,
   VirtualizedMessageListProps,
-} from '../MessageList/VirtualizedMessageList';
+} from '../MessageList';
 
-import { MessageToSend, useChannelActionContext } from '../../context/ChannelActionContext';
-import { StreamMessage, useChannelStateContext } from '../../context/ChannelStateContext';
-import { useChatContext } from '../../context/ChatContext';
-import { useComponentContext } from '../../context/ComponentContext';
-import { useTranslationContext } from '../../context/TranslationContext';
-
-import type { MessageProps, MessageUIComponentProps } from '../Message/types';
+import {
+  MessageToSend,
+  StreamMessage,
+  useChannelActionContext,
+  useChannelStateContext,
+  useChatContext,
+  useComponentContext,
+  useTranslationContext,
+} from '../../context';
 
 import type { CustomTrigger, DefaultStreamChatGenerics } from '../../types/types';
 
@@ -42,6 +44,8 @@ export type ThreadProps<
   Input?: React.ComponentType;
   /** Custom thread message UI component used to override the default `Message` value stored in `ComponentContext` */
   Message?: React.ComponentType<MessageUIComponentProps<StreamChatGenerics>>;
+  /** Array of allowed message actions (ex: ['edit', 'delete', 'flag', 'mute', 'pin', 'quote', 'react', 'reply']). To disable all actions, provide an empty array. */
+  messageActions?: MessageActionsArray;
   /** If true, render the `VirtualizedMessageList` instead of the standard `MessageList` component */
   virtualized?: boolean;
 };
@@ -129,6 +133,7 @@ const ThreadInner = <
     fullWidth = false,
     Input: PropInput,
     Message: PropMessage,
+    messageActions = Object.keys(MESSAGE_ACTIONS),
     virtualized,
   } = props;
 
@@ -199,6 +204,7 @@ const ThreadInner = <
           loadingMore={threadLoadingMore}
           loadMore={loadMoreThread}
           Message={ThreadMessage || FallbackMessage}
+          messageActions={messageActions}
           messages={threadMessages || []}
           threadList
           {...(virtualized ? additionalVirtualizedMessageListProps : additionalMessageListProps)}

--- a/src/components/Thread/__tests__/Thread.test.js
+++ b/src/components/Thread/__tests__/Thread.test.js
@@ -1,14 +1,16 @@
+import '@testing-library/jest-dom';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
-
-import { Thread } from '../Thread';
-
-import { Message as MessageMock } from '../../Message/Message';
-import { MessageInputSmall as MessageInputSmallMock } from '../../MessageInput/MessageInputSmall';
-import { MessageList as MessageListMock } from '../../MessageList';
-import { useMessageInputContext } from '../../../context/MessageInputContext';
+import {
+  ChannelActionProvider,
+  ChannelStateProvider,
+  ChatProvider,
+  ComponentProvider,
+  EmojiProvider,
+  TranslationProvider,
+  useMessageInputContext,
+} from '../../../context';
 
 import {
   emojiComponentMock,
@@ -21,12 +23,11 @@ import {
   useMockedApis,
 } from '../../../mock-builders';
 
-import { ChannelActionProvider } from '../../../context/ChannelActionContext';
-import { ChannelStateProvider } from '../../../context/ChannelStateContext';
-import { ChatProvider } from '../../../context/ChatContext';
-import { ComponentProvider } from '../../../context/ComponentContext';
-import { EmojiProvider } from '../../../context/EmojiContext';
-import { TranslationProvider } from '../../../context/TranslationContext';
+import { Message as MessageMock } from '../../Message/Message';
+import { MessageInputSmall as MessageInputSmallMock } from '../../MessageInput/MessageInputSmall';
+import { MessageList as MessageListMock } from '../../MessageList';
+
+import { Thread } from '../Thread';
 
 jest.mock('../../Message/Message', () => ({
   Message: jest.fn(() => <div />),
@@ -257,6 +258,23 @@ describe('Thread', () => {
     fireEvent.click(getByTestId('close-button'));
 
     expect(channelActionContextMock.closeThread).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass messageActions prop to the used messageList', () => {
+    const messageActions = ['edit', 'reply', 'delete'];
+    renderComponent({
+      chatClient,
+      threadProps: {
+        messageActions,
+      },
+    });
+
+    expect(MessageListMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageActions,
+      }),
+      expect.anything(), // refOrContext
+    );
   });
 
   it('should assign the str-chat__thread--full modifier class if the fullWidth prop is set to true', () => {

--- a/src/stories/toggle-message-actions.stories.tsx
+++ b/src/stories/toggle-message-actions.stories.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { ConnectedUser, ConnectedUserProps } from './utils';
+import {
+  Channel,
+  ChannelHeader,
+  ChannelList,
+  MESSAGE_ACTIONS,
+  MessageActionsArray,
+  MessageList,
+  Thread,
+  Window,
+} from '../components';
+import '@stream-io/stream-chat-css/dist/css/index.css';
+
+const allActions = Object.keys(MESSAGE_ACTIONS);
+const WrappedConnectedUser = ({ token, userId }: Omit<ConnectedUserProps, 'children'>) => {
+  const [messageActions, setMessageActions] = useState<MessageActionsArray>(allActions);
+  return (
+    <ConnectedUser token={token} userId={userId}>
+      <ChannelList filters={{ id: { $eq: 'jump-to-message' } }} />
+      <Channel>
+        <Window>
+          <ChannelHeader />
+          <MessageList messageActions={messageActions} />
+          <div>
+            Current messageActions: <i>{messageActions.join(', ') || 'None'}</i>
+          </div>
+          <div>
+            <span>Switch to: </span>
+            <button onClick={() => setMessageActions(allActions)} type='button'>
+              All
+            </button>
+            <button onClick={() => setMessageActions(['edit', 'react'])} type='button'>
+              edit, react
+            </button>
+            <button onClick={() => setMessageActions(['edit', 'react', 'reply'])} type='button'>
+              edit, react, reply
+            </button>
+            <button onClick={() => setMessageActions([])} type='button'>
+              None
+            </button>
+          </div>
+        </Window>
+        <Thread messageActions={messageActions} />
+      </Channel>
+    </ConnectedUser>
+  );
+};
+
+export const ToggleActions = () => {
+  const userId = import.meta.env.E2E_TEST_USER_1;
+  const token = import.meta.env.E2E_TEST_USER_1_TOKEN;
+  if (!userId || typeof userId !== 'string') {
+    throw new Error('expected TEST_USER_1');
+  }
+  if (!token || typeof token !== 'string') {
+    throw new Error('expected TEST_USER_1_TOKEN');
+  }
+  return <WrappedConnectedUser token={token} userId={userId} />;
+};


### PR DESCRIPTION
### 🎯 Goal
This PR fixes the issue described in #1627. While working on it, we discovered that `Thread` messages always have all messageActions enabled and afterwards filtered out based on user's permissions.

### 🛠 Implementation details
- `messageActionHandler` now respects the `messageActions` prop
- `Thread` component now accepts additional `messageActions` property which will later be passed down to the selected `MessageList` implementation

