### PR TITLE
fix: initial load earlier in vml persists the position

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-markdown": "^5.0.3",
     "react-player": "^2.10.1",
     "react-textarea-autosize": "^8.3.0",
-    "react-virtuoso": "^2.10.2",
+    "react-virtuoso": "^2.13.3",
     "textarea-caret": "^3.1.0"
   },
   "optionalDependencies": {

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -328,6 +328,18 @@ const VirtualizedMessageListWithContext = <
     [customMessageRenderer, shouldGroupByUser, numItemsPrepended],
   );
 
+  const Item = useMemo(() => {
+    // using 'display: inline-block'
+    // traps CSS margins of the item elements, preventing incorrect item measurements
+    const Item: Components['Item'] = (props) => (
+      <div
+        {...props}
+        className={customClasses?.virtualMessage || 'str-chat__virtual-list-message-wrapper'}
+      />
+    );
+    return Item;
+  }, [customClasses?.virtualMessage]);
+
   const virtuosoComponents: Partial<Components> = useMemo(() => {
     const EmptyPlaceholder: Components['EmptyPlaceholder'] = () => (
       <>{EmptyStateIndicator && <EmptyStateIndicator listType='message' />}</>
@@ -341,12 +353,6 @@ const VirtualizedMessageListWithContext = <
       ) : (
         <></>
       );
-
-    const virtualMessageClass =
-      customClasses?.virtualMessage || 'str-chat__virtual-list-message-wrapper';
-
-    // using 'display: inline-block' traps CSS margins of the item elements, preventing incorrect item measurements
-    const Item: Components['Item'] = (props) => <div {...props} className={virtualMessageClass} />;
 
     const Footer: Components['Footer'] = () =>
       TypingIndicator ? <TypingIndicator avatarSize={24} /> : <></>;
@@ -395,6 +401,9 @@ const VirtualizedMessageListWithContext = <
         <Virtuoso
           atBottomStateChange={atBottomStateChange}
           components={virtuosoComponents}
+          computeItemKey={(index) =>
+            processedMessages[numItemsPrepended + index - PREPEND_OFFSET].id
+          }
           endReached={endReached}
           firstItemIndex={PREPEND_OFFSET - numItemsPrepended}
           followOutput={followOutput}
@@ -502,8 +511,6 @@ export type VirtualizedMessageListProps<
 /**
  * The VirtualizedMessageList component renders a list of messages in a virtualized list.
  * It is a consumer of the React contexts set in [Channel](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Channel/Channel.tsx).
- *
- * **Note**: It works well when there are thousands of messages in a channel, it has a shortcoming though - the message UI should have a fixed height.
  */
 export function VirtualizedMessageList<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics

--- a/src/components/MessageList/__tests__/__snapshots__/VirtualizedMessageList.test.js.snap
+++ b/src/components/MessageList/__tests__/__snapshots__/VirtualizedMessageList.test.js.snap
@@ -21,6 +21,7 @@ exports[`VirtualizedMessageList should render the list without any message 1`] =
             "overflowX": "hidden",
             "overflowY": "auto",
             "position": "relative",
+            "willChange": "transform",
           }
         }
         tabIndex={0}

--- a/src/stories/hello.stories.tsx
+++ b/src/stories/hello.stories.tsx
@@ -48,7 +48,7 @@ export const VirtualizedSetup = () => (
     <Channel>
       <Window>
         <ChannelHeader />
-        <VirtualizedMessageList disableDateSeparator={false} messageLimit={16} />
+        <VirtualizedMessageList disableDateSeparator={false} messageLimit={50} />
         <MessageInput focus />
       </Window>
       <Thread />

--- a/yarn.lock
+++ b/yarn.lock
@@ -14423,6 +14423,14 @@ react-virtuoso@^2.10.2:
     "@virtuoso.dev/react-urx" "^0.2.12"
     "@virtuoso.dev/urx" "^0.2.12"
 
+react-virtuoso@^2.13.3:
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.13.3.tgz#11f67d56a0f7e259bc9d92547f952b446b43b56a"
+  integrity sha512-K/mPeJcNvY0R24r1XcNTPV5bs7LujTjhbvysEhVxS6hjssY5OI+2HpY4e3cKEb/8BMGFwsQ/c/b6BLCcmprquw==
+  dependencies:
+    "@virtuoso.dev/react-urx" "^0.2.12"
+    "@virtuoso.dev/urx" "^0.2.12"
+
 react@^18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.1.0.tgz#6f8620382decb17fdc5cc223a115e2adbf104890"


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

At some point, the virtualized message list regressed its default setup for loading earlier messages. 
The first load more did not persist its scroll location properly due to page size being larger than the initial message count.

Upgrading to the latest version should also reduce messages unmounting/remounting, so less blinking of the avatars.

### 🛠 Implementation details

Upgrade to the latest react-virtuoso version, which fixes the problem and adds tests for that scenario. 
Related test cases:
https://github.com/petyosi/react-virtuoso/blob/master/examples/prepend-items.tsx
https://github.com/petyosi/react-virtuoso/blob/master/e2e/prepend-items.test.ts#L27-L34
