### PR TITLE
ci(docusaurus): add staging enviroment

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -2,17 +2,21 @@ name: docusaurus
 on:
   push:
     branches:
-      - master # default branch name for each repo that docs should be push from
+      - master
+      - develop
     paths:
       - docusaurus/**
+env:
+  branch_map: '{"refs/heads/master": "production", "refs/heads/develop": "staging"}'
+
 jobs:
   push_docusaurus:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: push
+      - name: Push to stream-chat-docusaurus
         uses: GetStream/push-stream-chat-docusaurus-action@main
         with:
-          target-branch: production
+          target-branch: ${{ fromJSON(env.branch_map)[github.ref] }}
         env:
           DOCUSAURUS_GH_TOKEN: ${{ secrets.DOCUSAURUS_GH_TOKEN }}


### PR DESCRIPTION
### 🎯 Goal

Add ability to push documentation changes to `stream-chat-docusaurus` staging branch when new changes are pushed to the `develop` branch within this repository. 

### 🛠 Implementation details

Implementation [tested here](https://github.com/GetStream/stream-chat-react/runs/7200293672?check_suite_focus=true#step:2:1).