### PR TITLE
fix: allow quoting quoted messages

### DIFF
--- a/src/components/MessageActions/MessageActionsBox.tsx
+++ b/src/components/MessageActions/MessageActionsBox.tsx
@@ -141,7 +141,7 @@ const UnMemoizedMessageActionsBox = <
         {customMessageActions && (
           <CustomMessageActionsList customMessageActions={customMessageActions} message={message} />
         )}
-        {messageActions.indexOf(MESSAGE_ACTIONS.quote) > -1 && !message.quoted_message && (
+        {messageActions.indexOf(MESSAGE_ACTIONS.quote) > -1 && (
           <button
             aria-selected='false'
             className='str-chat__message-actions-list-item'


### PR DESCRIPTION
### 🎯 Goal

Allow quoting quoted messages by removing part of the condition within the `MessageActionsBox` component.

![image](https://user-images.githubusercontent.com/43254280/177385961-1923b8f4-dd3b-448a-9cec-75c537a6c2f2.png)