### PR TITLE
fix: align user role checks with channel membership, deprecate isModerator, isAdmin, isOwner

### DIFF
--- a/src/components/Message/hooks/__tests__/useUserRole.test.js
+++ b/src/components/Message/hooks/__tests__/useUserRole.test.js
@@ -115,13 +115,52 @@ describe('useUserRole custom hook', () => {
     ['channel_moderator', true],
     ['owner', false],
   ])(
-    'should tell if user is moderator when channel state membership is set to %s',
+    'should tell if user is moderator when channel state membership role is set to %s',
     async (role, expected) => {
       const message = generateMessage();
       const { isModerator } = await renderUserRoleHook(message, {
         state: {
           membership: {
             role,
+          },
+        },
+      });
+      expect(isModerator).toBe(expected);
+    },
+  );
+
+  it.each([
+    [true, true],
+    [false, false],
+    [undefined, false],
+  ])(
+    'should tell if user is moderator when channel state membership is_moderator is set to %s',
+    async (bool, expected) => {
+      const message = generateMessage();
+      const { isModerator } = await renderUserRoleHook(message, {
+        state: {
+          membership: {
+            is_moderator: bool,
+          },
+        },
+      });
+      expect(isModerator).toBe(expected);
+    },
+  );
+
+  it.each([
+    ['admin', false],
+    ['member', false],
+    ['channel_moderator', true],
+    ['owner', false],
+  ])(
+    'should tell if user is moderator when channel state membership channel_role is set to %s',
+    async (role, expected) => {
+      const message = generateMessage();
+      const { isModerator } = await renderUserRoleHook(message, {
+        state: {
+          membership: {
+            channel_role: role,
           },
         },
       });

--- a/src/components/Message/hooks/useUserRole.ts
+++ b/src/components/Message/hooks/useUserRole.ts
@@ -22,7 +22,11 @@ export const useUserRole = <
    * `isAdmin` will be removed in future release. See `channelCapabilities`.
    */
   const isAdmin = client.user?.role === 'admin' || channel.state.membership.role === 'admin';
-  const isMyMessage = client.userID === message.user?.id;
+
+  /**
+   * @deprecated as it relies on `membership.role` check which is already deprecated and shouldn't be used anymore.
+   * `isOwner` will be removed in future release. See `channelCapabilities`.
+   */
   const isOwner = channel.state.membership.role === 'owner';
 
   /**
@@ -36,6 +40,7 @@ export const useUserRole = <
     channel.state.membership.is_moderator === true ||
     channel.state.membership.channel_role === 'channel_moderator';
 
+  const isMyMessage = client.userID === message.user?.id;
   const canEdit =
     (!onlySenderCanEdit && channelCapabilities['update-any-message']) ||
     (isMyMessage && channelCapabilities['update-own-message']);

--- a/src/components/Message/hooks/useUserRole.ts
+++ b/src/components/Message/hooks/useUserRole.ts
@@ -17,10 +17,18 @@ export const useUserRole = <
   } = useChannelStateContext<StreamChatGenerics>('useUserRole');
   const { client } = useChatContext<StreamChatGenerics>('useUserRole');
 
+  /**
+   * @deprecated as it relies on `membership.role` check which is already deprecated and shouldn't be used anymore.
+   * `isAdmin` will be removed in future release. See `channelCapabilities`.
+   */
   const isAdmin = client.user?.role === 'admin' || channel.state.membership.role === 'admin';
   const isMyMessage = client.userID === message.user?.id;
   const isOwner = channel.state.membership.role === 'owner';
 
+  /**
+   * @deprecated as it relies on `membership.role` check which is already deprecated and shouldn't be used anymore.
+   * `isModerator` will be removed in future release. See `channelCapabilities`.
+   */
   const isModerator =
     client.user?.role === 'channel_moderator' ||
     channel.state.membership.role === 'channel_moderator' ||

--- a/src/components/Message/hooks/useUserRole.ts
+++ b/src/components/Message/hooks/useUserRole.ts
@@ -24,7 +24,9 @@ export const useUserRole = <
   const isModerator =
     client.user?.role === 'channel_moderator' ||
     channel.state.membership.role === 'channel_moderator' ||
-    channel.state.membership.role === 'moderator';
+    channel.state.membership.role === 'moderator' ||
+    channel.state.membership.is_moderator === true ||
+    channel.state.membership.channel_role === 'channel_moderator';
 
   const canEdit =
     (!onlySenderCanEdit && channelCapabilities['update-any-message']) ||


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

I'm not entirely sure how this was/is supposed to work. But in my case the api/library does not provide a `role` inside the channel state membership. Instead, it receives an `is_moderator: bool` and a `channel_role: string`.

![Screen Shot 2022-07-08 at 11 53 33](https://user-images.githubusercontent.com/1857585/177974056-3d0afb7c-c46f-4d02-991a-ff3dc24c1291.png)

### 🛠 Implementation details

This pull requests extends the `isModerator` check with these two props to correctly ensure a user is a moderator of the given channel. I didn't want to break previous behavior, so I left the `role` check in there.
