### PR TITLE
Theming v2 message reactions react

### DIFF
--- a/docusaurus/docs/React/message-components/reactions.mdx
+++ b/docusaurus/docs/React/message-components/reactions.mdx
@@ -195,6 +195,14 @@ If true, adds a CSS class that reverses the horizontal positioning of the select
 
 ## ReactionsList Props
 
+### additionalEmojiProps
+
+Additional props to be passed to the [NimbleEmoji](https://github.com/missive/emoji-mart/blob/master/src/components/emoji/nimble-emoji.js) component from `emoji-mart`.
+
+| Type   |
+| ------ |
+| object |
+
 ### onClick
 
 Custom on click handler for an individual reaction in the list (overrides the function stored in `MessageContext`).
@@ -202,6 +210,14 @@ Custom on click handler for an individual reaction in the list (overrides the fu
 | Type                                                        | Default                                                                                           |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | (event: React.BaseSyntheticEvent) => Promise<void\> \| void | [MessageContextValue['onReactionListClick']](../contexts/message-context.mdx#onreactionlistclick) |
+
+### own_reactions
+
+An array of the own reaction objects to distinguish own reactions visually (overrides `message.own_reactions` from `MessageContext`).
+
+| Type  |
+| ----- |
+| array |
 
 ### reaction_counts
 
@@ -252,6 +268,14 @@ Function that adds/removes a reaction on a message (overrides the function store
 | Type                                                                      | Default                                                                                 |
 | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
 | (reactionType: string, event: React.BaseSyntheticEvent) => Promise<void\> | [MessageContextValue['handleReaction']](../contexts/message-context.mdx#handlereaction) |
+
+### own_reactions
+
+An array of the own reaction objects to distinguish own reactions visually (overrides `message.own_reactions` from `MessageContext`).
+
+| Type  |
+| ----- |
+| array |
 
 ### reaction_counts
 

--- a/src/components/Gallery/Image.tsx
+++ b/src/components/Gallery/Image.tsx
@@ -45,7 +45,7 @@ export const ImageComponent = <
         className='str-chat__message-attachment--img'
         data-testid='image-test'
         onClick={toggleModal}
-        onKeyUp={toggleModal}
+        onKeyDown={toggleModal}
         src={imageSrc}
         tabIndex={0}
       />

--- a/src/components/Gallery/__tests__/__snapshots__/Image.test.js.snap
+++ b/src/components/Gallery/__tests__/__snapshots__/Image.test.js.snap
@@ -5,7 +5,7 @@ exports[`Image should render component with default props 1`] = `
   className="str-chat__message-attachment--img"
   data-testid="image-test"
   onClick={[Function]}
-  onKeyUp={[Function]}
+  onKeyDown={[Function]}
   src="about:blank"
   tabIndex={0}
 />

--- a/src/components/Message/MessageSimple.tsx
+++ b/src/components/Message/MessageSimple.tsx
@@ -146,15 +146,13 @@ const MessageSimpleWithContext = <
             }
           >
             <MessageOptions />
+            <div className='str-chat__message-reactions-host'>
+              {hasReactions && isReactionEnabled && <ReactionsList reverse />}
+              {showDetailedReactions && isReactionEnabled && (
+                <ReactionSelector ref={reactionSelectorRef} />
+              )}
+            </div>
             <div className='str-chat__message-bubble'>
-              <>
-                {hasReactions && !showDetailedReactions && isReactionEnabled && (
-                  <ReactionsList reverse />
-                )}
-                {showDetailedReactions && isReactionEnabled && (
-                  <ReactionSelector ref={reactionSelectorRef} />
-                )}
-              </>
               {message.attachments?.length && !message.quoted_message ? (
                 <Attachment actionHandler={handleAction} attachments={message.attachments} />
               ) : null}

--- a/src/components/Message/__tests__/MessageText.test.js
+++ b/src/components/Message/__tests__/MessageText.test.js
@@ -297,21 +297,22 @@ describe('<MessageText />', () => {
         >
           <div />
           <div
+            className="str-chat__message-reactions-host"
+          />
+          <div
             className="str-chat__message-bubble"
           >
             <div
               className="str-chat__message-text"
               tabIndex={0}
-              >
+            >
               <div
                 className="str-chat__message-text-inner str-chat__message-simple-text-inner"
                 data-testid="message-text-inner-wrapper"
                 onClick={[Function]}
                 onMouseOver={[Function]}
               >
-                <div
-
-                >
+                <div>
                   <p>
                     hello world
                   </p>
@@ -338,20 +339,22 @@ describe('<MessageText />', () => {
         >
           <div />
           <div
+            className="str-chat__message-reactions-host"
+          />
+          <div
             className="str-chat__message-bubble"
           >
             <div
               className="str-chat__message-text"
-            tabIndex={0}>
+              tabIndex={0}
+            >
               <div
                 className="str-chat__message-text-inner str-chat__message-simple-text-inner"
                 data-testid="message-text-inner-wrapper"
                 onClick={[Function]}
                 onMouseOver={[Function]}
               >
-                <div
-
-                >
+                <div>
                   <p>
                     hi mate
                   </p>
@@ -377,21 +380,22 @@ describe('<MessageText />', () => {
         >
           <div />
           <div
+            className="str-chat__message-reactions-host"
+          />
+          <div
             className="str-chat__message-bubble"
           >
             <div
               className="str-chat__message-text"
               tabIndex={0}
-              >
+            >
               <div
                 className="str-chat__message-text-inner str-chat__message-simple-text-inner"
                 data-testid="message-text-inner-wrapper"
                 onClick={[Function]}
                 onMouseOver={[Function]}
               >
-                <div
-
-                >
+                <div>
                   <p>
                     whatup?!
                   </p>

--- a/src/components/Message/hooks/useReactionHandler.ts
+++ b/src/components/Message/hooks/useReactionHandler.ts
@@ -222,7 +222,7 @@ export const useReactionClick = <
     if (event?.stopPropagation) {
       event.stopPropagation();
     }
-    setShowDetailedReactions(true);
+    setShowDetailedReactions((prev) => !prev);
   };
 
   return {

--- a/src/components/MessageInput/EditMessageForm.tsx
+++ b/src/components/MessageInput/EditMessageForm.tsx
@@ -95,8 +95,12 @@ export const EditMessageForm = <
               )}
             </div>
             <div>
-              <button onClick={clearEditingState}>{t<string>('Cancel')}</button>
-              <button type='submit'>{t<string>('Send')}</button>
+              <button className='str-chat__edit-message-cancel' onClick={clearEditingState}>
+                {t<string>('Cancel')}
+              </button>
+              <button className='str-chat__edit-message-send' type='submit'>
+                {t<string>('Send')}
+              </button>
             </div>
           </div>
         </form>

--- a/src/components/MessageList/CustomNotification.tsx
+++ b/src/components/MessageList/CustomNotification.tsx
@@ -13,7 +13,7 @@ const UnMemoizedCustomNotification = (props: PropsWithChildren<CustomNotificatio
   return (
     <div
       aria-live='polite'
-      className={`str-chat__custom-notification notification-${type}`}
+      className={`str-chat__custom-notification notification-${type} str-chat__notification`}
       data-testid='custom-notification'
     >
       {children}

--- a/src/components/MessageList/__tests__/CustomNotification.test.js
+++ b/src/components/MessageList/__tests__/CustomNotification.test.js
@@ -23,7 +23,7 @@ describe('CustomNotification', () => {
     expect(tree).toMatchInlineSnapshot(`
       <div
         aria-live="polite"
-        className="str-chat__custom-notification notification-undefined"
+        className="str-chat__custom-notification notification-undefined str-chat__notification"
         data-testid="custom-notification"
       >
         children

--- a/src/components/Reactions/ReactionSelector.tsx
+++ b/src/components/Reactions/ReactionSelector.tsx
@@ -28,6 +28,8 @@ export type ReactionSelectorProps<
   handleReaction?: (reactionType: string, event: React.BaseSyntheticEvent) => Promise<void>;
   /** An array of the reaction objects to display in the list */
   latest_reactions?: ReactionResponse<StreamChatGenerics>[];
+  /** An array of the own reaction objects to distinguish own reactions visually */
+  own_reactions?: ReactionResponse<StreamChatGenerics>[];
   /** An object that keeps track of the count of each type of reaction on a message */
   reaction_counts?: { [key: string]: number };
   /** A list of the currently supported reactions on a message */
@@ -47,6 +49,7 @@ const UnMemoizedReactionSelector = React.forwardRef(
       detailedView = true,
       handleReaction: propHandleReaction,
       latest_reactions: propLatestReactions,
+      own_reactions: propOwnReactions,
       reaction_counts: propReactionCounts,
       reactionOptions: propReactionOptions,
       reverse = false,
@@ -64,6 +67,7 @@ const UnMemoizedReactionSelector = React.forwardRef(
     const Avatar = propAvatar || contextAvatar || DefaultAvatar;
     const handleReaction = propHandleReaction || contextHandleReaction;
     const latestReactions = propLatestReactions || message?.latest_reactions || [];
+    const ownReactions = propOwnReactions || message?.own_reactions || [];
     const reactionCounts = propReactionCounts || message?.reaction_counts || {};
     const reactionOptions = propReactionOptions || defaultMinimalEmojis;
     const reactionsAreCustom = !!propReactionOptions?.length;
@@ -129,7 +133,7 @@ const UnMemoizedReactionSelector = React.forwardRef(
         .filter(Boolean);
 
     const iHaveReactedWithReaction = (reactionType: string) =>
-      latestReactions.find((reaction) => reaction.type === reactionType);
+      ownReactions.find((reaction) => reaction.type === reactionType);
 
     const getLatestUserForReactionType = (type: string | null) =>
       latestReactions.find((reaction) => reaction.type === type && !!reaction.user)?.user ||

--- a/src/components/Reactions/ReactionSelector.tsx
+++ b/src/components/Reactions/ReactionSelector.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import clsx from 'clsx';
 
 import { isMutableRef } from './utils/utils';
 
@@ -127,15 +128,19 @@ const UnMemoizedReactionSelector = React.forwardRef(
         })
         .filter(Boolean);
 
+    const iHaveReactedWithReaction = (reactionType: string) =>
+      latestReactions.find((reaction) => reaction.type === reactionType);
+
     const getLatestUserForReactionType = (type: string | null) =>
       latestReactions.find((reaction) => reaction.type === type && !!reaction.user)?.user ||
       undefined;
 
     return (
       <div
-        className={`str-chat__reaction-selector ${
-          reverse ? 'str-chat__reaction-selector--reverse' : ''
-        }`}
+        className={clsx(
+          'str-chat__reaction-selector str-chat__message-reaction-selector',
+          reverse && 'str-chat__reaction-selector--reverse',
+        )}
         data-testid='reaction-selector'
         ref={ref}
       >
@@ -156,48 +161,51 @@ const UnMemoizedReactionSelector = React.forwardRef(
             ))}
           </div>
         )}
-        <ul className='str-chat__message-reactions-list'>
+        <ul className='str-chat__message-reactions-list str-chat__message-reactions-options'>
           {reactionOptions.map((reactionOption: ReactionEmoji) => {
             const latestUser = getLatestUserForReactionType(reactionOption.id);
             const count = reactionCounts && reactionCounts[reactionOption.id];
-
             return (
               <li key={`item-${reactionOption.id}`}>
                 <button
                   aria-label={`Select Reaction: ${reactionOption.name}`}
-                  className='str-chat__message-reactions-list-item'
+                  className={clsx(
+                    'str-chat__message-reactions-list-item str-chat__message-reactions-option',
+                    iHaveReactedWithReaction(reactionOption.id) &&
+                      'str-chat__message-reactions-option-selected',
+                  )}
                   data-text={reactionOption.id}
                   onClick={(event) => handleReaction(reactionOption.id, event)}
                 >
                   {!!count && detailedView && (
-                    <>
-                      <div
-                        className='latest-user'
-                        onClick={hideTooltip}
-                        onMouseEnter={(e) => showTooltip(e, reactionOption.id)}
-                        onMouseLeave={hideTooltip}
-                      >
-                        {latestUser ? (
-                          <Avatar
-                            image={latestUser.image}
-                            name={latestUser.name}
-                            size={20}
-                            user={latestUser}
-                          />
-                        ) : (
-                          <div className='latest-user-not-found' />
-                        )}
-                      </div>
-                    </>
+                    <div
+                      className='latest-user str-chat__message-reactions-last-user'
+                      onClick={hideTooltip}
+                      onMouseEnter={(e) => showTooltip(e, reactionOption.id)}
+                      onMouseLeave={hideTooltip}
+                    >
+                      {latestUser ? (
+                        <Avatar
+                          image={latestUser.image}
+                          name={latestUser.name}
+                          size={20}
+                          user={latestUser}
+                        />
+                      ) : (
+                        <div className='latest-user-not-found' />
+                      )}
+                    </div>
                   )}
                   {
                     <Suspense fallback={null}>
-                      <Emoji
-                        data={emojiData}
-                        emoji={reactionOption}
-                        size={20}
-                        {...(reactionsAreCustom ? additionalEmojiProps : emojiSetDef)}
-                      />
+                      <span className='str-chat__message-reaction-emoji'>
+                        <Emoji
+                          data={emojiData}
+                          emoji={reactionOption}
+                          size={20}
+                          {...(reactionsAreCustom ? additionalEmojiProps : emojiSetDef)}
+                        />
+                      </span>
                     </Suspense>
                   }
                   {Boolean(count) && detailedView && (

--- a/src/components/Reactions/SimpleReactionsList.tsx
+++ b/src/components/Reactions/SimpleReactionsList.tsx
@@ -1,14 +1,15 @@
-import React, { Suspense, useMemo, useState } from 'react';
-
-import { getStrippedEmojiData, ReactionEmoji } from '../Channel/emojiData';
+import React, { Suspense, useState } from 'react';
+import clsx from 'clsx';
 
 import { useEmojiContext } from '../../context/EmojiContext';
 import { useMessageContext } from '../../context/MessageContext';
+import { useProcessReactions } from './hooks/useProcessReactions';
 
 import type { NimbleEmojiProps } from 'emoji-mart';
 import type { ReactionResponse } from 'stream-chat';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
+import type { ReactionEmoji } from '../Channel/emojiData';
 
 export type SimpleReactionsListProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
@@ -17,6 +18,8 @@ export type SimpleReactionsListProps<
   additionalEmojiProps?: Partial<NimbleEmojiProps>;
   /** Function that adds/removes a reaction on a message (overrides the function stored in `MessageContext`) */
   handleReaction?: (reactionType: string, event: React.BaseSyntheticEvent) => Promise<void>;
+  /** An array of the own reaction objects to distinguish own reactions visually */
+  own_reactions?: ReactionResponse<StreamChatGenerics>[];
   /** An object that keeps track of the count of each type of reaction on a message */
   reaction_counts?: { [key: string]: number };
   /** A list of the currently supported reactions on a message */
@@ -30,38 +33,34 @@ const UnMemoizedSimpleReactionsList = <
 >(
   props: SimpleReactionsListProps<StreamChatGenerics>,
 ) => {
-  const {
-    additionalEmojiProps = {},
-    handleReaction: propHandleReaction,
-    reaction_counts: propReactionCounts,
-    reactionOptions: propReactionOptions,
-    reactions: propReactions,
-  } = props;
+  const { handleReaction: propHandleReaction, ...rest } = props;
 
   const { Emoji, emojiConfig } = useEmojiContext('SimpleReactionsList');
-  const { handleReaction: contextHandleReaction, message } = useMessageContext<StreamChatGenerics>(
+  const { handleReaction: contextHandleReaction } = useMessageContext<StreamChatGenerics>(
     'SimpleReactionsList',
   );
 
-  const { defaultMinimalEmojis, emojiData: fullEmojiData, emojiSetDef } = emojiConfig || {};
+  const {
+    additionalEmojiProps,
+    emojiData,
+    getEmojiByReactionType,
+    iHaveReactedWithReaction,
+    latestReactions,
+    latestReactionTypes,
+    supportedReactionsArePresent,
+    totalReactionCount,
+  } = useProcessReactions({ emojiConfig, ...rest });
 
   const [tooltipReactionType, setTooltipReactionType] = useState<string | undefined>(undefined);
 
   const handleReaction = propHandleReaction || contextHandleReaction;
-  const reactions = propReactions || message.latest_reactions || [];
-  const reactionCounts = propReactionCounts || message.reaction_counts || {};
-  const reactionOptions = propReactionOptions || defaultMinimalEmojis;
-  const reactionsAreCustom = !!propReactionOptions?.length;
 
-  const emojiData = useMemo(
-    () => (reactionsAreCustom ? fullEmojiData : getStrippedEmojiData(fullEmojiData)),
-    [fullEmojiData, reactionsAreCustom],
-  );
+  if (!latestReactions.length) return null;
 
-  if (!reactions.length) return null;
+  if (!supportedReactionsArePresent) return null;
 
   const getUsersPerReactionType = (type: string) =>
-    reactions
+    latestReactions
       .map((reaction) => {
         if (reaction.type === type) {
           return reaction.user?.name || reaction.user?.id;
@@ -70,83 +69,56 @@ const UnMemoizedSimpleReactionsList = <
       })
       .filter(Boolean);
 
-  const getTotalReactionCount = () =>
-    Object.values(reactionCounts).reduce((total, count) => total + count, 0);
-
-  const getCurrentMessageReactionTypes = () => {
-    const reactionTypes: string[] = [];
-    reactions.forEach(({ type }) => {
-      if (reactionTypes.indexOf(type) === -1) {
-        reactionTypes.push(type);
-      }
-    });
-    return reactionTypes;
-  };
-
-  const getEmojiByReactionType = (type: string): ReactionEmoji | undefined => {
-    const reactionEmoji = reactionOptions.find((option: ReactionEmoji) => option.id === type);
-    return reactionEmoji;
-  };
-
-  const getSupportedReactionMap = () => {
-    const reactionMap: Record<string, boolean> = {};
-    reactionOptions.forEach(({ id }) => (reactionMap[id] = true));
-    return reactionMap;
-  };
-
-  const messageReactionTypes = getCurrentMessageReactionTypes();
-  const supportedReactionMap = getSupportedReactionMap();
-
-  const supportedReactionsArePresent = messageReactionTypes.some(
-    (type) => supportedReactionMap[type],
-  );
-
-  if (!supportedReactionsArePresent) return null;
-
   return (
-    <ul
-      className='str-chat__simple-reactions-list'
-      data-testid='simple-reaction-list'
-      onMouseLeave={() => setTooltipReactionType(undefined)}
-    >
-      {messageReactionTypes.map((reactionType, i) => {
-        const emojiObject = getEmojiByReactionType(reactionType);
+    <div className='str-chat__message-reactions-container'>
+      <ul
+        className='str-chat__simple-reactions-list str-chat__message-reactions'
+        data-testid='simple-reaction-list'
+        onMouseLeave={() => setTooltipReactionType(undefined)}
+      >
+        {latestReactionTypes.map((reactionType, i) => {
+          const emojiObject = getEmojiByReactionType(reactionType);
+          const isOwnReaction = iHaveReactedWithReaction(reactionType);
 
-        return emojiObject ? (
-          <li
-            className='str-chat__simple-reactions-list-item'
-            key={`${emojiObject.id}-${i}`}
-            onClick={(event) => handleReaction(reactionType, event)}
-            onKeyPress={(event) => handleReaction(reactionType, event)}
-          >
-            <span onMouseEnter={() => setTooltipReactionType(reactionType)}>
-              {
-                <Suspense fallback={null}>
-                  <Emoji
-                    data={emojiData}
-                    emoji={emojiObject}
-                    size={13}
-                    {...(reactionsAreCustom ? additionalEmojiProps : emojiSetDef)}
-                  />
-                </Suspense>
-              }
-              &nbsp;
-            </span>
-            {tooltipReactionType === emojiObject.id && (
-              <div className='str-chat__simple-reactions-list-tooltip'>
-                <div className='arrow' />
-                {getUsersPerReactionType(tooltipReactionType)?.join(', ')}
-              </div>
-            )}
+          return emojiObject ? (
+            <li
+              className={clsx(
+                'str-chat__simple-reactions-list-item',
+                isOwnReaction && 'str-chat__message-reaction-own',
+              )}
+              key={`${emojiObject.id}-${i}`}
+              onClick={(event) => handleReaction(reactionType, event)}
+              onKeyUp={(event) => handleReaction(reactionType, event)}
+            >
+              <span onMouseEnter={() => setTooltipReactionType(reactionType)}>
+                {
+                  <Suspense fallback={null}>
+                    <Emoji
+                      data={emojiData}
+                      emoji={emojiObject}
+                      size={13}
+                      {...additionalEmojiProps}
+                    />
+                  </Suspense>
+                }
+                &nbsp;
+              </span>
+              {tooltipReactionType === emojiObject.id && (
+                <div className='str-chat__simple-reactions-list-tooltip str-chat__tooltip'>
+                  <div className='arrow' />
+                  {getUsersPerReactionType(tooltipReactionType)?.join(', ')}
+                </div>
+              )}
+            </li>
+          ) : null;
+        })}
+        {
+          <li className='str-chat__simple-reactions-list-item--last-number'>
+            {totalReactionCount}
           </li>
-        ) : null;
-      })}
-      {
-        <li className='str-chat__simple-reactions-list-item--last-number'>
-          {getTotalReactionCount()}
-        </li>
-      }
-    </ul>
+        }
+      </ul>
+    </div>
   );
 };
 

--- a/src/components/Reactions/hooks/useProcessReactions.tsx
+++ b/src/components/Reactions/hooks/useProcessReactions.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useMemo } from 'react';
+import { getStrippedEmojiData, ReactionEmoji } from '../../Channel/emojiData';
+import type { EmojiContextValue } from '../../../context/EmojiContext';
+import type { ReactionsListProps } from '../ReactionsList';
+import { useMessageContext } from '../../../context';
+import type { DefaultStreamChatGenerics } from '../../../types/types';
+
+type SharedReactionListProps =
+  | 'additionalEmojiProps'
+  | 'own_reactions'
+  | 'reaction_counts'
+  | 'reactionOptions'
+  | 'reactions';
+
+type UseProcessReactionsParams = Pick<ReactionsListProps, SharedReactionListProps> &
+  Pick<EmojiContextValue, 'emojiConfig'>;
+
+export const useProcessReactions = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>(
+  params: UseProcessReactionsParams,
+) => {
+  const {
+    additionalEmojiProps = {},
+    emojiConfig,
+    own_reactions: propOwnReactions,
+    reaction_counts: propReactionCounts,
+    reactionOptions: propReactionOptions,
+    reactions: propReactions,
+  } = params;
+  const { message } = useMessageContext<StreamChatGenerics>('ReactionsList');
+  const { defaultMinimalEmojis, emojiData: fullEmojiData, emojiSetDef } = emojiConfig || {};
+
+  const latestReactions = propReactions || message.latest_reactions || [];
+  const ownReactions = propOwnReactions || message?.own_reactions || [];
+  const reactionCounts = propReactionCounts || message.reaction_counts || {};
+  const reactionOptions = propReactionOptions || defaultMinimalEmojis;
+  const reactionsAreCustom = !!propReactionOptions?.length;
+
+  const iHaveReactedWithReaction = useCallback(
+    (reactionType: string) => ownReactions.find((reaction) => reaction.type === reactionType),
+    [ownReactions],
+  );
+
+  const getEmojiByReactionType = useCallback(
+    (type: string): ReactionEmoji | undefined =>
+      reactionOptions.find((option: ReactionEmoji) => option.id === type),
+    [reactionOptions],
+  );
+
+  const emojiData = useMemo(
+    () => (reactionsAreCustom ? fullEmojiData : getStrippedEmojiData(fullEmojiData)),
+    [fullEmojiData, reactionsAreCustom],
+  );
+
+  const latestReactionTypes = useMemo(
+    () =>
+      latestReactions.reduce((reactionTypes, { type }) => {
+        if (reactionTypes.indexOf(type) === -1) {
+          reactionTypes.push(type);
+        }
+        return reactionTypes;
+      }, [] as string[]),
+    [latestReactions],
+  );
+
+  const supportedReactionMap = useMemo(
+    () =>
+      reactionOptions.reduce((acc, { id }) => {
+        acc[id] = true;
+        return acc;
+      }, {} as Record<string, boolean>),
+    [reactionOptions],
+  );
+
+  const supportedReactionsArePresent = useMemo(
+    () => latestReactionTypes.some((type) => supportedReactionMap[type]),
+    [latestReactionTypes, supportedReactionMap],
+  );
+
+  const totalReactionCount = useMemo(
+    () =>
+      supportedReactionsArePresent
+        ? Object.values(reactionCounts).reduce((total, count) => total + count, 0)
+        : 0,
+    [reactionCounts, supportedReactionsArePresent],
+  );
+
+  return {
+    additionalEmojiProps: reactionsAreCustom ? additionalEmojiProps : emojiSetDef,
+    emojiData,
+    getEmojiByReactionType,
+    iHaveReactedWithReaction,
+    latestReactions,
+    latestReactionTypes,
+    reactionCounts,
+    supportedReactionsArePresent,
+    totalReactionCount,
+  };
+};


### PR DESCRIPTION
### 🎯 Goal

Add classes and markup to adapt to theme v2. Besides that the duplicate processing code from `ReactionList` and `SimpleReactionList` has been extracted to a single hook now shared by the both components.

Depends on https://github.com/GetStream/stream-chat-css/pull/150
Closes #1585


### 🎨 UI Changes

#### `ReactionList` component

![image](https://user-images.githubusercontent.com/32706194/178510838-cd7c810a-5843-44fd-aa69-92acc5781444.png)

- with reaction selector
![image](https://user-images.githubusercontent.com/32706194/178510898-0df7308b-f6a7-4707-aa06-37adfea0ed24.png)


#### `SimpleReactionList` component
There is no distinction btw. own and other users' reactions.

![image](https://user-images.githubusercontent.com/32706194/178511036-631a8e1a-ee46-4968-97cb-ae84f1c00bff.png)

- with reaction selector (same as for the `ReactionList`)

![image](https://user-images.githubusercontent.com/32706194/178511221-71e4651f-9471-4792-b481-787fddb19767.png)

