### PR TITLE
feat(message-status): extendable user information in read-by tooltip

### DIFF
--- a/docusaurus/docs/React/message-components/ui-components.mdx
+++ b/docusaurus/docs/React/message-components/ui-components.mdx
@@ -245,7 +245,7 @@ Allows you to customize the username(s) that appear on the message status toolti
 
 | Type                                               | Default                         |
 | -------------------------------------------------- | ------------------------------- |
-| (user: UserResponse<StreamchatGenerics>) => string | (user ) => user.name || user.id |
+| (user: UserResponse<StreamChatGenerics>) => string | (user) => user.name || user.id  |
 
 ## MessageText Props
 

--- a/docusaurus/docs/React/message-components/ui-components.mdx
+++ b/docusaurus/docs/React/message-components/ui-components.mdx
@@ -247,6 +247,33 @@ Allows you to customize the username(s) that appear on the message status toolti
 | -------------------------------------------------- | ------------------------------- |
 | (user: UserResponse<StreamChatGenerics>) => string | (user) => user.name || user.id  |
 
+This prop's implementation is not provided out of the box by the SDK. See below for a customization example:
+
+```tsx
+const CustomMessageStatus = (props: MessageStatusProps) => {
+  const allCapsUserName = useCallback<TooltipUsernameMapper>(
+    (user) => (user.name || user.id).toUpperCase(),
+    [],
+  );
+  return <MessageStatus {...props} tooltipUserNameMapper={allCapsUserName} />;
+};
+
+// Sort in reverse order to avoid auto-selecting unread channel
+const sort: ChannelSort = { last_updated: 1 };
+const WrappedConnectedUser = ({ token, userId }: Omit<ConnectedUserProps, 'children'>) => (
+  <ConnectedUser token={token} userId={userId}>
+    <ChannelList filters={{ id: { $eq: 'add-message' }, members: { $in: [userId] } }} sort={sort} />
+    <Channel MessageStatus={CustomMessageStatus}>
+      <Window>
+        <ChannelHeader />
+        <MessageList />
+      </Window>
+      <Thread />
+    </Channel>
+  </ConnectedUser>
+);
+```
+
 ## MessageText Props
 
 ### customInnerClass

--- a/docusaurus/docs/React/message-components/ui-components.mdx
+++ b/docusaurus/docs/React/message-components/ui-components.mdx
@@ -239,6 +239,14 @@ Message type string to be added to CSS class names.
 | ------ | -------- |
 | string | 'simple' |
 
+### tooltipUserNameMapper
+
+Allows you to customize the username(s) that appear on the message status tooltip.
+
+| Type                                               | Default                         |
+| -------------------------------------------------- | ------------------------------- |
+| (user: UserResponse<StreamchatGenerics>) => string | (user ) => user.name || user.id |
+
 ## MessageText Props
 
 ### customInnerClass

--- a/src/components/Message/MessageStatus.tsx
+++ b/src/components/Message/MessageStatus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { DeliveredCheckIcon } from './icons';
-import { getReadByTooltipText } from './utils';
+import { getReadByTooltipText, ReadByToolTipFormat } from './utils';
 
 import { AvatarProps, Avatar as DefaultAvatar } from '../Avatar';
 import { LoadingIndicator } from '../Loading';
@@ -17,6 +17,7 @@ import type { DefaultStreamChatGenerics } from '../../types/types';
 export type MessageStatusProps = {
   Avatar?: React.ComponentType<AvatarProps>;
   messageType?: string;
+  readByToolTipFormat?: ReadByToolTipFormat;
 };
 
 const UnMemoizedMessageStatus = <
@@ -24,7 +25,7 @@ const UnMemoizedMessageStatus = <
 >(
   props: MessageStatusProps,
 ) => {
-  const { Avatar: propAvatar, messageType = 'simple' } = props;
+  const { Avatar: propAvatar, messageType = 'simple', readByToolTipFormat } = props;
 
   const { client } = useChatContext<StreamChatGenerics>('MessageStatus');
   const { Avatar: contextAvatar } = useComponentContext<StreamChatGenerics>('MessageStatus');
@@ -65,7 +66,7 @@ const UnMemoizedMessageStatus = <
         className={`str-chat__message-${messageType}-status`}
         data-testid='message-status-read-by'
       >
-        <Tooltip>{getReadByTooltipText(readBy, t, client)}</Tooltip>
+        <Tooltip>{getReadByTooltipText(readBy, t, client, readByToolTipFormat)}</Tooltip>
         <Avatar
           image={lastReadUser.image}
           name={lastReadUser.name || lastReadUser.id}

--- a/src/components/Message/MessageStatus.tsx
+++ b/src/components/Message/MessageStatus.tsx
@@ -13,11 +13,12 @@ import { useMessageContext } from '../../context/MessageContext';
 import { useTranslationContext } from '../../context/TranslationContext';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
+import type { UserResponse } from 'stream-chat';
 
 export type MessageStatusProps = {
   Avatar?: React.ComponentType<AvatarProps>;
   messageType?: string;
-  readByToolTipFormat?: TooltipUsernameMapper;
+  tooltipUserNameMapper?: TooltipUsernameMapper;
 };
 
 const UnMemoizedMessageStatus = <
@@ -25,7 +26,11 @@ const UnMemoizedMessageStatus = <
 >(
   props: MessageStatusProps,
 ) => {
-  const { Avatar: propAvatar, messageType = 'simple', readByToolTipFormat } = props;
+  const {
+    Avatar: propAvatar,
+    messageType = 'simple',
+    tooltipUserNameMapper = (user: UserResponse<StreamChatGenerics>) => user.name || user.id,
+  } = props;
 
   const { client } = useChatContext<StreamChatGenerics>('MessageStatus');
   const { Avatar: contextAvatar } = useComponentContext<StreamChatGenerics>('MessageStatus');
@@ -66,7 +71,7 @@ const UnMemoizedMessageStatus = <
         className={`str-chat__message-${messageType}-status`}
         data-testid='message-status-read-by'
       >
-        <Tooltip>{getReadByTooltipText(readBy, t, client, readByToolTipFormat)}</Tooltip>
+        <Tooltip>{getReadByTooltipText(readBy, t, client, tooltipUserNameMapper)}</Tooltip>
         <Avatar
           image={lastReadUser.image}
           name={lastReadUser.name || lastReadUser.id}

--- a/src/components/Message/MessageStatus.tsx
+++ b/src/components/Message/MessageStatus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { DeliveredCheckIcon } from './icons';
-import { getReadByTooltipText, TooltipUsernameMapper } from './utils';
+import { getReadByTooltipText, mapToUserNameOrId, TooltipUsernameMapper } from './utils';
 
 import { AvatarProps, Avatar as DefaultAvatar } from '../Avatar';
 import { LoadingIndicator } from '../Loading';
@@ -13,7 +13,6 @@ import { useMessageContext } from '../../context/MessageContext';
 import { useTranslationContext } from '../../context/TranslationContext';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
-import type { UserResponse } from 'stream-chat';
 
 export type MessageStatusProps = {
   Avatar?: React.ComponentType<AvatarProps>;
@@ -29,7 +28,7 @@ const UnMemoizedMessageStatus = <
   const {
     Avatar: propAvatar,
     messageType = 'simple',
-    tooltipUserNameMapper = (user: UserResponse<StreamChatGenerics>) => user.name || user.id,
+    tooltipUserNameMapper = mapToUserNameOrId,
   } = props;
 
   const { client } = useChatContext<StreamChatGenerics>('MessageStatus');

--- a/src/components/Message/MessageStatus.tsx
+++ b/src/components/Message/MessageStatus.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { DeliveredCheckIcon } from './icons';
-import { getReadByTooltipText, ReadByToolTipFormat } from './utils';
+import { getReadByTooltipText, TooltipUsernameMapper } from './utils';
 
 import { AvatarProps, Avatar as DefaultAvatar } from '../Avatar';
 import { LoadingIndicator } from '../Loading';
@@ -17,7 +17,7 @@ import type { DefaultStreamChatGenerics } from '../../types/types';
 export type MessageStatusProps = {
   Avatar?: React.ComponentType<AvatarProps>;
   messageType?: string;
-  readByToolTipFormat?: ReadByToolTipFormat;
+  readByToolTipFormat?: TooltipUsernameMapper;
 };
 
 const UnMemoizedMessageStatus = <

--- a/src/components/Message/__tests__/utils.test.js
+++ b/src/components/Message/__tests__/utils.test.js
@@ -328,22 +328,39 @@ describe('Message utils', () => {
   });
 
   describe('getReadbyTooltipText', () => {
+    const tooltipUserNameMapper = (user) => user.name || user.id;
+
     let client;
 
     beforeAll(async () => {
       client = await getTestClientWithUser(alice);
     });
     it('ignores the client user', () => {
-      const result = getReadByTooltipText([client.user], mockTranslatorFunction, client);
+      const result = getReadByTooltipText(
+        [client.user],
+        mockTranslatorFunction,
+        client,
+        tooltipUserNameMapper,
+      );
       expect(result).toStrictEqual('');
     });
     it('returns a single user if only one user in array', () => {
-      const result = getReadByTooltipText([bob], mockTranslatorFunction, client);
+      const result = getReadByTooltipText(
+        [bob],
+        mockTranslatorFunction,
+        client,
+        tooltipUserNameMapper,
+      );
       expect(result).toStrictEqual(`${bob.name} `);
     });
     it('returns "1 and 2" if read by two users', () => {
       const users = [generateUser({ name: '1' }), generateUser({ name: '2' })];
-      const result = getReadByTooltipText(users, mockTranslatorFunction, client);
+      const result = getReadByTooltipText(
+        users,
+        mockTranslatorFunction,
+        client,
+        tooltipUserNameMapper,
+      );
       expect(result).toStrictEqual(`1 and 2`);
     });
     it('returns "1, 2, and 3" if read by three users', () => {
@@ -352,15 +369,25 @@ describe('Message utils', () => {
         generateUser({ name: '2' }),
         generateUser({ name: '3' }),
       ];
-      const result = getReadByTooltipText(users, mockTranslatorFunction, client);
+      const result = getReadByTooltipText(
+        users,
+        mockTranslatorFunction,
+        client,
+        tooltipUserNameMapper,
+      );
       expect(result).toStrictEqual(`1, 2, and 3`);
     });
     it('returns "1, 2, 3, 4, 5, and 5 more if read by ten users', () => {
       const users = [...Array(10).keys()].map((n) => generateUser({ name: (n + 1).toString() }));
-      const result = getReadByTooltipText(users, mockTranslatorFunction, client);
+      const result = getReadByTooltipText(
+        users,
+        mockTranslatorFunction,
+        client,
+        tooltipUserNameMapper,
+      );
       expect(result).toStrictEqual(`1, 2, 3, 4, 5, and 5 more`);
     });
-    it('overrides user format with readByToolTipFormat', () => {
+    it('overrides user format with tooltipUserNameMapper', () => {
       const users = [generateUser({ name: '1' }), generateUser({ name: '2' })];
       const result = getReadByTooltipText(
         users,
@@ -371,8 +398,13 @@ describe('Message utils', () => {
       expect(result).toStrictEqual(`Dr. 1 and Dr. 2`);
     });
     it('throws error if no translator function provided', () => {
-      expect(() => getReadByTooltipText([], null, client)).toThrow(
-        '`getReadByTooltipText was called, but translation function is not available`',
+      expect(() => getReadByTooltipText([], null, client, tooltipUserNameMapper)).toThrow(
+        'getReadByTooltipText was called, but translation function is not available',
+      );
+    });
+    it('throws error if no tooltipUserNameMapper function provided', () => {
+      expect(() => getReadByTooltipText([], mockTranslatorFunction, client)).toThrow(
+        'getReadByTooltipText was called, but tooltipUserNameMapper function is not available',
       );
     });
   });

--- a/src/components/Message/__tests__/utils.test.js
+++ b/src/components/Message/__tests__/utils.test.js
@@ -8,6 +8,7 @@ import {
   getNonImageAttachments,
   getReadByTooltipText,
   isUserMuted,
+  mapToUserNameOrId,
   MESSAGE_ACTIONS,
   messageHasAttachments,
   messageHasReactions,
@@ -327,8 +328,8 @@ describe('Message utils', () => {
     });
   });
 
-  describe('getReadbyTooltipText', () => {
-    const tooltipUserNameMapper = (user) => user.name || user.id;
+  describe('getReadByTooltipText', () => {
+    const tooltipUserNameMapper = mapToUserNameOrId;
 
     let client;
 
@@ -377,7 +378,7 @@ describe('Message utils', () => {
       );
       expect(result).toStrictEqual(`1, 2, and 3`);
     });
-    it('returns "1, 2, 3, 4, 5, and 5 more if read by ten users', () => {
+    it('returns "1, 2, 3, 4, 5 and 5 more if read by ten users', () => {
       const users = [...Array(10).keys()].map((n) => generateUser({ name: (n + 1).toString() }));
       const result = getReadByTooltipText(
         users,
@@ -385,7 +386,7 @@ describe('Message utils', () => {
         client,
         tooltipUserNameMapper,
       );
-      expect(result).toStrictEqual(`1, 2, 3, 4, 5, and 5 more`);
+      expect(result).toStrictEqual(`1, 2, 3, 4, 5 and 5 more`);
     });
     it('overrides user format with tooltipUserNameMapper', () => {
       const users = [generateUser({ name: '1' }), generateUser({ name: '2' })];
@@ -403,7 +404,7 @@ describe('Message utils', () => {
       );
     });
     it('throws error if no tooltipUserNameMapper function provided', () => {
-      expect(() => getReadByTooltipText([], mockTranslatorFunction, client)).toThrow(
+      expect(() => getReadByTooltipText([], mockTranslatorFunction, client, undefined)).toThrow(
         'getReadByTooltipText was called, but tooltipUserNameMapper function is not available',
       );
     });

--- a/src/components/Message/__tests__/utils.test.js
+++ b/src/components/Message/__tests__/utils.test.js
@@ -1,10 +1,12 @@
 import { generateMessage, generateReaction, generateUser } from 'mock-builders';
+import { getTestClientWithUser, mockTranslatorFunction } from '../../../mock-builders';
 import {
   areMessagePropsEqual,
   areMessageUIPropsEqual,
   getImages,
   getMessageActions,
   getNonImageAttachments,
+  getReadByTooltipText,
   isUserMuted,
   MESSAGE_ACTIONS,
   messageHasAttachments,
@@ -322,6 +324,41 @@ describe('Message utils', () => {
         attachments: [pdf, img],
       });
       expect(getNonImageAttachments(message)).toStrictEqual([pdf]);
+    });
+  });
+
+  describe('getReadbyTooltipText', () => {
+    let client;
+
+    beforeAll(async () => {
+      client = await getTestClientWithUser(alice);
+    });
+    it('ignores the client user', () => {
+      const result = getReadByTooltipText([client.user], mockTranslatorFunction, client);
+      expect(result).toStrictEqual('');
+    });
+    it('returns a single user if only one user in array', () => {
+      const result = getReadByTooltipText([bob], mockTranslatorFunction, client);
+      expect(result).toStrictEqual(`${bob.name} `);
+    });
+    it('returns "1 and 2" if read by two users', () => {
+      const users = [generateUser({ name: '1' }), generateUser({ name: '2' })];
+      const result = getReadByTooltipText(users, mockTranslatorFunction, client);
+      expect(result).toStrictEqual(`1 and 2`);
+    });
+    it('returns "1, 2, and 3" if read by three users', () => {
+      const users = [
+        generateUser({ name: '1' }),
+        generateUser({ name: '2' }),
+        generateUser({ name: '3' }),
+      ];
+      const result = getReadByTooltipText(users, mockTranslatorFunction, client);
+      expect(result).toStrictEqual(`1, 2, and 3`);
+    });
+    it('returns "1, 2, 3, 4, 5, and 5 more if read by ten users', () => {
+      const users = [...Array(10).keys()].map((n) => generateUser({ name: (n + 1).toString() }));
+      const result = getReadByTooltipText(users, mockTranslatorFunction, client);
+      expect(result).toStrictEqual(`1, 2, 3, 4, 5, and 5 more`);
     });
   });
 });

--- a/src/components/Message/__tests__/utils.test.js
+++ b/src/components/Message/__tests__/utils.test.js
@@ -360,5 +360,20 @@ describe('Message utils', () => {
       const result = getReadByTooltipText(users, mockTranslatorFunction, client);
       expect(result).toStrictEqual(`1, 2, 3, 4, 5, and 5 more`);
     });
+    it('overrides user format with readByToolTipFormat', () => {
+      const users = [generateUser({ name: '1' }), generateUser({ name: '2' })];
+      const result = getReadByTooltipText(
+        users,
+        mockTranslatorFunction,
+        client,
+        (user) => `Dr. ${user.name}`,
+      );
+      expect(result).toStrictEqual(`Dr. 1 and Dr. 2`);
+    });
+    it('throws error if no translator function provided', () => {
+      expect(() => getReadByTooltipText([], null, client)).toThrow(
+        '`getReadByTooltipText was called, but translation function is not available`',
+      );
+    });
   });
 });

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -369,13 +369,13 @@ export const getReadByTooltipText = <
     // example: "bob, joe, sam and 4 more"
     if (restLength === 0) {
       // mutate slicedArr to remove last user to display it separately
-      const lastUser = slicedArr.splice(slicedArr.length - 2, 1);
+      const lastUser = slicedArr.splice(slicedArr.length - 1, 1);
       outStr = t('{{ commaSeparatedUsers }}, and {{ lastUser }}', {
         commaSeparatedUsers: slicedArr.join(', '),
         lastUser,
       });
     } else {
-      outStr = t('{{ commaSeparatedUsers }} and {{ moreCount }} more', {
+      outStr = t('{{ commaSeparatedUsers }}, and {{ moreCount }} more', {
         commaSeparatedUsers: slicedArr.join(', '),
         moreCount: restLength,
       });

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -334,7 +334,7 @@ export const getNonImageAttachments = <
   return message.attachments.filter((item) => item.type !== 'image');
 };
 
-export interface ReadByToolTipFormat {
+export interface TooltipUsernameMapper {
   <StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics>(
     user: UserResponse<StreamChatGenerics>,
   ): string;
@@ -346,7 +346,8 @@ export const getReadByTooltipText = <
   users: UserResponse<StreamChatGenerics>[],
   t: TFunction,
   client: StreamChat<StreamChatGenerics>,
-  readByToolTipFormat?: ReadByToolTipFormat,
+  tooltipUserNameMapper: TooltipUsernameMapper = (user: UserResponse<StreamChatGenerics>) =>
+    user.name || user.id,
 ) => {
   let outStr = '';
 
@@ -354,12 +355,10 @@ export const getReadByTooltipText = <
     throw new Error('`getReadByTooltipText was called, but translation function is not available`');
   }
 
-  const defaultFormat = (user: UserResponse<StreamChatGenerics>) => user.name || user.id;
-
   // first filter out client user, so restLength won't count it
   const otherUsers = users
     .filter((item) => item && client?.user && item.id !== client.user.id)
-    .map(readByToolTipFormat || defaultFormat);
+    .map(tooltipUserNameMapper);
 
   const slicedArr = otherUsers.slice(0, 5);
   const restLength = otherUsers.length - slicedArr.length;

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -346,15 +346,19 @@ export const getReadByTooltipText = <
   users: UserResponse<StreamChatGenerics>[],
   t: TFunction,
   client: StreamChat<StreamChatGenerics>,
-  tooltipUserNameMapper: TooltipUsernameMapper = (user: UserResponse<StreamChatGenerics>) =>
-    user.name || user.id,
+  tooltipUserNameMapper: TooltipUsernameMapper,
 ) => {
   let outStr = '';
 
   if (!t) {
-    throw new Error('`getReadByTooltipText was called, but translation function is not available`');
+    throw new Error('getReadByTooltipText was called, but translation function is not available');
   }
 
+  if (!tooltipUserNameMapper) {
+    throw new Error(
+      'getReadByTooltipText was called, but tooltipUserNameMapper function is not available',
+    );
+  }
   // first filter out client user, so restLength won't count it
   const otherUsers = users
     .filter((item) => item && client?.user && item.id !== client.user.id)

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -340,6 +340,13 @@ export interface TooltipUsernameMapper {
   ): string;
 }
 
+/**
+ * Default Tooltip Username mapper implementation.
+ *
+ * @param user the user.
+ */
+export const mapToUserNameOrId: TooltipUsernameMapper = (user) => user.name || user.id;
+
 export const getReadByTooltipText = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 >(
@@ -387,7 +394,7 @@ export const getReadByTooltipText = <
         lastUser,
       });
     } else {
-      outStr = t('{{ commaSeparatedUsers }}, and {{ moreCount }} more', {
+      outStr = t('{{ commaSeparatedUsers }} and {{ moreCount }} more', {
         commaSeparatedUsers: slicedArr.join(', '),
         moreCount: restLength,
       });

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -334,12 +334,19 @@ export const getNonImageAttachments = <
   return message.attachments.filter((item) => item.type !== 'image');
 };
 
+export interface ReadByToolTipFormat {
+  <StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics>(
+    user: UserResponse<StreamChatGenerics>,
+  ): string;
+}
+
 export const getReadByTooltipText = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 >(
   users: UserResponse<StreamChatGenerics>[],
   t: TFunction,
   client: StreamChat<StreamChatGenerics>,
+  readByToolTipFormat?: ReadByToolTipFormat,
 ) => {
   let outStr = '';
 
@@ -347,10 +354,12 @@ export const getReadByTooltipText = <
     throw new Error('`getReadByTooltipText was called, but translation function is not available`');
   }
 
+  const defaultFormat = (user: UserResponse<StreamChatGenerics>) => user.name || user.id;
+
   // first filter out client user, so restLength won't count it
   const otherUsers = users
     .filter((item) => item && client?.user && item.id !== client.user.id)
-    .map((item) => item.name || item.id);
+    .map(readByToolTipFormat || defaultFormat);
 
   const slicedArr = otherUsers.slice(0, 5);
   const restLength = otherUsers.length - slicedArr.length;

--- a/src/mock-builders/__test__/translator.test.js
+++ b/src/mock-builders/__test__/translator.test.js
@@ -1,0 +1,20 @@
+import { mockTranslatorFunction } from '../translator';
+
+describe('mockTranslatorFunction', () => {
+  it('returns string if no map passed in as second argument', () => {
+    const result = mockTranslatorFunction('');
+    expect(result).toStrictEqual('');
+  });
+  it('inserts a single param value', () => {
+    const result = mockTranslatorFunction('{{ testKey }}', { testKey: 'test' });
+    expect(result).toStrictEqual('test');
+  });
+  it('inserts multiple param values', () => {
+    const result = mockTranslatorFunction('{{ testKey1 }}, {{ testKey2 }}, and {{ testKey3 }}', {
+      testKey1: 'test1',
+      testKey2: 'test2',
+      testKey3: 'test3',
+    });
+    expect(result).toStrictEqual('test1, test2, and test3');
+  });
+});

--- a/src/mock-builders/index.js
+++ b/src/mock-builders/index.js
@@ -48,3 +48,4 @@ export const getRandomInt = (min, max) => {
 export * from './api';
 export * from './event';
 export * from './generator';
+export * from './translator';

--- a/src/mock-builders/translator.js
+++ b/src/mock-builders/translator.js
@@ -1,0 +1,5 @@
+export const mockTranslatorFunction = (value, params = {}) =>
+  Object.keys(params).reduce((acc, key) => {
+    const regexp = new RegExp(`\\{\\{\\s${key}\\s\\}\\}`, 'g');
+    return acc.replace(regexp, params[key]);
+  }, value);

--- a/src/stories/message-status-readby-tooltip.stories.tsx
+++ b/src/stories/message-status-readby-tooltip.stories.tsx
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import '@stream-io/stream-chat-css/dist/css/index.css';
+import React, { useCallback } from 'react';
+import type { ChannelSort } from 'stream-chat';
+import {
+  Channel,
+  ChannelHeader,
+  ChannelList,
+  MessageList,
+  MessageStatus,
+  MessageStatusProps,
+  Thread,
+  TooltipUsernameMapper,
+  Window,
+} from '../index';
+import { ConnectedUser, ConnectedUserProps } from './utils';
+
+const channelId = import.meta.env.E2E_ADD_MESSAGE_CHANNEL;
+if (!channelId || typeof channelId !== 'string') {
+  throw new Error('expected ADD_MESSAGE_CHANNEL');
+}
+
+const CustomMessageStatus = (props: MessageStatusProps) => {
+  const allCapsUserName = useCallback<TooltipUsernameMapper>(
+    (user) => (user.name || user.id).toUpperCase(),
+    [],
+  );
+  return <MessageStatus {...props} tooltipUserNameMapper={allCapsUserName} />;
+};
+
+// Sort in reverse order to avoid auto-selecting unread channel
+const sort: ChannelSort = { last_updated: 1 };
+const WrappedConnectedUser = ({ token, userId }: Omit<ConnectedUserProps, 'children'>) => (
+  <ConnectedUser token={token} userId={userId}>
+    <ChannelList filters={{ id: { $eq: 'add-message' }, members: { $in: [userId] } }} sort={sort} />
+    <Channel MessageStatus={CustomMessageStatus}>
+      <Window>
+        <ChannelHeader />
+        <MessageList />
+      </Window>
+      <Thread />
+    </Channel>
+  </ConnectedUser>
+);
+
+export const User1 = () => {
+  const userId = import.meta.env.E2E_TEST_USER_1;
+  const token = import.meta.env.E2E_TEST_USER_1_TOKEN;
+  if (!userId || typeof userId !== 'string') {
+    throw new Error('expected TEST_USER_1');
+  }
+  if (!token || typeof token !== 'string') {
+    throw new Error('expected TEST_USER_1_TOKEN');
+  }
+  return <WrappedConnectedUser token={token} userId={userId} />;
+};
+
+export const User2 = () => {
+  const userId = import.meta.env.E2E_TEST_USER_2;
+  const token = import.meta.env.E2E_TEST_USER_2_TOKEN;
+  if (!userId || typeof userId !== 'string') {
+    throw new Error('expected TEST_USER_2');
+  }
+  if (!token || typeof token !== 'string') {
+    throw new Error('expected TEST_USER_2_TOKEN');
+  }
+  return <WrappedConnectedUser token={token} userId={userId} />;
+};


### PR DESCRIPTION
# Override read-by tooltip format

### 🎯 Goal

Allow the user to customize read-by tooltips based on user information.

I needed this in my project so that I could add information about users from another database to the readby tooltip.  Due to our architecture, user.name was email, and we wanted it to be first/last name from our own users table.

### 🛠 Implementation details

Adds an optional callback to MessageStatus that takes in a UserResponse and and returns a string of the custom tooltip text.  This is passed into getReadByTooltipText.  If it's null, it uses the original format.

I also added some testing around getReadByTooltipText, including a minimal test helper function to enable testing with i18n. 

### 🎨 UI Changes

<img width="456" alt="Screen Shot 2022-07-12 at 4 37 18 PM" src="https://user-images.githubusercontent.com/10293788/178776388-2971acaf-8161-4e57-b1c1-96b75b148735.png">

