### PR TITLE
Theming v2 message notifications react

### DIFF
--- a/src/components/MessageList/CustomNotification.tsx
+++ b/src/components/MessageList/CustomNotification.tsx
@@ -13,7 +13,7 @@ const UnMemoizedCustomNotification = (props: PropsWithChildren<CustomNotificatio
   return (
     <div
       aria-live='polite'
-      className={`str-chat__custom-notification notification-${type}`}
+      className={`str-chat__custom-notification notification-${type} str-chat__notification`}
       data-testid='custom-notification'
     >
       {children}

--- a/src/components/MessageList/__tests__/CustomNotification.test.js
+++ b/src/components/MessageList/__tests__/CustomNotification.test.js
@@ -23,7 +23,7 @@ describe('CustomNotification', () => {
     expect(tree).toMatchInlineSnapshot(`
       <div
         aria-live="polite"
-        className="str-chat__custom-notification notification-undefined"
+        className="str-chat__custom-notification notification-undefined str-chat__notification"
         data-testid="custom-notification"
       >
         children


### PR DESCRIPTION
### 🎯 Goal

Closes #1587 

This PR brings only a single change related to v2 theme for message notitications - addition of v2 class to `CustomNotification` component. The message notification logic remains the same.

Compared to https://github.com/GetStream/stream-chat-angular/pull/314, this PR does not introduce message notification into the `EmptyStateIndicator` as shown below:

![image](https://user-images.githubusercontent.com/32706194/178777662-1598afa0-4655-4ee1-9086-4b5f4d6f0636.png)

It may be beneficial to introduce a notification service and not a`MessageNotification` component that is tightly coupled to `MessageList` logic. A proposal of such system is described in the issue #1671

### 🎨 UI Changes

The only change is the styling of the notification stripe:

![image](https://user-images.githubusercontent.com/32706194/178776823-1099da0e-e5bc-489a-afbf-3f3b42da8de3.png)
