### PR TITLE
Feat/add autoscrolltobottom to message context

### DIFF
--- a/docusaurus/docs/React/contexts/message-context.mdx
+++ b/docusaurus/docs/React/contexts/message-context.mdx
@@ -35,6 +35,14 @@ while editing.
 | ------ |
 | object |
 
+### autoscrollToBottom
+
+Call this function to keep message list scrolled to the bottom when the message list container scroll height increases (only available in the `VirtualizedMessageList`). An example use case is that upon user's interaction with the application, a new element appears below the last message. In order to keep the newly rendered content visible, the `autoscrollToBottom` function can be called. The container, however, is not scrolled to the bottom, if already scrolled up more than 4px from the bottom.
+
+| Type       |
+| ---------- |
+| () => void |
+
 ### clearEditingState
 
 When called, this function will exit the editing state on the message.

--- a/docusaurus/docs/React/message-components/message-ui.mdx
+++ b/docusaurus/docs/React/message-components/message-ui.mdx
@@ -113,6 +113,14 @@ while editing (overrides the value stored in `MessageContext`).
 | ------ |
 | object |
 
+### autoscrollToBottom
+
+Call this function to keep message list scrolled to the bottom when the message list container scroll height increases (only available in the `VirtualizedMessageList`). An example use case is that upon user's interaction with the application, a new element appears below the last message. In order to keep the newly rendered content visible, the `autoscrollToBottom` function can be called. The container, however, is not scrolled to the bottom, if already scrolled up more than 4px from the bottom.
+
+| Type       |
+| ---------- |
+| () => void |
+
 ### clearEditingState
 
 When called, this function will exit the editing state on the message (overrides the function stored in `MessageContext`).

--- a/docusaurus/docs/React/message-components/message-ui.mdx
+++ b/docusaurus/docs/React/message-components/message-ui.mdx
@@ -115,7 +115,24 @@ while editing (overrides the value stored in `MessageContext`).
 
 ### autoscrollToBottom
 
-Call this function to keep message list scrolled to the bottom when the message list container scroll height increases (only available in the `VirtualizedMessageList`). An example use case is that upon user's interaction with the application, a new element appears below the last message. In order to keep the newly rendered content visible, the `autoscrollToBottom` function can be called. The container, however, is not scrolled to the bottom, if already scrolled up more than 4px from the bottom.
+Call this function to keep message list scrolled to the bottom when the message list container scroll height increases (only available in the `VirtualizedMessageList`). An example use case: upon user's interaction with the application, a new element appears below the last message. In order to keep the newly rendered content visible, the `autoscrollToBottom` function can be called. The container, however, is not scrolled to the bottom, if already scrolled up more than 4px from the bottom.
+
+You can even use the function to keep the container scrolled to the bottom while images are loading:
+
+```tsx
+const Image = (props: ImageProps) => {
+    ...
+    const { autoscrollToBottom } = useMessageContext();
+    ...
+
+    return (
+        <img
+            ...
+            onLoad={autoscrollToBottom}
+            ...
+        />
+}
+```
 
 | Type       |
 | ---------- |

--- a/docusaurus/docs/React/message-components/message.mdx
+++ b/docusaurus/docs/React/message-components/message.mdx
@@ -43,6 +43,14 @@ Additional props to be passed to the underlying `MessageInput` component, [avail
 | ------ |
 | object |
 
+### autoscrollToBottom
+
+Call this function to keep message list scrolled to the bottom when the message list container scroll height increases (only available in the `VirtualizedMessageList`). An example use case is that upon user's interaction with the application, a new element appears below the last message. In order to keep the newly rendered content visible, the `autoscrollToBottom` function can be called. The container, however, is not scrolled to the bottom, if already scrolled up more than 4px from the bottom.
+
+| Type       |
+| ---------- |
+| () => void |
+
 ### closeReactionSelectorOnClick
 
 If true, picking a reaction from the `ReactionSelector` component will close the selector.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-markdown": "^5.0.3",
     "react-player": "^2.10.1",
     "react-textarea-autosize": "^8.3.0",
-    "react-virtuoso": "^2.13.3",
+    "react-virtuoso": "^2.16.5",
     "textarea-caret": "^3.1.0"
   },
   "optionalDependencies": {

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -222,6 +222,7 @@ export const Message = <
   return (
     <MemoizedMessage
       additionalMessageInputProps={props.additionalMessageInputProps}
+      autoscrollToBottom={props.autoscrollToBottom}
       canPin={canPin}
       customMessageActions={props.customMessageActions}
       disableQuotedMessages={props.disableQuotedMessages}

--- a/src/components/Message/types.ts
+++ b/src/components/Message/types.ts
@@ -25,6 +25,8 @@ export type MessageProps<
   message: StreamMessage<StreamChatGenerics>;
   /** Additional props for underlying MessageInput component, [available props](https://getstream.io/chat/docs/sdk/react/message-input-components/message_input/#props) */
   additionalMessageInputProps?: MessageInputProps<StreamChatGenerics, V>;
+  /** Call this function to keep message list scrolled to the bottom when the scroll height increases, e.g. an element appears below the last message (only used in the `VirtualizedMessageList`) */
+  autoscrollToBottom?: () => void;
   /** If true, picking a reaction from the `ReactionSelector` component will close the selector */
   closeReactionSelectorOnClick?: boolean;
   /** Object containing custom message actions and function handlers */

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -314,6 +314,7 @@ const VirtualizedMessageListWithContext = <
 
       return (
         <Message
+          autoscrollToBottom={virtuoso.current?.autoscrollToBottom}
           closeReactionSelectorOnClick={closeReactionSelectorOnClick}
           customMessageActions={props.customMessageActions}
           endOfGroup={endOfGroup}

--- a/src/components/MessageList/__tests__/__snapshots__/VirtualizedMessageList.test.js.snap
+++ b/src/components/MessageList/__tests__/__snapshots__/VirtualizedMessageList.test.js.snap
@@ -21,7 +21,6 @@ exports[`VirtualizedMessageList should render the list without any message 1`] =
             "overflowX": "hidden",
             "overflowY": "auto",
             "position": "relative",
-            "willChange": "transform",
           }
         }
         tabIndex={0}

--- a/src/context/MessageContext.tsx
+++ b/src/context/MessageContext.tsx
@@ -80,6 +80,8 @@ export type MessageContextValue<
   showDetailedReactions: boolean;
   /** Additional props for underlying MessageInput component, [available props](https://getstream.io/chat/docs/sdk/react/message-input-components/message_input/#props) */
   additionalMessageInputProps?: MessageInputProps<StreamChatGenerics>;
+  /** Call this function to keep message list scrolled to the bottom when the scroll height increases, e.g. an element appears below the last message (only used in the `VirtualizedMessageList`) */
+  autoscrollToBottom?: () => void;
   /** Object containing custom message actions and function handlers */
   customMessageActions?: CustomMessageActions<StreamChatGenerics>;
   /** If true, the message is the last one in a group sent by a specific user (only used in the `VirtualizedMessageList`) */

--- a/yarn.lock
+++ b/yarn.lock
@@ -14423,10 +14423,10 @@ react-virtuoso@^2.10.2:
     "@virtuoso.dev/react-urx" "^0.2.12"
     "@virtuoso.dev/urx" "^0.2.12"
 
-react-virtuoso@^2.13.3:
-  version "2.13.3"
-  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.13.3.tgz#11f67d56a0f7e259bc9d92547f952b446b43b56a"
-  integrity sha512-K/mPeJcNvY0R24r1XcNTPV5bs7LujTjhbvysEhVxS6hjssY5OI+2HpY4e3cKEb/8BMGFwsQ/c/b6BLCcmprquw==
+react-virtuoso@^2.16.5:
+  version "2.16.5"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.16.5.tgz#807b79ed378b9aa5430d45a94034afef5ab5afab"
+  integrity sha512-bedbW1eJX/s0/XdDVxYZG1kLwXbLkpASskRQ4+UuvZ3mU0LWqDtjPsEzylXbOGhRaWeiuiG768BGl4zxQUBczg==
   dependencies:
     "@virtuoso.dev/react-urx" "^0.2.12"
     "@virtuoso.dev/urx" "^0.2.12"


### PR DESCRIPTION
### 🎯 Goal

Fixes #1678 
New function `autoscrollToBottom` scrolls to the bottom on message list container height change only if the container is scrolled 4px from the bottom. This is the default react-virtuoso behavior, that is not configurable at the moment.