### PR TITLE
fix: replace FileReader with URL.createObjectURL

### DIFF
--- a/src/components/MessageInput/hooks/useAttachments.ts
+++ b/src/components/MessageInput/hooks/useAttachments.ts
@@ -63,7 +63,13 @@ export const useAttachments = <
             file.type.startsWith('image/') &&
             !file.type.endsWith('.photoshop') // photoshop files begin with 'image/'
           ) {
-            dispatch({ file, id, state: 'uploading', type: 'setImageUpload' });
+            dispatch({
+              file,
+              id,
+              previewUri: URL.createObjectURL?.(file),
+              state: 'uploading',
+              type: 'setImageUpload',
+            });
           } else if (file instanceof File && !noFiles) {
             dispatch({ file, id, state: 'uploading', type: 'setFileUpload' });
           }

--- a/src/components/MessageInput/hooks/useImageUploads.ts
+++ b/src/components/MessageInput/hooks/useImageUploads.ts
@@ -97,8 +97,11 @@ export const useImageUploads = <
         return;
       }
 
+      if (img.previewUri) URL.revokeObjectURL?.(img.previewUri);
+
       dispatch({
         id,
+        previewUri: undefined,
         state: 'finished',
         type: 'setImageUpload',
         url: response.file,
@@ -108,32 +111,12 @@ export const useImageUploads = <
   );
 
   useEffect(() => {
-    if (FileReader) {
-      const upload = Object.values(imageUploads).find(
-        (imageUpload) =>
-          imageUpload.state === 'uploading' && !!imageUpload.file && !imageUpload.previewUri,
-      );
-      if (upload) {
-        const { file, id } = upload;
-        // TODO: Possibly use URL.createObjectURL instead. However, then we need
-        // to release the previews when not used anymore though.
-        const reader = new FileReader();
-        reader.onload = (event) => {
-          if (typeof event.target?.result !== 'string') return;
-          dispatch({
-            id,
-            previewUri: event.target.result,
-            type: 'setImageUpload',
-          });
-        };
-        reader.readAsDataURL((file as unknown) as Blob);
-        uploadImage(id);
-        return () => {
-          reader.onload = null;
-        };
-      }
-    }
-    return;
+    const upload = Object.values(imageUploads).find(
+      (imageUpload) => imageUpload.state === 'uploading' && imageUpload.file,
+    );
+    if (!upload) return;
+
+    uploadImage(upload.id);
   }, [imageUploads, uploadImage]);
 
   return {


### PR DESCRIPTION
### 🎯 Goal

Fix image upload behaviour where preview URI does not get generated while the image is being uploaded.

### 🛠 Implementation details

Replace `FileReader` API with `URL.createObjectURL`.

### 🎨 UI Changes
![image](https://user-images.githubusercontent.com/43254280/182717594-6e437548-b949-473d-9b4f-dfcde6ca5ffa.png)
