### PR TITLE
Theming v2 user testing  scroll to bottom buttom

### DIFF
--- a/src/components/Channel/__tests__/Channel.test.js
+++ b/src/components/Channel/__tests__/Channel.test.js
@@ -923,7 +923,7 @@ describe('Channel', () => {
           getFirstMessageAvatar: () => {
             // the first avatar is that of the ThreadHeader
             const avatars = screen.queryAllByTestId('custom-avatar') || [];
-            return avatars[1];
+            return avatars[0];
           },
           name: 'Thread',
         },

--- a/src/components/ChannelSearch/__tests__/SearchResults.test.js
+++ b/src/components/ChannelSearch/__tests__/SearchResults.test.js
@@ -6,38 +6,9 @@ import { SearchResults } from '../SearchResults';
 
 import { ChatProvider } from '../../../context/ChatContext';
 
-import {
-  generateChannel,
-  generateMember,
-  generateMessage,
-  generateUser,
-  getOrCreateChannelApi,
-  getTestClientWithUser,
-  useMockedApis,
-} from '../../../mock-builders';
+import { createClientWithChannel, generateChannel, generateUser } from '../../../mock-builders';
 
 const SEARCH_RESULT_LIST_SELECTOR = '.str-chat__channel-search-result-list';
-
-async function createClientWithChannel(empty = false) {
-  const user1 = generateUser();
-  const user2 = generateUser();
-  const mockedChannel = generateChannel({
-    data: { image: 'image-xxx', name: 'channel-xxx' },
-    members: [generateMember({ user: user1 }), generateMember({ user: user2 })],
-    messages: empty
-      ? []
-      : ' '
-          .repeat(20)
-          .split(' ')
-          .map((v, i) => generateMessage({ user: i % 3 ? user1 : user2 })),
-  });
-  const client = await getTestClientWithUser({ id: 'id' });
-  useMockedApis(client, [getOrCreateChannelApi(mockedChannel)]); // eslint-disable-line react-hooks/rules-of-hooks
-  const channel = client.channel('messaging', mockedChannel.id);
-  await channel.watch();
-
-  return { channel, client };
-}
 
 const renderComponent = (props = {}, chatContext = { themeVersion: '2' }) =>
   render(

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -81,6 +81,7 @@ const MessageListWithContext = <
 
   const {
     hasNewMessages,
+    isMessageListScrolledToBottom,
     onMessageLoadCaptured,
     onScroll,
     scrollToBottom,
@@ -215,10 +216,12 @@ const MessageListWithContext = <
       {themeVersion === '2' && <TypingIndicator threadList={threadList} />}
       <MessageListNotifications
         hasNewMessages={hasNewMessages}
+        isMessageListScrolledToBottom={isMessageListScrolledToBottom}
         isNotAtLatestMessageSet={hasMoreNewer}
         MessageNotification={MessageNotification}
         notifications={notifications}
         scrollToBottom={scrollToBottomFromNotification}
+        threadList={threadList}
       />
     </>
   );
@@ -294,7 +297,7 @@ export type MessageListProps<
   /** The pixel threshold to determine whether or not the user is scrolled up in the list, defaults to 200px */
   scrolledUpThreshold?: number;
   /** If true, indicates the message list is a thread  */
-  threadList?: boolean;
+  threadList?: boolean; // todo: refactor needed - message list should have a state in which among others it would be optionally flagged as thread
 };
 
 /**

--- a/src/components/MessageList/MessageListNotifications.tsx
+++ b/src/components/MessageList/MessageListNotifications.tsx
@@ -11,19 +11,23 @@ import type { ChannelNotifications } from '../../context/ChannelStateContext';
 
 export type MessageListNotificationsProps = {
   hasNewMessages: boolean;
+  isMessageListScrolledToBottom: boolean;
   isNotAtLatestMessageSet: boolean;
   MessageNotification: React.ComponentType<MessageNotificationProps>;
   notifications: ChannelNotifications;
   scrollToBottom: () => void;
+  threadList?: boolean;
 };
 
 export const MessageListNotifications = (props: MessageListNotificationsProps) => {
   const {
     hasNewMessages,
+    isMessageListScrolledToBottom,
     isNotAtLatestMessageSet,
     MessageNotification,
     notifications,
     scrollToBottom,
+    threadList,
   } = props;
 
   const { t } = useTranslationContext('MessageListNotifications');
@@ -37,8 +41,10 @@ export const MessageListNotifications = (props: MessageListNotificationsProps) =
       ))}
       <ConnectionStatus />
       <MessageNotification
+        isMessageListScrolledToBottom={isMessageListScrolledToBottom}
         onClick={scrollToBottom}
         showNotification={hasNewMessages || isNotAtLatestMessageSet}
+        threadList={threadList}
       >
         {isNotAtLatestMessageSet ? t<string>('Latest Messages') : t<string>('New Messages!')}
       </MessageNotification>

--- a/src/components/MessageList/MessageNotification.tsx
+++ b/src/components/MessageList/MessageNotification.tsx
@@ -3,8 +3,12 @@ import React, { PropsWithChildren } from 'react';
 export type MessageNotificationProps = PropsWithChildren<{
   /** button click event handler */
   onClick: React.MouseEventHandler;
-  /** Whether or not to show notification */
-  showNotification: boolean;
+  /** signals whether the message list is considered (below a threshold) to be scrolled to the bottom. Prop used only by [ScrollToBottomButton](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageList/ScrollToBottomButton.tsx) */
+  isMessageListScrolledToBottom?: boolean;
+  /** Whether or not to show notification. Prop used only by [MessageNotification](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageList/MessageNotification.tsx)  */
+  showNotification?: boolean;
+  /** informs the component whether it is rendered inside a thread message list */
+  threadList?: boolean;
 }>;
 
 const UnMemoizedMessageNotification = (props: MessageNotificationProps) => {

--- a/src/components/MessageList/ScrollToBottomButton.tsx
+++ b/src/components/MessageList/ScrollToBottomButton.tsx
@@ -1,11 +1,66 @@
-import React from 'react';
-import type { MessageNotificationProps } from './MessageNotification';
+import React, { useEffect, useState } from 'react';
+import clsx from 'clsx';
+
 import { ArrowDown } from './icons';
 
-const UnMemoizedScrollToBottomButton = (props: Omit<MessageNotificationProps, 'children'>) => {
-  const { onClick, showNotification = true } = props;
+import { useChannelStateContext, useChatContext } from '../../context';
 
-  if (!showNotification) return null;
+import type { Event } from 'stream-chat';
+import type { MessageNotificationProps } from './MessageNotification';
+
+const UnMemoizedScrollToBottomButton = (
+  props: Pick<MessageNotificationProps, 'isMessageListScrolledToBottom' | 'onClick' | 'threadList'>,
+) => {
+  const { isMessageListScrolledToBottom, onClick, threadList } = props;
+
+  const { channel: activeChannel, client } = useChatContext();
+  const { thread } = useChannelStateContext();
+  const [countUnread, setCountUnread] = useState(activeChannel?.countUnread() || 0);
+  const [replyCount, setReplyCount] = useState(thread?.reply_count || 0);
+  const observedEvent = threadList ? 'message.updated' : 'message.new';
+
+  useEffect(() => {
+    const handleEvent = (event: Event) => {
+      const newMessageInAnotherChannel = event.cid !== activeChannel?.cid;
+      const newMessageIsMine = event.user?.id === client.user?.id;
+
+      const isThreadOpen = !!thread;
+      const newMessageIsReply = !!event.message?.parent_id;
+      const dontIncreaseMainListCounterOnNewReply =
+        isThreadOpen && !threadList && newMessageIsReply;
+
+      if (
+        isMessageListScrolledToBottom ||
+        newMessageInAnotherChannel ||
+        newMessageIsMine ||
+        dontIncreaseMainListCounterOnNewReply
+      ) {
+        return;
+      }
+
+      if (event.type === 'message.new') {
+        // cannot rely on channel.countUnread because active channel is automatically marked read
+        setCountUnread((prev) => prev + 1);
+      } else if (event.message?.id === thread?.id) {
+        const newReplyCount = event.message?.reply_count || 0;
+        setCountUnread(() => newReplyCount - replyCount);
+      }
+    };
+    client.on(observedEvent, handleEvent);
+
+    return () => {
+      client.off(observedEvent, handleEvent);
+    };
+  }, [activeChannel, isMessageListScrolledToBottom, replyCount, thread]);
+
+  useEffect(() => {
+    if (isMessageListScrolledToBottom) {
+      setCountUnread(0);
+      setReplyCount(thread?.reply_count || 0);
+    }
+  }, [isMessageListScrolledToBottom, thread]);
+
+  if (isMessageListScrolledToBottom) return null;
 
   return (
     <div className='str-chat__jump-to-latest-message'>
@@ -20,6 +75,18 @@ const UnMemoizedScrollToBottomButton = (props: Omit<MessageNotificationProps, 'c
         onClick={onClick}
       >
         <ArrowDown />
+        {countUnread > 0 && (
+          <div
+            className={clsx(
+              'str-chat__message-notification',
+              'str-chat__message-notification-scroll-to-latest-unread-count',
+              'str-chat__jump-to-latest-unread-count',
+            )}
+            data-testid={'unread-message-notification-counter'}
+          >
+            {countUnread}
+          </div>
+        )}
       </button>
     </div>
   );

--- a/src/components/MessageList/ScrollToBottomButton.tsx
+++ b/src/components/MessageList/ScrollToBottomButton.tsx
@@ -51,7 +51,7 @@ const UnMemoizedScrollToBottomButton = (
     return () => {
       client.off(observedEvent, handleEvent);
     };
-  }, [activeChannel, isMessageListScrolledToBottom, replyCount, thread]);
+  }, [activeChannel, isMessageListScrolledToBottom, observedEvent, replyCount, thread]);
 
   useEffect(() => {
     if (isMessageListScrolledToBottom) {

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -195,7 +195,9 @@ const VirtualizedMessageListWithContext = <
 
   const {
     atBottom,
+    isMessageListScrolledToBottom,
     newMessagesNotification,
+    setIsMessageListScrolledToBottom,
     setNewMessagesNotification,
   } = useNewMessageNotification(processedMessages, client.userID, hasMoreNewer);
 
@@ -375,6 +377,7 @@ const VirtualizedMessageListWithContext = <
 
   const atBottomStateChange = (isAtBottom: boolean) => {
     atBottom.current = isAtBottom;
+    setIsMessageListScrolledToBottom(isAtBottom);
     if (isAtBottom && newMessagesNotification) {
       setNewMessagesNotification(false);
     }
@@ -408,6 +411,7 @@ const VirtualizedMessageListWithContext = <
       <div className={customClasses?.virtualizedMessageList || 'str-chat__virtual-list'}>
         <Virtuoso
           atBottomStateChange={atBottomStateChange}
+          atBottomThreshold={50}
           components={virtuosoComponents}
           computeItemKey={(index) =>
             processedMessages[numItemsPrepended + index - PREPEND_OFFSET].id
@@ -436,10 +440,12 @@ const VirtualizedMessageListWithContext = <
       {themeVersion === '2' && TypingIndicator && <TypingIndicator threadList={threadList} />}
       <MessageListNotifications
         hasNewMessages={newMessagesNotification}
+        isMessageListScrolledToBottom={isMessageListScrolledToBottom}
         isNotAtLatestMessageSet={hasMoreNewer}
         MessageNotification={MessageNotification}
         notifications={notifications}
         scrollToBottom={scrollToBottom}
+        threadList={threadList}
       />
       {giphyPreviewMessage && <GiphyPreviewMessage message={giphyPreviewMessage} />}
     </>

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -411,7 +411,7 @@ const VirtualizedMessageListWithContext = <
       <div className={customClasses?.virtualizedMessageList || 'str-chat__virtual-list'}>
         <Virtuoso
           atBottomStateChange={atBottomStateChange}
-          atBottomThreshold={50}
+          atBottomThreshold={200}
           components={virtuosoComponents}
           computeItemKey={(index) =>
             processedMessages[numItemsPrepended + index - PREPEND_OFFSET].id

--- a/src/components/MessageList/__tests__/ScrollToBottomButton.test.js
+++ b/src/components/MessageList/__tests__/ScrollToBottomButton.test.js
@@ -1,0 +1,301 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { ScrollToBottomButton } from '../ScrollToBottomButton';
+import { ChannelStateProvider, ChatProvider } from '../../../context';
+import {
+  createClientWithChannel,
+  dispatchMessageNewEvent,
+  dispatchMessageUpdatedEvent,
+  generateMessage,
+} from '../../../mock-builders';
+
+const BUTTON_TEST_ID = 'message-notification';
+const NEW_MESSAGE_COUNTER_TEST_ID = 'unread-message-notification-counter';
+
+const mainList = 'the main message list';
+const threadList = 'a thread';
+
+let client;
+let channel;
+let users;
+let containerIsThread;
+let anotherUser;
+let channelStateContext;
+let parentMsg;
+
+const onClick = jest.fn();
+
+const dispatchMessageEvents = ({ channel, client, newMessage, parentMsg, user }) => {
+  if (containerIsThread) {
+    dispatchMessageUpdatedEvent(
+      client,
+      { ...parentMsg, reply_count: parentMsg.reply_count + 1 },
+      channel,
+      user,
+    );
+  }
+  dispatchMessageNewEvent(client, newMessage, channel);
+};
+
+describe.each([
+  [mainList, threadList],
+  [threadList, mainList],
+])('ScrollToBottomButton in %s', (containerMsgList, otherMsgList) => {
+  beforeEach(async () => {
+    const result = await createClientWithChannel();
+    client = result.client;
+    channel = result.channel;
+    users = result.users;
+    containerIsThread = containerMsgList === threadList;
+    anotherUser = Object.values(channel.state.members).find((u) => u.id !== client.user.id);
+    parentMsg = { ...Object.values(channel.state.messages)[0], reply_count: 0 };
+    channelStateContext = {
+      thread: containerIsThread ? parentMsg : null,
+    };
+  });
+
+  afterEach(jest.clearAllMocks);
+
+  it(`is not rendered if ${containerMsgList} scrolled to the bottom`, () => {
+    const { container } = render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('is rendered if scrolled above the threshold', () => {
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+    expect(screen.queryByTestId(BUTTON_TEST_ID)).toBeInTheDocument();
+  });
+  it('calls the onclick callback', async () => {
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      fireEvent.click(screen.queryByTestId(BUTTON_TEST_ID));
+    });
+
+    await waitFor(() => {
+      // eslint-disable-next-line jest/prefer-called-with
+      expect(onClick).toHaveBeenCalled();
+    });
+  });
+
+  it('does not increase the unread count if already scrolled at the bottom', async () => {
+    const newMessage = generateMessage({ user: anotherUser });
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      dispatchMessageEvents({
+        channel,
+        client,
+        newMessage,
+        parentMsg,
+        user: anotherUser,
+      });
+    });
+
+    await waitFor(() => {
+      const counter = screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID);
+      expect(counter).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows the count unread if new message arrives to active channel from another user', async () => {
+    const newMessage = generateMessage({ user: anotherUser });
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      dispatchMessageEvents({
+        channel,
+        client,
+        newMessage,
+        parentMsg,
+        user: anotherUser,
+      });
+    });
+
+    await waitFor(() => {
+      const counter = screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID);
+      expect(counter).toBeInTheDocument();
+      expect(counter).toHaveTextContent('1');
+    });
+  });
+
+  it('does not show unread count for own arriving messages', async () => {
+    const newMessage = generateMessage({ user: client.user });
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      dispatchMessageEvents({
+        channel,
+        client,
+        newMessage,
+        parentMsg,
+        user: client.user,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID)).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show unread count for messages from others arriving to non-active channel', async () => {
+    const newMessage = generateMessage({ user: anotherUser });
+    const { channel: nonActiveChannel } = await createClientWithChannel({
+      existingClient: client,
+      existingUsers: users,
+    });
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      dispatchMessageEvents({
+        channel: nonActiveChannel,
+        client,
+        newMessage,
+        parentMsg,
+        user: anotherUser,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID)).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show unread count for messages arriving from me to non-active channel', async () => {
+    const newMessage = generateMessage({ user: client.user });
+    const { channel: nonActiveChannel } = await createClientWithChannel({
+      existingClient: client,
+      existingUsers: users,
+    });
+
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      dispatchMessageEvents({
+        channel: nonActiveChannel,
+        client,
+        newMessage,
+        parentMsg,
+        user: client.user,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID)).not.toBeInTheDocument();
+    });
+  });
+
+  it('increases the count unread with each new message arrival', async () => {
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    for (let i = 1; i <= 2; i++) {
+      const newMessage = generateMessage({ user: anotherUser });
+      await act(() => {
+        dispatchMessageEvents({ channel, client, newMessage, parentMsg, user: anotherUser });
+      });
+      const counter = screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID);
+      await waitFor(() => {
+        expect(counter).toHaveTextContent(i.toString());
+      });
+    }
+  });
+
+  it(`does not show the count unread of ${containerMsgList} in ${otherMsgList}`, async () => {
+    const [mainListId, threadListId] = ['main-msg-list', 'thread-msg-list'];
+    const [mainListCounterSelector, threadListCounterSelector] = [
+      `#${mainListId} [data-testid="${NEW_MESSAGE_COUNTER_TEST_ID}"]`,
+      `#${threadListId} [data-testid="${NEW_MESSAGE_COUNTER_TEST_ID}"]`,
+    ];
+
+    const messagePayload = containerIsThread
+      ? { parent_id: parentMsg.id, user: anotherUser }
+      : { user: anotherUser };
+    const newMessage = generateMessage(messagePayload);
+
+    const { container } = render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <div id={mainListId}>
+            <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+          </div>
+          <div id={threadListId}>
+            <ScrollToBottomButton
+              isMessageListScrolledToBottom={false}
+              onClick={onClick}
+              threadList
+            />
+          </div>
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      dispatchMessageEvents({ channel, client, newMessage, parentMsg, user: anotherUser });
+    });
+
+    const [containerMsgListCounterSelector, otherMsgListCounterSelector] = containerIsThread
+      ? [threadListCounterSelector, mainListCounterSelector]
+      : [mainListCounterSelector, threadListCounterSelector];
+
+    await waitFor(() => {
+      expect(container.querySelector(containerMsgListCounterSelector)).toBeInTheDocument();
+      expect(container.querySelector(otherMsgListCounterSelector)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/MessageList/hooks/useNewMessageNotification.ts
+++ b/src/components/MessageList/hooks/useNewMessageNotification.ts
@@ -12,6 +12,7 @@ export function useNewMessageNotification<
   hasMoreNewer?: boolean,
 ) {
   const [newMessagesNotification, setNewMessagesNotification] = useState(false);
+  const [isMessageListScrolledToBottom, setIsMessageListScrolledToBottom] = useState(true);
   /**
    * use the flag to avoid the initial "new messages" quick blink
    */
@@ -46,5 +47,11 @@ export function useNewMessageNotification<
     didMount.current = true;
   }, [currentUserId, messages, hasMoreNewer]);
 
-  return { atBottom, newMessagesNotification, setNewMessagesNotification };
+  return {
+    atBottom,
+    isMessageListScrolledToBottom,
+    newMessagesNotification,
+    setIsMessageListScrolledToBottom,
+    setNewMessagesNotification,
+  };
 }

--- a/src/components/MessageList/hooks/useScrollLocationLogic.tsx
+++ b/src/components/MessageList/hooks/useScrollLocationLogic.tsx
@@ -29,7 +29,7 @@ export const useScrollLocationLogic = <
 ) => {
   const {
     messages = [],
-    scrolledUpThreshold = 200,
+    scrolledUpThreshold = 50,
     hasMoreNewer,
     suppressAutoscroll,
     listElement,
@@ -39,6 +39,7 @@ export const useScrollLocationLogic = <
   const [hasNewMessages, setHasNewMessages] = useState(false);
   const [wrapperRect, setWrapperRect] = useState<DOMRect>();
 
+  const [isMessageListScrolledToBottom, setIsMessageListScrolledToBottom] = useState(true);
   const closeToBottom = useRef(false);
   const closeToTop = useRef(false);
   const scrollCounter = useRef({ autoScroll: 0, scroll: 0 });
@@ -123,11 +124,17 @@ export const useScrollLocationLogic = <
       const offsetHeight = element.offsetHeight;
       const scrollHeight = element.scrollHeight;
 
+      const prevCloseToBottom = closeToBottom.current;
       closeToBottom.current = scrollHeight - (scrollTop + offsetHeight) < scrolledUpThreshold;
       closeToTop.current = scrollTop < scrolledUpThreshold;
 
       if (closeToBottom.current) {
         setHasNewMessages(false);
+      }
+      if (prevCloseToBottom && !closeToBottom.current) {
+        setIsMessageListScrolledToBottom(false);
+      } else if (!prevCloseToBottom && closeToBottom.current) {
+        setIsMessageListScrolledToBottom(true);
       }
     },
     [updateScrollTop, closeToTop, closeToBottom, scrolledUpThreshold],
@@ -145,6 +152,7 @@ export const useScrollLocationLogic = <
 
   return {
     hasNewMessages,
+    isMessageListScrolledToBottom,
     onMessageLoadCaptured,
     onScroll,
     scrollToBottom,

--- a/src/components/MessageList/hooks/useScrollLocationLogic.tsx
+++ b/src/components/MessageList/hooks/useScrollLocationLogic.tsx
@@ -29,7 +29,7 @@ export const useScrollLocationLogic = <
 ) => {
   const {
     messages = [],
-    scrolledUpThreshold = 50,
+    scrolledUpThreshold = 200,
     hasMoreNewer,
     suppressAutoscroll,
     listElement,

--- a/src/mock-builders/event/messageNew.js
+++ b/src/mock-builders/event/messageNew.js
@@ -4,5 +4,6 @@ export default (client, newMessage, channel = {}) => {
     cid: channel.cid,
     message: newMessage,
     type: 'message.new',
+    user: newMessage.user,
   });
 };

--- a/src/mock-builders/event/messageUpdated.js
+++ b/src/mock-builders/event/messageUpdated.js
@@ -1,8 +1,12 @@
-export default (client, newMessage, channel = {}) => {
+export default (client, newMessage, channel = {}, user) => {
+  const [channel_id, channel_type] = channel.cid.split(':');
   client.dispatchEvent({
     channel,
+    channel_id,
+    channel_type,
     cid: channel.cid,
     message: newMessage,
     type: 'message.updated',
+    user: user || newMessage.user,
   });
 };

--- a/src/mock-builders/index.js
+++ b/src/mock-builders/index.js
@@ -49,3 +49,4 @@ export * from './api';
 export * from './event';
 export * from './generator';
 export * from './translator';
+export * from './utils';

--- a/src/mock-builders/utils.js
+++ b/src/mock-builders/utils.js
@@ -1,0 +1,33 @@
+import { generateChannel, generateMember, generateMessage, generateUser } from './generator';
+import { getOrCreateChannelApi, getTestClientWithUser, useMockedApis } from './index';
+
+export async function createClientWithChannel(
+  { channelData, empty, existingClient, existingUsers, memberCount, messageCount } = {
+    channelData: { image: 'image-xxx', name: 'channel-xxx' },
+    empty: false,
+    existingClient: null,
+    existingUsers: null,
+    memberCount: 2,
+    messageCount: 20,
+  },
+) {
+  const users = existingUsers || Array.from({ length: memberCount }, generateUser);
+  const members = users.map((user) => generateMember({ user }));
+  const mockedChannel = generateChannel({
+    data: channelData,
+    members,
+    messages: empty
+      ? []
+      : ' '
+          .repeat(messageCount)
+          .split(' ')
+          .map((v, i) => generateMessage({ user: users[i % memberCount] })),
+  });
+
+  const client = existingClient || (await getTestClientWithUser({ id: users[0].id }));
+  useMockedApis(client, [getOrCreateChannelApi(mockedChannel)]); // eslint-disable-line react-hooks/rules-of-hooks
+  const channel = client.channel('messaging', mockedChannel.id);
+  await channel.watch();
+
+  return { channel, client, users };
+}


### PR DESCRIPTION
### 🎯 Goal

Add missing logic to the `ScrollToBottomButton` component:

- show the component on scroll above a threshold, where the message list is not considered to be scrolled to the bottom. Show it even no new messages have arrived.
- show the counter of unread messages that is independent between the main message list and the thread message list

### 🛠 Implementation details

The calculation of unread messages differs depending on the button's location context. 

#### Button rendered in the main message list

The unread counter is increased by 1 upon arrival of each `message.new` event.

#### Button rendered in the thread message list

The unread count is calculated as a difference between the `event.message.reply_count` and the last stored reply count value.

In the both contexts the counter is reset upon scrolling bellow the threshold that signals the container is scrolled to the bottom.

The component does not increase the unread counter if:
1. own new message arrived
2. new message arrived to a channel., that is currently not rendered
3. the message list container is scrolled to the bottom (below the threshold)
4. the reply arrived but the component is rendered in main message list and vice versa


### 🎨 UI Changes

[demo_scroll-to-bottom-button.webm](https://user-images.githubusercontent.com/32706194/183953865-917f19fd-9926-4223-9b77-3e2e79de31e7.webm)

