### PR TITLE
Theming v2 user testing - card image enlargement

### DIFF
--- a/src/components/Attachment/Card.tsx
+++ b/src/components/Attachment/Card.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import ReactPlayer from 'react-player';
 
 import { AudioProps, PlayButton, ProgressBar } from './Audio';
+import { ImageComponent } from '../Gallery';
 import { SafeAnchor } from '../SafeAnchor';
 import { useAudioController } from './hooks/useAudioController';
 
@@ -12,6 +13,7 @@ import { useTranslationContext } from '../../context/TranslationContext';
 
 import type { Attachment } from 'stream-chat';
 import type { RenderAttachmentProps } from './utils';
+import type { Dimensions } from '../../types/types';
 
 const getHostFromURL = (url?: string | null) => {
   if (url !== undefined && url !== null) {
@@ -39,8 +41,6 @@ const UnableToRenderCard = ({ type }: { type?: CardProps['type'] }) => {
     </div>
   );
 };
-
-type Dimensions = { height?: string; width?: string };
 
 interface CardV1Props {
   giphy?: Attachment['giphy'];
@@ -122,13 +122,16 @@ const SourceLink = ({ author_name, url }: Pick<CardProps, 'author_name'> & { url
   </div>
 );
 
-type CardHeaderProps = Pick<CardProps, 'asset_url' | 'title' | 'type'> & {
+type CardHeaderProps = Pick<
+  CardProps,
+  'asset_url' | 'title' | 'type' | 'image_url' | 'thumb_url'
+> & {
   dimensions: Dimensions;
   image?: string;
 };
 
 const CardHeader = (props: CardHeaderProps) => {
-  const { asset_url, dimensions, image, title, type } = props;
+  const { asset_url, dimensions, image, image_url, thumb_url, title, type } = props;
 
   let visual = null;
   if (asset_url && type === 'video') {
@@ -136,11 +139,21 @@ const CardHeader = (props: CardHeaderProps) => {
       <ReactPlayer className='react-player' controls height='100%' url={asset_url} width='100%' />
     );
   } else if (image) {
-    visual = <img alt={title || image} src={image} {...dimensions} />;
+    visual = (
+      <ImageComponent
+        dimensions={dimensions}
+        fallback={title || image}
+        image_url={image_url}
+        thumb_url={thumb_url}
+      />
+    );
   }
 
   return visual ? (
-    <div className='str-chat__message-attachment-card--header' data-testid={'card-header'}>
+    <div
+      className='str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header'
+      data-testid={'card-header'}
+    >
       {visual}
     </div>
   ) : null;

--- a/src/components/Attachment/__tests__/Card.test.js
+++ b/src/components/Attachment/__tests__/Card.test.js
@@ -6,6 +6,7 @@ import { Card } from '../Card';
 
 import { ChannelStateProvider } from '../../../context/ChannelStateContext';
 import { ChatProvider } from '../../../context/ChatContext';
+import { ComponentProvider } from '../../../context/ComponentContext';
 
 import {
   generateChannel,
@@ -31,7 +32,9 @@ const renderCard = ({ cardProps, chatContext, theRenderer = render }) =>
   theRenderer(
     <ChatProvider value={{ themeVersion: '1', ...chatContext }}>
       <ChannelStateProvider value={{}}>
-        <Card {...cardProps} />
+        <ComponentProvider value={{}}>
+          <Card {...cardProps} />
+        </ComponentProvider>
       </ChannelStateProvider>
     </ChatProvider>,
   );

--- a/src/components/Attachment/__tests__/__snapshots__/Card.test.js.snap
+++ b/src/components/Attachment/__tests__/__snapshots__/Card.test.js.snap
@@ -6,12 +6,15 @@ exports[`Card theme V2 (1) should render card without caption if attachment type
     class="str-chat__message-attachment-card str-chat__message-attachment-card--audio"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_title"
-        src="dummyAttachment_thumb_url"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
+        src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -88,7 +91,7 @@ exports[`Card theme V2 (2) should render card without caption if attachment type
     class="str-chat__message-attachment-card str-chat__message-attachment-card--video"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <div
@@ -124,12 +127,15 @@ exports[`Card theme V2 (3) should render card without caption if attachment type
     class="str-chat__message-attachment-card str-chat__message-attachment-card--image"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_title"
-        src="dummyAttachment_thumb_url"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
+        src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -214,12 +220,15 @@ exports[`Card theme V2 (7) should render audio with caption using og_scrape_url 
     class="str-chat__message-attachment-card str-chat__message-attachment-card--audio"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_title"
-        src="dummyAttachment_thumb_url"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
+        src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -310,7 +319,7 @@ exports[`Card theme V2 (8) should render video with caption using og_scrape_url 
     class="str-chat__message-attachment-card str-chat__message-attachment-card--video"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <div
@@ -367,12 +376,15 @@ exports[`Card theme V2 (9) should render image with caption using og_scrape_url 
     class="str-chat__message-attachment-card str-chat__message-attachment-card--image"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_title"
-        src="dummyAttachment_thumb_url"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
+        src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -417,12 +429,15 @@ exports[`Card theme V2 (10) should render audio without title if attachment type
     class="str-chat__message-attachment-card str-chat__message-attachment-card--audio"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_thumb_url"
-        src="dummyAttachment_thumb_url"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
+        src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -508,7 +523,7 @@ exports[`Card theme V2 (11) should render video without title if attachment type
     class="str-chat__message-attachment-card str-chat__message-attachment-card--video"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <div
@@ -560,12 +575,15 @@ exports[`Card theme V2 (12) should render image without title if attachment type
     class="str-chat__message-attachment-card str-chat__message-attachment-card--image"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_thumb_url"
-        src="dummyAttachment_thumb_url"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
+        src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -605,12 +623,15 @@ exports[`Card theme V2 (13) should render audio without title and with caption u
     class="str-chat__message-attachment-card str-chat__message-attachment-card--audio"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_thumb_url"
-        src="dummyAttachment_thumb_url"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
+        src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -696,7 +717,7 @@ exports[`Card theme V2 (14) should render video without title and with caption u
     class="str-chat__message-attachment-card str-chat__message-attachment-card--video"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <div
@@ -748,12 +769,15 @@ exports[`Card theme V2 (15) should render image without title and with caption u
     class="str-chat__message-attachment-card str-chat__message-attachment-card--image"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_thumb_url"
-        src="dummyAttachment_thumb_url"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
+        src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -880,7 +904,7 @@ exports[`Card theme V2 (17) should render video widget in header and title & tex
     class="str-chat__message-attachment-card str-chat__message-attachment-card--video"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <div
@@ -978,12 +1002,15 @@ exports[`Card theme V2 (19) should render image loaded from thumb_url not audio 
     class="str-chat__message-attachment-card str-chat__message-attachment-card--audio"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_title"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
         src="dummyAttachment_thumb_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -1033,12 +1060,15 @@ exports[`Card theme V2 (20) should render image loaded from thumb_url not video 
     class="str-chat__message-attachment-card str-chat__message-attachment-card--video"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_title"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
         src="dummyAttachment_thumb_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -1083,12 +1113,15 @@ exports[`Card theme V2 (21) should render image loaded from thumb_url if attachm
     class="str-chat__message-attachment-card str-chat__message-attachment-card--image"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_title"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
         src="dummyAttachment_thumb_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -1133,12 +1166,15 @@ exports[`Card theme V2 (22) should render image loaded from image_url not audio 
     class="str-chat__message-attachment-card str-chat__message-attachment-card--audio"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_title"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
         src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -1188,12 +1224,15 @@ exports[`Card theme V2 (23) should render image loaded from image_url not video 
     class="str-chat__message-attachment-card str-chat__message-attachment-card--video"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_title"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
         src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -1238,12 +1277,15 @@ exports[`Card theme V2 (24) should render image loaded from image_url if attachm
     class="str-chat__message-attachment-card str-chat__message-attachment-card--image"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_title"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
         src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -1288,12 +1330,15 @@ exports[`Card theme V2 (25) should render audio widget with image loaded from th
     class="str-chat__message-attachment-card str-chat__message-attachment-card--audio"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <img
         alt="dummyAttachment_title"
-        src="dummyAttachment_thumb_url"
+        class="str-chat__message-attachment--img"
+        data-testid="image-test"
+        src="dummyAttachment_image_url"
+        tabindex="0"
       />
     </div>
     <div
@@ -1384,7 +1429,7 @@ exports[`Card theme V2 (26) should render video widget in header and title & tex
     class="str-chat__message-attachment-card str-chat__message-attachment-card--video"
   >
     <div
-      class="str-chat__message-attachment-card--header"
+      class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
       data-testid="card-header"
     >
       <div

--- a/src/components/Gallery/Image.tsx
+++ b/src/components/Gallery/Image.tsx
@@ -6,11 +6,11 @@ import { ModalGallery as DefaultModalGallery } from './ModalGallery';
 import { useComponentContext } from '../../context';
 
 import type { Attachment } from 'stream-chat';
-import type { DefaultStreamChatGenerics } from '../../types/types';
+import type { DefaultStreamChatGenerics, Dimensions } from '../../types/types';
 
 export type ImageProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
-> =
+> = { dimensions?: Dimensions } & (
   | {
       /** The text fallback for the image */
       fallback?: string;
@@ -19,7 +19,8 @@ export type ImageProps<
       /** The thumb url */
       thumb_url?: string;
     }
-  | Attachment<StreamChatGenerics>;
+  | Attachment<StreamChatGenerics>
+);
 
 /**
  * A simple component that displays an image.
@@ -29,7 +30,7 @@ export const ImageComponent = <
 >(
   props: ImageProps<StreamChatGenerics>,
 ) => {
-  const { fallback, image_url, thumb_url } = props;
+  const { dimensions = {}, fallback, image_url, thumb_url } = props;
 
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const { ModalGallery = DefaultModalGallery } = useComponentContext('ImageComponent');
@@ -47,6 +48,7 @@ export const ImageComponent = <
         onClick={toggleModal}
         src={imageSrc}
         tabIndex={0}
+        {...dimensions}
       />
       <Modal onClose={toggleModal} open={modalIsOpen}>
         <ModalGallery images={[props]} index={0} />

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -98,3 +98,5 @@ export type PaginatorProps = {
 export interface IconProps {
   className?: string;
 }
+
+export type Dimensions = { height?: string; width?: string };


### PR DESCRIPTION
### 🎯 Goal

Allow to view the whole attachment image if rendered in the `Card` attachment. This aligns the image display behavior. Also, this solves the problem of not being able to see the whole og image if the images does not match the ration 1:1.91.

### 🛠 Implementation details

The `Image` component was reused for rendering images in `Card`. This component conditionally renders modal with the displayed image.

### 🎨 UI Changes

![image](https://user-images.githubusercontent.com/32706194/184613951-5afad352-7222-4c78-bf6d-61a8691484dd.png)

![image](https://user-images.githubusercontent.com/32706194/184613917-10f287c4-d4a7-4764-898a-a178a1662104.png)

