### PR TITLE
feat: increase and support overriding jump to message limit

### DIFF
--- a/e2e/jump-to-message.test.ts
+++ b/e2e/jump-to-message.test.ts
@@ -40,7 +40,7 @@ suiteArray.forEach(([mode, story]) => {
   });
 });
 
-test.describe('jump to messsage - dataset', () => {
+test.describe('jump to message - dataset', () => {
   test('only the current message set is loaded', async ({ controller, page, user }) => {
     await controller.openStory(
       'jump-to-message--jump-in-regular-message-list',
@@ -52,6 +52,6 @@ test.describe('jump to messsage - dataset', () => {
       page.click(controlsButtonSelector),
     ]);
 
-    await user.sees(MessageList).hasLength(26);
+    await user.sees(MessageList).hasLength(100 + 1);
   });
 });

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
     "react-dom": "^18.0.0 || ^17.0.0 || ^16.8.0",
-    "stream-chat": "^6.7.3"
+    "stream-chat": "^6.9.0"
   },
   "files": [
     "dist",
@@ -167,7 +167,7 @@
     "rollup-plugin-visualizer": "^4.2.0",
     "semantic-release": "^19.0.2",
     "semantic-release-cli": "^5.4.4",
-    "stream-chat": "^6.7.3",
+    "stream-chat": "^6.9.0",
     "style-loader": "^2.0.0",
     "ts-jest": "^26.5.1",
     "tslib": "2.3.0",

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -190,8 +190,6 @@ export type ChannelProps<
   VirtualMessage?: ComponentContextValue<StreamChatGenerics>['VirtualMessage'];
 };
 
-const JUMP_MESSAGE_PAGE_SIZE = 25;
-
 const UnMemoizedChannel = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
   V extends CustomTrigger = CustomTrigger
@@ -526,16 +524,16 @@ const ChannelInner = <
     return queryResponse.messages.length;
   };
 
-  const jumpToMessage = async (messageId: string) => {
+  const jumpToMessage = async (messageId: string, messageLimit = 100) => {
     dispatch({ loadingMore: true, type: 'setLoadingMore' });
-    await channel.state.loadMessageIntoState(messageId);
+    await channel.state.loadMessageIntoState(messageId, undefined, messageLimit);
 
     /**
      * if the message we are jumping to has less than half of the page size older messages,
      * we have jumped to the beginning of the channel.
      */
     const indexOfMessage = channel.state.messages.findIndex((message) => message.id === messageId);
-    const hasMoreMessages = indexOfMessage >= Math.floor(JUMP_MESSAGE_PAGE_SIZE / 2);
+    const hasMoreMessages = indexOfMessage >= Math.floor(messageLimit / 2);
 
     loadMoreFinished(hasMoreMessages, channel.state.messages);
     dispatch({

--- a/src/context/ChannelActionContext.tsx
+++ b/src/context/ChannelActionContext.tsx
@@ -49,7 +49,7 @@ export type ChannelActionContextValue<
     message: UpdatedMessage<StreamChatGenerics>,
   ) => Promise<UpdateMessageAPIResponse<StreamChatGenerics> | void>;
   jumpToLatestMessage: () => Promise<void>;
-  jumpToMessage: (messageId: string) => Promise<void>;
+  jumpToMessage: (messageId: string, limit?: number) => Promise<void>;
   loadMore: (limit?: number) => Promise<number>;
   loadMoreNewer: (limit?: number) => Promise<number>;
   loadMoreThread: () => Promise<void>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3207,7 +3207,7 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
-"@types/mdast@^3.0.0", "@types/mdast@^3.0.3", "@types/mdast@^3.0.10":
+"@types/mdast@^3.0.0", "@types/mdast@^3.0.10", "@types/mdast@^3.0.3":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
   integrity sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==
@@ -16050,10 +16050,10 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-chat@^6.7.3:
-  version "6.7.3"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-6.7.3.tgz#5d3a0f1678c5bcac6241e15882230bf71b56d06d"
-  integrity sha512-O2gBocLG4rgAMOHq4PlXDkexfgkXFp1ZEGF+W3lllFXBC2/e52KbbojQNMhyoQPv82n2JQCGpkychUP4jdpn9Q==
+stream-chat@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-6.9.0.tgz#cc5c8e68849b36a891178b6b39cd150fc8a69ddf"
+  integrity sha512-GERt6ohbMucs1mOFY6xoU3p9gl0oEQieod09hSiaRnHG++LP//SQafYlSyE9v2n368VQcc6OSiP5tAinBWafJw==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "^8.5.6"


### PR DESCRIPTION
### 🎯 Goal

The default limit of 25 can be too small for tall screens (or short items), causing additional queryChannel request and potential scroll glitches.

### 🛠 Implementation details

Introduce an additional parameter for jumpToMessage, defaulting it to 100 (default value for pagination).

### 🎨 UI Changes
