### PR TITLE
fix: prevent double submissions in korean

### DIFF
--- a/src/components/AutoCompleteTextarea/Textarea.jsx
+++ b/src/components/AutoCompleteTextarea/Textarea.jsx
@@ -85,7 +85,15 @@ export class ReactTextareaAutocomplete extends React.Component {
     return this.textareaRef.selectionEnd;
   };
 
-  _defaultShouldSubmit = (event) => event.key === 'Enter' && !event.shiftKey;
+  /**
+   * isComposing prevents double submissions in Korean and other languages.
+   * starting point for a read:
+   * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing
+   * In the long term, the fix should happen by handling keypress, but changing this has unknown implications.
+   * @param event React.KeyboardEvent
+   */
+  _defaultShouldSubmit = (event) =>
+    event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing;
 
   _handleKeyDown = (event) => {
     const { shouldSubmit = this._defaultShouldSubmit } = this.props;


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Hitting enter in Korean text mode entry submits twice. This PR fixes it.

### 🛠 Implementation details

I've patched this by ignoring compositing events (left links in the comments for reference). 
Long term, we should not handle keydown but keypress (considered a better practice). But I am not sure about the implications of such change. 

<img width="357" alt="image" src="https://user-images.githubusercontent.com/13347/185893851-cec8d3ea-4d71-4d34-b343-661e232ea86f.png">
