### PR TITLE
fix(Vite): add emoji-mart (emoji, picker) re-export

### DIFF
--- a/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -31,33 +31,6 @@ import {
 
 expect.extend(toHaveNoViolations);
 
-jest.mock('react', () => {
-  const React = jest.requireActual('react');
-  const Suspense = ({ children }) => children;
-
-  const lazy = jest.fn().mockImplementation((fn) => {
-    const Component = (props) => {
-      const [C, setC] = React.useState();
-
-      React.useEffect(() => {
-        fn().then((v) => {
-          setC(v);
-        });
-      }, []);
-
-      return C ? <C.default {...props} /> : null;
-    };
-
-    return Component;
-  });
-
-  return {
-    ...React,
-    lazy,
-    Suspense,
-  };
-});
-
 jest.mock('../../Channel/utils', () => ({ makeAddNotifications: jest.fn }));
 
 let chatClient;

--- a/src/context/DefaultEmoji.ts
+++ b/src/context/DefaultEmoji.ts
@@ -1,0 +1,4 @@
+// @ts-expect-error
+import NimbleEmoji from 'emoji-mart/dist/components/emoji/nimble-emoji';
+
+export { NimbleEmoji as default };

--- a/src/context/DefaultEmojiPicker.ts
+++ b/src/context/DefaultEmojiPicker.ts
@@ -1,0 +1,4 @@
+// @ts-expect-error
+import NimblePicker from 'emoji-mart/dist/components/picker/nimble-picker';
+
+export { NimblePicker as default };

--- a/src/context/EmojiContext.tsx
+++ b/src/context/EmojiContext.tsx
@@ -49,17 +49,9 @@ export type EmojiContextValue = {
   EmojiPicker?: React.ComponentType<NimblePickerProps>;
 };
 
-const DefaultEmoji = React.lazy(async () => {
-  //@ts-expect-error
-  const emoji = await import('emoji-mart/dist/components/emoji/nimble-emoji.js');
-  return { default: emoji.default };
-});
+const DefaultEmoji = React.lazy(() => import('./DefaultEmoji'));
 
-const DefaultEmojiPicker = React.lazy(async () => {
-  // @ts-expect-error
-  const emojiPicker = await import('emoji-mart/dist/components/picker/nimble-picker.js');
-  return { default: emojiPicker.default };
-});
+const DefaultEmojiPicker = React.lazy(() => import('./DefaultEmojiPicker'));
 
 export const EmojiContext = React.createContext<EmojiContextValue | undefined>(undefined);
 


### PR DESCRIPTION
### 🎯 Goal

Vite development mode is broken for the latest version of the SDK (when installed from the NPM) when using "custom" object (with `default` property) dynamic imports. I've re-exported the `emoji-mart` modules based on this comment of one [somewhat unrelated issue on GH](https://github.com/fuse-box/fuse-box/issues/1646#issuecomment-666468319) and that seems to fix the issue. ~Used [`/dist-es` instead of `/dist`](https://github.com/missive/emoji-mart/tree/v3.0.1#optimizing-for-production) which comes with the benefit of sligtly smaller bundle size.~

### 🛠 Implementation details

```ts
// this approach (as suggested by the aforementioned comment) increases bundle size
// so I chose different approach 
export { NimblePicker as default } from 'emoji-mart';
```