### PR TITLE
fix(Textarea): prevent caret movement on suggestion list item select

### DIFF
--- a/src/components/AutoCompleteTextarea/Textarea.jsx
+++ b/src/components/AutoCompleteTextarea/Textarea.jsx
@@ -100,6 +100,10 @@ export class ReactTextareaAutocomplete extends React.Component {
   _handleKeyDown = (event) => {
     const { shouldSubmit = this._defaultShouldSubmit } = this.props;
 
+    // prevent default behaviour when the selection list is rendered
+    if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && this.dropdownRef)
+      event.preventDefault();
+
     if (shouldSubmit?.(event)) return this._onEnter(event);
     if (event.key === ' ') return this._onSpace(event);
     if (event.key === 'Escape') return this._closeAutocomplete();


### PR DESCRIPTION
### 🎯 Goal

Prevents caret movement of the textarea component when the suggestion list is rendered (actively selecting from the list). 

Fixes: #1731
