### PR TITLE
fix: avoid race condition crash in jumping

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -524,6 +524,8 @@ const ChannelInner = <
     return queryResponse.messages.length;
   };
 
+  const clearHighlightedMessageTimeoutId = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const jumpToMessage = async (messageId: string, messageLimit = 100) => {
     dispatch({ loadingMore: true, type: 'setLoadingMore' });
     await channel.state.loadMessageIntoState(messageId, undefined, messageLimit);
@@ -542,7 +544,12 @@ const ChannelInner = <
       type: 'jumpToMessageFinished',
     });
 
-    setTimeout(() => {
+    if (clearHighlightedMessageTimeoutId.current) {
+      clearTimeout(clearHighlightedMessageTimeoutId.current);
+    }
+
+    clearHighlightedMessageTimeoutId.current = setTimeout(() => {
+      clearHighlightedMessageTimeoutId.current = null;
       dispatch({ type: 'clearHighlightedMessage' });
     }, 500);
   };


### PR DESCRIPTION
### 🎯 Goal

This change fixes a production-only issue where rapid jumping between messages created a race condition + exception. 
@szuperaz - more of an FYI if you copied this mistake from me :(. 