### PR TITLE
fix(ChannelList): update class names order for theming variables

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -24,6 +24,7 @@ import {
   UserResponse,
 } from 'stream-chat';
 import { nanoid } from 'nanoid';
+import clsx from 'clsx';
 
 import { channelReducer, ChannelStateReducer, initialState } from './channelState';
 import { commonEmoji, defaultMinimalEmojis, emojiSetDef } from './emojiData';
@@ -229,9 +230,11 @@ const UnMemoizedChannel = <
 
   const channel = propsChannel || contextChannel;
 
+  const className = clsx(chatClass, theme, channelClass);
+
   if (channelsQueryState.queryInProgress === 'reload' && LoadingIndicator) {
     return (
-      <div className={`${chatClass} ${channelClass} str-chat__channel ${theme}`}>
+      <div className={className}>
         <LoadingIndicator />
       </div>
     );
@@ -239,18 +242,14 @@ const UnMemoizedChannel = <
 
   if (channelsQueryState.error && LoadingErrorIndicator) {
     return (
-      <div className={`${chatClass} ${channelClass} str-chat__channel ${theme}`}>
+      <div className={className}>
         <LoadingErrorIndicator error={channelsQueryState.error} />
       </div>
     );
   }
 
   if (!channel?.cid) {
-    return (
-      <div className={`${chatClass} ${channelClass} str-chat__channel ${theme}`}>
-        {EmptyPlaceholder}
-      </div>
-    );
+    return <div className={className}>{EmptyPlaceholder}</div>;
   }
 
   // @ts-ignore
@@ -903,9 +902,11 @@ const ChannelInner = <
     [dragAndDropWindow],
   );
 
+  const className = clsx(chatClass, theme, channelClass);
+
   if (state.error) {
     return (
-      <div className={`${chatClass} ${channelClass} str-chat__channel ${theme}`}>
+      <div className={className}>
         <LoadingErrorIndicator error={state.error} />
       </div>
     );
@@ -913,7 +914,7 @@ const ChannelInner = <
 
   if (state.loading) {
     return (
-      <div className={`${chatClass} ${channelClass} str-chat__channel ${theme}`}>
+      <div className={className}>
         <LoadingIndicator />
       </div>
     );
@@ -921,14 +922,14 @@ const ChannelInner = <
 
   if (!channel.watch) {
     return (
-      <div className={`${chatClass} ${channelClass} str-chat__channel ${theme}`}>
+      <div className={className}>
         <div>{t<string>('Channel Missing')}</div>
       </div>
     );
   }
 
   return (
-    <div className={`${chatClass} ${channelClass} str-chat__channel ${theme} ${windowsEmojiClass}`}>
+    <div className={clsx(className, windowsEmojiClass)}>
       <ChannelStateProvider value={channelStateContextValue}>
         <ChannelActionProvider value={channelActionContextValue}>
           <ComponentProvider value={componentContextValue}>

--- a/src/components/Channel/__tests__/__snapshots__/Channel.test.js.snap
+++ b/src/components/Channel/__tests__/__snapshots__/Channel.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Channel should render a LoadingIndicator if it is loading 1`] = `
 <DocumentFragment>
   <div
-    class="str-chat str-chat-channel str-chat__channel messaging light"
+    class="str-chat messaging light str-chat-channel str-chat__channel"
   >
     <div
       class="str-chat__loading-channel"
@@ -119,7 +119,7 @@ exports[`Channel should render a LoadingIndicator if it is loading 1`] = `
 exports[`Channel should render default loading indicator if channels query is in progress 1`] = `
 <DocumentFragment>
   <div
-    class="str-chat str-chat-channel str-chat__channel undefined"
+    class="str-chat str-chat-channel str-chat__channel"
   >
     <div
       class="str-chat__loading-channel"
@@ -235,7 +235,7 @@ exports[`Channel should render default loading indicator if channels query is in
 exports[`Channel should render empty channel container if channel does not have cid 1`] = `
 <DocumentFragment>
   <div
-    class="str-chat str-chat-channel str-chat__channel undefined"
+    class="str-chat str-chat-channel str-chat__channel"
   />
 </DocumentFragment>
 `;
@@ -243,7 +243,7 @@ exports[`Channel should render empty channel container if channel does not have 
 exports[`Channel should render empty channel container if channels query failed 1`] = `
 <DocumentFragment>
   <div
-    class="str-chat str-chat-channel str-chat__channel undefined"
+    class="str-chat str-chat-channel str-chat__channel"
   />
 </DocumentFragment>
 `;

--- a/src/components/Channel/hooks/useChannelContainerClasses.ts
+++ b/src/components/Channel/hooks/useChannelContainerClasses.ts
@@ -11,7 +11,7 @@ export const useChannelContainerClasses = <
   const { useImageFlagEmojisOnWindows } = useChatContext<StreamChatGenerics>('Channel');
 
   return {
-    channelClass: customClasses?.channel ?? 'str-chat-channel',
+    channelClass: customClasses?.channel ?? 'str-chat-channel str-chat__channel',
     chatClass: customClasses?.chat ?? 'str-chat',
     chatContainerClass: customClasses?.chatContainer ?? 'str-chat__container',
     windowsEmojiClass:

--- a/src/components/ChannelList/ChannelList.tsx
+++ b/src/components/ChannelList/ChannelList.tsx
@@ -315,10 +315,9 @@ const UnMemoizedChannelList = <
   };
 
   const className = clsx(
-    'str-chat__channel-list',
+    customClasses?.chat ?? 'str-chat',
     theme,
-    customClasses?.chat || 'str-chat',
-    customClasses?.channelList || 'str-chat-channel-list',
+    customClasses?.channelList ?? 'str-chat-channel-list str-chat__channel-list',
     {
       'str-chat--windows-flags': useImageFlagEmojisOnWindows && navigator.userAgent.match(/Win/),
       'str-chat-channel-list--open': navOpen,

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -14,6 +14,9 @@ import type { Streami18n } from '../../i18n/Streami18n';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
 
+/**
+ * @deprecated will be removed with the complete transition to the theming V2 (next major release - `v11.0.0`)
+ */
 export type Theme<T extends string = string> =
   | 'commerce dark'
   | 'commerce light'
@@ -32,9 +35,15 @@ export type ChatProps<
   client: StreamChat<StreamChatGenerics>;
   /** Object containing custom CSS classnames to override the library's default container CSS */
   customClasses?: CustomClasses;
-  /** Object containing custom styles to override the default CSS variables */
+  /**
+   * @desc object containing custom styles to override the default CSS variables
+   * @deprecated will be removed with the complete transition to the theming v2 (next major release - `v11.0.0`)
+   */
   customStyles?: CustomStyles;
-  /** If true, toggles the CSS variables to the default dark mode color palette */
+  /**
+   * @desc if true, toggles the CSS variables to the default dark mode color palette
+   * @deprecated will be removed with the complete transition to the theming v2 (next major release - `v11.0.0`)
+   */
   darkMode?: boolean;
   /** Sets the default fallback language for UI component translation, defaults to 'en' for English */
   defaultLanguage?: SupportedTranslations;
@@ -42,8 +51,8 @@ export type ChatProps<
   i18nInstance?: Streami18n;
   /** Initial status of mobile navigation */
   initialNavOpen?: boolean;
-  /** @deprecated and to be removed in a future major release. Use the `customStyles` prop to adjust CSS variables and [customize the theme](https://getstream.io/chat/docs/sdk/react/customization/css_and_theming/#css-variables) of your app  */
-  theme?: Theme;
+  /** Used for injecting className/s to the Channel and ChannelList components */
+  theme?: string;
   /** Windows 10 does not support country flag emojis out of the box. It chooses to render these emojis as characters instead. Stream
    * Chat can override this behavior by loading a custom web font that will render images instead (PNGs or SVGs depending on the platform).
    * Set this prop to true if you want to use these custom emojis for Windows users.

--- a/src/components/MessageInput/MessageInputSmall.tsx
+++ b/src/components/MessageInput/MessageInputSmall.tsx
@@ -32,7 +32,7 @@ import { CooldownTimer as DefaultCooldownTimer } from './CooldownTimer';
  * In case you need to change styling in places where `MessageInputSmall` has been used previously ([`Thread`](../Thread/Thread.tsx))
  * please do so by updating the CSS or by overriding the component itself.
  *
- * **Will be removed with the complete transition to the theming V2.**
+ * **Will be removed with the complete transition to the theming V2 (next major release - `v11.0.0`).**
  */
 export const MessageInputSmall = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,

--- a/src/components/MessageInput/UploadsPreview.tsx
+++ b/src/components/MessageInput/UploadsPreview.tsx
@@ -12,7 +12,7 @@ import { useChatContext } from '../../context';
  * utilises outdated components from the package [`react-file-utils`](https://github.com/GetStream/react-file-utils)
  * which will no longer receive updates for aforementioned components.
  *
- * **Will be removed with the complete transition to the theming V2.**
+ * **Will be removed with the complete transition to the theming V2 (next major release - `v11.0.0`).**
  */
 export const UploadsPreview = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics

--- a/src/components/MessageList/__tests__/__snapshots__/VirtualizedMessageList.test.js.snap
+++ b/src/components/MessageList/__tests__/__snapshots__/VirtualizedMessageList.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`VirtualizedMessageList should render the list without any message 1`] = `
 <div
-  className="str-chat str-chat-channel str-chat__channel messaging light "
+  className="str-chat messaging light str-chat-channel str-chat__channel"
 >
   <div
     className="str-chat__container"

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -1,9 +1,9 @@
 import React, { PropsWithChildren, useContext } from 'react';
 
-import type { AppSettingsAPIResponse, Channel, Mute, StreamChat } from 'stream-chat';
+import type { AppSettingsAPIResponse, Channel, Mute } from 'stream-chat';
 
 import { getDisplayName } from './utils/getDisplayName';
-import type { Theme } from '../components/Chat/Chat';
+import type { ChatProps } from '../components/Chat/Chat';
 import type { DefaultStreamChatGenerics, UnknownType } from '../types/types';
 import type { ChannelsQueryState } from '../components/Chat/hooks/useChannelsQueryState';
 
@@ -29,7 +29,6 @@ export type ChatContextValue<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = {
   channelsQueryState: ChannelsQueryState;
-  client: StreamChat<StreamChatGenerics>;
   closeMobileNav: () => void;
   getAppSettings: () => Promise<AppSettingsAPIResponse<StreamChatGenerics>> | null;
   latestMessageDatesByChannels: Record<ChannelCID, Date>;
@@ -40,14 +39,12 @@ export type ChatContextValue<
     watchers?: { limit?: number; offset?: number },
     event?: React.BaseSyntheticEvent,
   ) => void;
-  /** @deprecated */
-  theme: Theme;
   themeVersion: ThemeVersion;
   useImageFlagEmojisOnWindows: boolean;
   channel?: Channel<StreamChatGenerics>;
   customClasses?: CustomClasses;
   navOpen?: boolean;
-};
+} & Required<Pick<ChatProps<StreamChatGenerics>, 'theme' | 'client'>>;
 
 export const ChatContext = React.createContext<ChatContextValue | undefined>(undefined);
 


### PR DESCRIPTION
### 🎯 Goal

Remove deprecation notice for Chat's `theme` property and fix order of class names in `ChannelList` which sets the theming variables.
