### PR TITLE
fix: play video in attachment card theme v1

### DIFF
--- a/src/components/Attachment/Card.tsx
+++ b/src/components/Attachment/Card.tsx
@@ -43,6 +43,7 @@ const UnableToRenderCard = ({ type }: { type?: CardProps['type'] }) => {
 };
 
 interface CardV1Props {
+  asset_url?: Attachment['asset_url'];
   giphy?: Attachment['giphy'];
   /** The url of the full sized image */
   image_url?: string;
@@ -61,7 +62,17 @@ interface CardV1Props {
 }
 
 const CardV1 = (props: CardV1Props) => {
-  const { giphy, image_url, og_scrape_url, text, thumb_url, title, title_link, type } = props;
+  const {
+    asset_url,
+    giphy,
+    image_url,
+    og_scrape_url,
+    text,
+    thumb_url,
+    title,
+    title_link,
+    type,
+  } = props;
   const { giphyVersion: giphyVersionName } = useChannelStateContext('Card');
 
   let image = thumb_url || image_url;
@@ -74,7 +85,7 @@ const CardV1 = (props: CardV1Props) => {
     dimensions.width = giphyVersion.width;
   }
 
-  if (!title && !title_link && !image) {
+  if (!title && !title_link && !asset_url && !image) {
     return <UnableToRenderCard type={type} />;
   }
 
@@ -84,27 +95,25 @@ const CardV1 = (props: CardV1Props) => {
 
   return (
     <div className={`str-chat__message-attachment-card str-chat__message-attachment-card--${type}`}>
-      {image && (
-        <div className='str-chat__message-attachment-card--header'>
-          <img alt={image} src={image} {...dimensions} />
+      <CardHeader {...props} dimensions={dimensions} image={image} />
+      {type !== 'video' && (
+        <div className='str-chat__message-attachment-card--content'>
+          <div className='str-chat__message-attachment-card--flex'>
+            {title && <div className='str-chat__message-attachment-card--title'>{title}</div>}
+            {text && <div className='str-chat__message-attachment-card--text'>{text}</div>}
+            {(title_link || og_scrape_url) && (
+              <SafeAnchor
+                className='str-chat__message-attachment-card--url'
+                href={title_link || og_scrape_url}
+                rel='noopener noreferrer'
+                target='_blank'
+              >
+                {getHostFromURL(title_link || og_scrape_url)}
+              </SafeAnchor>
+            )}
+          </div>
         </div>
       )}
-      <div className='str-chat__message-attachment-card--content'>
-        <div className='str-chat__message-attachment-card--flex'>
-          {title && <div className='str-chat__message-attachment-card--title'>{title}</div>}
-          {text && <div className='str-chat__message-attachment-card--text'>{text}</div>}
-          {(title_link || og_scrape_url) && (
-            <SafeAnchor
-              className='str-chat__message-attachment-card--url'
-              href={title_link || og_scrape_url}
-              rel='noopener noreferrer'
-              target='_blank'
-            >
-              {getHostFromURL(title_link || og_scrape_url)}
-            </SafeAnchor>
-          )}
-        </div>
-      </div>
     </div>
   );
 };

--- a/src/components/Attachment/__tests__/Card.test.js
+++ b/src/components/Attachment/__tests__/Card.test.js
@@ -155,41 +155,45 @@ describe('Card', () => {
         chatContext: { chatClient },
       });
       expect(container.firstChild).toMatchInlineSnapshot(`
+        <div
+          class="str-chat__message-attachment-card str-chat__message-attachment-card--undefined"
+        >
+          <div
+            class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
+            data-testid="card-header"
+          >
+            <img
+              alt="test"
+              class="str-chat__message-attachment--img"
+              data-testid="image-test"
+              src="test.jpg"
+              tabindex="0"
+            />
+          </div>
+          <div
+            class="str-chat__message-attachment-card--content"
+          >
+            <div
+              class="str-chat__message-attachment-card--flex"
+            >
               <div
-                class="str-chat__message-attachment-card str-chat__message-attachment-card--undefined"
+                class="str-chat__message-attachment-card--title"
               >
-                <div
-                  class="str-chat__message-attachment-card--header"
-                >
-                  <img
-                    alt="test.jpg"
-                    src="test.jpg"
-                  />
-                </div>
-                <div
-                  class="str-chat__message-attachment-card--content"
-                >
-                  <div
-                    class="str-chat__message-attachment-card--flex"
-                  >
-                    <div
-                      class="str-chat__message-attachment-card--title"
-                    >
-                      test
-                    </div>
-                    <a
-                      aria-label="Attachment"
-                      class="str-chat__message-attachment-card--url"
-                      href="https://google.com"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      google.com
-                    </a>
-                  </div>
-                </div>
+                test
               </div>
-          `);
+              <a
+                aria-label="Attachment"
+                class="str-chat__message-attachment-card--url"
+                href="https://google.com"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                google.com
+              </a>
+            </div>
+          </div>
+        </div>
+      `);
     });
 
     it('should render Card with default props and title, og_scrape_url, image_url, text', async () => {
@@ -204,46 +208,50 @@ describe('Card', () => {
       });
 
       expect(container.firstChild).toMatchInlineSnapshot(`
+        <div
+          class="str-chat__message-attachment-card str-chat__message-attachment-card--undefined"
+        >
+          <div
+            class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
+            data-testid="card-header"
+          >
+            <img
+              alt="test"
+              class="str-chat__message-attachment--img"
+              data-testid="image-test"
+              src="test.jpg"
+              tabindex="0"
+            />
+          </div>
+          <div
+            class="str-chat__message-attachment-card--content"
+          >
+            <div
+              class="str-chat__message-attachment-card--flex"
+            >
               <div
-                class="str-chat__message-attachment-card str-chat__message-attachment-card--undefined"
+                class="str-chat__message-attachment-card--title"
               >
-                <div
-                  class="str-chat__message-attachment-card--header"
-                >
-                  <img
-                    alt="test.jpg"
-                    src="test.jpg"
-                  />
-                </div>
-                <div
-                  class="str-chat__message-attachment-card--content"
-                >
-                  <div
-                    class="str-chat__message-attachment-card--flex"
-                  >
-                    <div
-                      class="str-chat__message-attachment-card--title"
-                    >
-                      test
-                    </div>
-                    <div
-                      class="str-chat__message-attachment-card--text"
-                    >
-                      test text
-                    </div>
-                    <a
-                      aria-label="Attachment"
-                      class="str-chat__message-attachment-card--url"
-                      href="https://google.com"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      google.com
-                    </a>
-                  </div>
-                </div>
+                test
               </div>
-          `);
+              <div
+                class="str-chat__message-attachment-card--text"
+              >
+                test text
+              </div>
+              <a
+                aria-label="Attachment"
+                class="str-chat__message-attachment-card--url"
+                href="https://google.com"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                google.com
+              </a>
+            </div>
+          </div>
+        </div>
+      `);
     });
 
     it('should render trimmed url', async () => {
@@ -264,6 +272,68 @@ describe('Card', () => {
         chatContext: { chatClient },
       });
       expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should fall back to render image for video card if no asset_url', async () => {
+      const { container } = await renderCard({
+        cardProps: {
+          image_url: 'test.jpg',
+          og_scrape_url: 'https://google.com',
+          text: 'test text',
+          title: 'test',
+          type: 'video',
+        },
+        chatContext: { chatClient },
+      });
+
+      expect(container.firstChild).toMatchInlineSnapshot(`
+        <div
+          class="str-chat__message-attachment-card str-chat__message-attachment-card--video"
+        >
+          <div
+            class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
+            data-testid="card-header"
+          >
+            <img
+              alt="test"
+              class="str-chat__message-attachment--img"
+              data-testid="image-test"
+              src="test.jpg"
+              tabindex="0"
+            />
+          </div>
+        </div>
+      `);
+    });
+
+    it('should render card with video player', async () => {
+      const { container } = await renderCard({
+        cardProps: {
+          asset_url: 'https://example.com',
+          image_url: 'test.jpg',
+          og_scrape_url: 'https://google.com',
+          text: 'test text',
+          title: 'test',
+          type: 'video',
+        },
+        chatContext: { chatClient },
+      });
+
+      expect(container.firstChild).toMatchInlineSnapshot(`
+        <div
+          class="str-chat__message-attachment-card str-chat__message-attachment-card--video"
+        >
+          <div
+            class="str-chat__message-attachment-card--header str-chat__message-attachment-card-react--header"
+            data-testid="card-header"
+          >
+            <div
+              class="react-player"
+              style="width: 100%; height: 100%;"
+            />
+          </div>
+        </div>
+      `);
     });
   });
 

--- a/src/components/Attachment/__tests__/__snapshots__/Card.test.js.snap
+++ b/src/components/Attachment/__tests__/__snapshots__/Card.test.js.snap
@@ -97,7 +97,14 @@ exports[`Card theme V2 (2) should render card without caption if attachment type
       <div
         class="react-player"
         style="width: 100%; height: 100%;"
-      />
+      >
+        <video
+          controls=""
+          preload="auto"
+          src="dummyAttachment_asset_url"
+          style="width: 100%; height: 100%;"
+        />
+      </div>
     </div>
     <div
       class="str-chat__message-attachment-card--content"


### PR DESCRIPTION
### 🎯 Goal

Allow to play the video directly in the `Card` with video asset link with css theme version 1. After the release v10.0.0 the video widget was replaced with an image. Click on the image lead to opening of a new tab with the video link.

### 🛠 Implementation details

It was necessary to check the attachment type in `Card` component using theme v1.