### PR TITLE
fix: export all necessary components

### DIFF
--- a/src/components/ChannelPreview/hooks/index.ts
+++ b/src/components/ChannelPreview/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useChannelPreviewInfo } from './useChannelPreviewInfo';

--- a/src/components/ChannelPreview/index.ts
+++ b/src/components/ChannelPreview/index.ts
@@ -1,3 +1,4 @@
 export * from './ChannelPreview';
 export * from './ChannelPreviewMessenger';
+export * from './hooks';
 export * from './utils';

--- a/src/components/MessageInput/index.ts
+++ b/src/components/MessageInput/index.ts
@@ -1,4 +1,5 @@
 export * from './AttachmentPreviewList';
+export * from './CooldownTimer';
 export * from './DefaultTriggerProvider';
 export * from './EditMessageForm';
 export * from './EmojiPicker';
@@ -9,4 +10,3 @@ export * from './MessageInputFlat';
 export * from './MessageInputSmall';
 export * from './QuotedMessagePreview';
 export * from './UploadsPreview';
-export * from './CooldownTimer';

--- a/src/components/MessageInput/index.ts
+++ b/src/components/MessageInput/index.ts
@@ -1,3 +1,4 @@
+export * from './AttachmentPreviewList';
 export * from './DefaultTriggerProvider';
 export * from './EditMessageForm';
 export * from './EmojiPicker';

--- a/src/components/MessageList/Center.tsx
+++ b/src/components/MessageList/Center.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import type { PropsWithChildrenOnly } from '../../types/types';
-
-const UnMemoizedCenter = ({ children }: PropsWithChildrenOnly) => (
-  <div className='str-chat__list__center'>{children}</div>
-);
-
-export const Center = React.memo(UnMemoizedCenter) as typeof UnMemoizedCenter;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -14,7 +14,7 @@ export type PopperTooltipProps<T extends HTMLElement> = React.PropsWithChildren<
   offset?: [number, number];
   /** Popper's placement property defining default position of the tooltip, default 'top' */
   placement?: PopperProps<unknown>['placement'];
-  /** Tells component whether to render it's contents */
+  /** Tells component whether to render its contents */
   visible?: boolean;
 }>;
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,6 @@
 export * from './Attachment';
 export * from './AutoCompleteTextarea';
-export * from './Avatar/Avatar';
+export * from './Avatar';
 export * from './Channel';
 export * from './ChannelHeader';
 export * from './ChannelList';
@@ -8,7 +8,7 @@ export * from './ChannelPreview';
 export * from './ChannelSearch';
 export * from './Chat';
 export * from './ChatAutoComplete';
-export * from './ChatDown/ChatDown';
+export * from './ChatDown';
 export * from './CommandItem';
 export * from './DateSeparator';
 export * from './EmoticonItem';


### PR DESCRIPTION
### 🎯 Goal

Export recently added components that were not exported from the SDK (`AttachmentPreviewList`, `useChannelPreviewHook`).
