### PR TITLE
fix: replace use of channel config with channel.own_capabilities to derive permission flags

### DIFF
--- a/src/components/Message/__tests__/Message.test.js
+++ b/src/components/Message/__tests__/Message.test.js
@@ -677,6 +677,7 @@ describe('<Message /> component', () => {
     let context;
 
     await renderComponent({
+      channelStateOpts: { channelCapabilities: { 'flag-message': true } },
       contextCallback: (ctx) => {
         context = ctx;
       },
@@ -691,7 +692,7 @@ describe('<Message /> component', () => {
     let context;
 
     await renderComponent({
-      channelStateOpts: { channelConfig: { mutes: true } },
+      channelStateOpts: { channelCapabilities: { 'mute-channel': true } },
       contextCallback: (ctx) => {
         context = ctx;
       },

--- a/src/components/Message/hooks/__tests__/useUserRole.test.js
+++ b/src/components/Message/hooks/__tests__/useUserRole.test.js
@@ -16,12 +16,14 @@ const getConfig = jest.fn();
 const alice = generateUser({ name: 'alice' });
 const bob = generateUser({ name: 'bob' });
 
-async function renderUserRoleHook(
+async function renderUserRoleHook({
+  channelProps = {},
+  channelStateContextValue = {},
+  clientContextValue = {},
+  disableQuotedMessages,
   message = generateMessage(),
-  channelProps,
-  channelStateContextValue,
-  clientContextValue,
-) {
+  onlySenderCanEdit = false,
+}) {
   const client = await getTestClientWithUser(alice);
   const channel = generateChannel({
     getConfig,
@@ -37,18 +39,22 @@ async function renderUserRoleHook(
     </ChatProvider>
   );
 
-  const { result } = renderHook(() => useUserRole(message, false), { wrapper });
+  const { result } = renderHook(
+    () => useUserRole(message, onlySenderCanEdit, disableQuotedMessages),
+    { wrapper },
+  );
   return result.current;
 }
 
 describe('useUserRole custom hook', () => {
   afterEach(jest.clearAllMocks);
+
   it.each([
     ['belongs', alice, true],
     ['does not belong', bob, false],
   ])('should tell when the message %s to user', async (_, user, expected) => {
     const message = generateMessage({ user });
-    const { isMyMessage } = await renderUserRoleHook(message);
+    const { isMyMessage } = await renderUserRoleHook({ message });
     expect(isMyMessage).toBe(expected);
   });
 
@@ -59,10 +65,9 @@ describe('useUserRole custom hook', () => {
     ['channel_moderator', false],
     ['owner', false],
   ])('should tell if user is admin when user has %s role', async (role, expected) => {
-    const message = generateMessage();
     const adminUser = generateUser({ role });
     const clientMock = await getTestClientWithUser(adminUser);
-    const { isAdmin } = await renderUserRoleHook(message, {}, {}, { client: clientMock });
+    const { isAdmin } = await renderUserRoleHook({ clientContextValue: { client: clientMock } });
     expect(isAdmin).toBe(expected);
   });
 
@@ -75,11 +80,12 @@ describe('useUserRole custom hook', () => {
   ])(
     'should tell if user is admin when channel state membership is set to %s',
     async (role, expected) => {
-      const message = generateMessage();
-      const { isAdmin } = await renderUserRoleHook(message, {
-        state: {
-          membership: {
-            role,
+      const { isAdmin } = await renderUserRoleHook({
+        channelProps: {
+          state: {
+            membership: {
+              role,
+            },
           },
         },
       });
@@ -96,14 +102,16 @@ describe('useUserRole custom hook', () => {
   ])(
     'should tell if user is owner when channel state membership is set to %s',
     async (role, expected) => {
-      const message = generateMessage();
-      const { isOwner } = await renderUserRoleHook(message, {
-        state: {
-          membership: {
-            role,
+      const { isOwner } = await renderUserRoleHook({
+        channelProps: {
+          state: {
+            membership: {
+              role,
+            },
           },
         },
       });
+
       expect(isOwner).toBe(expected);
     },
   );
@@ -117,11 +125,12 @@ describe('useUserRole custom hook', () => {
   ])(
     'should tell if user is moderator when channel state membership role is set to %s',
     async (role, expected) => {
-      const message = generateMessage();
-      const { isModerator } = await renderUserRoleHook(message, {
-        state: {
-          membership: {
-            role,
+      const { isModerator } = await renderUserRoleHook({
+        channelProps: {
+          state: {
+            membership: {
+              role,
+            },
           },
         },
       });
@@ -136,11 +145,12 @@ describe('useUserRole custom hook', () => {
   ])(
     'should tell if user is moderator when channel state membership is_moderator is set to %s',
     async (bool, expected) => {
-      const message = generateMessage();
-      const { isModerator } = await renderUserRoleHook(message, {
-        state: {
-          membership: {
-            is_moderator: bool,
+      const { isModerator } = await renderUserRoleHook({
+        channelProps: {
+          state: {
+            membership: {
+              is_moderator: bool,
+            },
           },
         },
       });
@@ -156,11 +166,12 @@ describe('useUserRole custom hook', () => {
   ])(
     'should tell if user is moderator when channel state membership channel_role is set to %s',
     async (role, expected) => {
-      const message = generateMessage();
-      const { isModerator } = await renderUserRoleHook(message, {
-        state: {
-          membership: {
-            channel_role: role,
+      const { isModerator } = await renderUserRoleHook({
+        channelProps: {
+          state: {
+            membership: {
+              channel_role: role,
+            },
           },
         },
       });
@@ -175,24 +186,175 @@ describe('useUserRole custom hook', () => {
     ['channel_moderator', true],
     ['owner', false],
   ])('should allow user to edit or delete message if user role is %s', async (role, expected) => {
-    const message = generateMessage();
-    const { canDelete, canEdit } = await renderUserRoleHook(
-      message,
-      {
+    const { canDelete, canEdit } = await renderUserRoleHook({
+      channelProps: {
         state: {
           membership: {
             role,
           },
         },
       },
-      {
+      channelStateContextValue: {
         channelCapabilities: {
           'delete-any-message': expected,
           'update-any-message': expected,
         },
       },
-    );
+    });
     expect(canEdit).toBe(expected);
     expect(canDelete).toBe(expected);
+  });
+
+  describe('canDo flags', () => {
+    it.each([
+      [true, true, true, alice, true],
+      [true, true, true, bob, false],
+      [false, true, true, alice, true],
+      [false, true, true, bob, true],
+      [true, false, true, alice, true],
+      [true, false, true, bob, false],
+      [true, true, false, alice, false],
+      [true, true, false, bob, false],
+      [false, false, true, alice, true],
+      [false, false, true, bob, false],
+      [false, true, false, alice, true],
+      [false, true, false, bob, true],
+      [true, false, false, alice, false],
+      [true, false, false, bob, false],
+      [false, false, false, alice, false],
+      [false, false, false, bob, false],
+    ])(
+      'determine message edit permission',
+      async (
+        onlySenderCanEdit,
+        updateAnyPermission,
+        updateOwnPermission,
+        messageAuthor,
+        expected,
+      ) => {
+        const message = generateMessage({ user: messageAuthor });
+        const { canEdit } = await renderUserRoleHook({
+          channelStateContextValue: {
+            channelCapabilities: {
+              'update-any-message': updateAnyPermission,
+              'update-own-message': updateOwnPermission,
+            },
+          },
+          message,
+          onlySenderCanEdit,
+        });
+        expect(canEdit).toBe(expected);
+      },
+    );
+
+    it.each([
+      [true, true, alice, true],
+      [true, true, bob, true],
+      [false, true, alice, true],
+      [false, true, bob, false],
+      [true, false, alice, true],
+      [true, false, bob, true],
+      [false, false, alice, false],
+      [false, false, bob, false],
+    ])(
+      'determine delete message permission',
+      async (deleteAnyMessagePerm, deleteOwnMessagePerm, messageAuthor, expected) => {
+        const message = generateMessage({ user: messageAuthor });
+        const { canDelete } = await renderUserRoleHook({
+          channelStateContextValue: {
+            channelCapabilities: {
+              'delete-any-message': deleteAnyMessagePerm,
+              'delete-own-message': deleteOwnMessagePerm,
+            },
+          },
+          message,
+        });
+        expect(canDelete).toBe(expected);
+      },
+    );
+
+    it.each([
+      [true, alice, false],
+      [true, bob, true],
+      [false, alice, false],
+      [false, bob, false],
+    ])('determine flag message permission', async (flagMessagePerm, messageAuthor, expected) => {
+      const message = generateMessage({ user: messageAuthor });
+      const { canFlag } = await renderUserRoleHook({
+        channelStateContextValue: {
+          channelCapabilities: {
+            'flag-message': flagMessagePerm,
+          },
+        },
+        message,
+      });
+      expect(canFlag).toBe(expected);
+    });
+
+    it.each([
+      [true, alice, false],
+      [true, bob, true],
+      [false, alice, false],
+      [false, bob, false],
+    ])('determine mute channel permission', async (muteChannelPerm, messageAuthor, expected) => {
+      const message = generateMessage({ user: messageAuthor });
+      const { canMute } = await renderUserRoleHook({
+        channelStateContextValue: {
+          channelCapabilities: {
+            'mute-channel': muteChannelPerm,
+          },
+        },
+        message,
+      });
+      expect(canMute).toBe(expected);
+    });
+
+    it.each([
+      [true, true, false],
+      [true, false, false],
+      [false, true, true],
+      [false, false, false],
+    ])(
+      'determine quote message permission',
+      async (disableQuotedMessages, quoteMessagePerm, expected) => {
+        const { canQuote } = await renderUserRoleHook({
+          channelStateContextValue: {
+            channelCapabilities: {
+              'quote-message': quoteMessagePerm,
+            },
+          },
+          disableQuotedMessages,
+        });
+        expect(canQuote).toBe(expected);
+      },
+    );
+
+    it.each([
+      [true, true],
+      [false, false],
+    ])('determine react to a message permission', async (sendReactionPerm, expected) => {
+      const { canReact } = await renderUserRoleHook({
+        channelStateContextValue: {
+          channelCapabilities: {
+            'send-reaction': sendReactionPerm,
+          },
+        },
+      });
+      expect(canReact).toBe(expected);
+    });
+
+    it.each([
+      [true, true],
+      [false, false],
+    ])('determine react to a message permission', async (sendReplyPerm, expected) => {
+      const { canReply } = await renderUserRoleHook({
+        channelStateContextValue: {
+          channelCapabilities: {
+            'send-reply': sendReplyPerm,
+          },
+        },
+      });
+      expect(canReply).toBe(expected);
+    });
   });
 });

--- a/src/components/Message/hooks/useUserRole.ts
+++ b/src/components/Message/hooks/useUserRole.ts
@@ -10,11 +10,9 @@ export const useUserRole = <
   onlySenderCanEdit?: boolean,
   disableQuotedMessages?: boolean,
 ) => {
-  const {
-    channel,
-    channelCapabilities = {},
-    channelConfig,
-  } = useChannelStateContext<StreamChatGenerics>('useUserRole');
+  const { channel, channelCapabilities = {} } = useChannelStateContext<StreamChatGenerics>(
+    'useUserRole',
+  );
   const { client } = useChatContext<StreamChatGenerics>('useUserRole');
 
   /**
@@ -41,6 +39,7 @@ export const useUserRole = <
     channel.state.membership.channel_role === 'channel_moderator';
 
   const isMyMessage = client.userID === message.user?.id;
+
   const canEdit =
     (!onlySenderCanEdit && channelCapabilities['update-any-message']) ||
     (isMyMessage && channelCapabilities['update-own-message']);
@@ -49,11 +48,11 @@ export const useUserRole = <
     channelCapabilities['delete-any-message'] ||
     (isMyMessage && channelCapabilities['delete-own-message']);
 
-  const canFlag = !isMyMessage;
-  const canMute = !isMyMessage && channelConfig?.mutes;
+  const canFlag = !isMyMessage && channelCapabilities['flag-message'];
+  const canMute = !isMyMessage && channelCapabilities['mute-channel'];
   const canQuote = !disableQuotedMessages && channelCapabilities['quote-message'];
-  const canReact = channelConfig?.reactions !== false && channelCapabilities['send-reaction'];
-  const canReply = channelConfig?.replies !== false && channelCapabilities['send-reply'];
+  const canReact = channelCapabilities['send-reaction'];
+  const canReply = channelCapabilities['send-reply'];
 
   return {
     canDelete,


### PR DESCRIPTION
### 🎯 Goal

Enable permission configuration for message flagging, stop inferring `mute, react, reply` permissions from `channel.config`.

fixes #1806 
