### PR TITLE
fix: add linkify.test check before any URL instantiation

### DIFF
--- a/src/components/Attachment/AttachmentContainer.tsx
+++ b/src/components/Attachment/AttachmentContainer.tsx
@@ -2,6 +2,8 @@ import React, { PropsWithChildren, useLayoutEffect, useRef, useState } from 'rea
 import ReactPlayer from 'react-player';
 import clsx from 'clsx';
 
+import * as linkify from 'linkifyjs';
+
 import { AttachmentActions as DefaultAttachmentActions } from './AttachmentActions';
 import { Audio as DefaultAudio } from './Audio';
 import { Gallery as DefaultGallery, ImageComponent as DefaultImage } from '../Gallery';
@@ -78,11 +80,11 @@ export const AttachmentActionsContainer = <
 
 function getCssDimensionsVariables(url: string) {
   const cssVars = {
-    ['--original-height']: 1000000,
-    ['--original-width']: 1000000,
+    '--original-height': 1000000,
+    '--original-width': 1000000,
   } as Record<string, number>;
 
-  if (url) {
+  if (linkify.test(url, 'url')) {
     const urlParams = new URL(url).searchParams;
     const oh = Number(urlParams.get('oh'));
     const ow = Number(urlParams.get('ow'));
@@ -91,6 +93,7 @@ function getCssDimensionsVariables(url: string) {
     cssVars['--original-width'] = originalWidth;
     cssVars['--original-height'] = originalHeight;
   }
+
   return cssVars;
 }
 

--- a/src/components/Attachment/attachment-sizing.tsx
+++ b/src/components/Attachment/attachment-sizing.tsx
@@ -1,18 +1,26 @@
 import type { Attachment } from 'stream-chat';
+import * as linkify from 'linkifyjs';
 
 export const getImageAttachmentConfiguration = (attachment: Attachment, element: HTMLElement) => {
-  const url = new URL((attachment.image_url || attachment.thumb_url || '') as string);
-  const resizeDimensions = getSizingRestrictions(url, element);
+  let newUrl = undefined;
 
-  if (resizeDimensions) {
-    // Apply 2x for retina displays
-    resizeDimensions.height *= 2;
-    resizeDimensions.width *= 2;
-    addResizingParamsToUrl(resizeDimensions, url);
+  const urlToTest = attachment.image_url || attachment.thumb_url || '';
+
+  if (linkify.test(urlToTest, 'url')) {
+    const url = new URL(urlToTest);
+    const resizeDimensions = getSizingRestrictions(url, element);
+
+    if (resizeDimensions) {
+      // Apply 2x for retina displays
+      resizeDimensions.height *= 2;
+      resizeDimensions.width *= 2;
+      addResizingParamsToUrl(resizeDimensions, url);
+    }
+    newUrl = url.href;
   }
 
   return {
-    url: url.href,
+    url: newUrl || '',
   };
 };
 
@@ -22,7 +30,11 @@ export const getVideoAttachmentConfiguration = (
   shouldGenerateVideoThumbnail: boolean,
 ) => {
   let thumbUrl = undefined;
-  if (attachment.thumb_url && shouldGenerateVideoThumbnail) {
+  if (
+    attachment.thumb_url &&
+    shouldGenerateVideoThumbnail &&
+    linkify.test(attachment.thumb_url, 'url')
+  ) {
     const url = new URL(attachment.thumb_url);
     const resizeDimensions = getSizingRestrictions(url, element);
 


### PR DESCRIPTION
### 🎯 Goal

Add `linkify.test` check before any `URL` instantiation to prevent errors due to malformed links.
