### PR TITLE
Docs typo fix: changed setQuoteMessage to setQuotedMessage

### DIFF
--- a/docusaurus/docs/React/components/contexts/channel-action-context.mdx
+++ b/docusaurus/docs/React/components/contexts/channel-action-context.mdx
@@ -176,7 +176,7 @@ The function to send a `message` on `Channel`. Takes a `message` object with the
 |----------|
 | function |
 
-### setQuoteMessage
+### setQuotedMessage
 
 The function to send a `QuotedMessage` on a `Channel`, take a `message` object.
 


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Typo: setQuoteMessage should be setQuotedMessage.

### 🛠 Implementation details

Changed: setQuoteMessage -> setQuotedMessage
