### PR TITLE
fix: merge mentionQueryParams.sort configuration correctly

### DIFF
--- a/src/components/MessageInput/hooks/useUserTrigger.ts
+++ b/src/components/MessageInput/hooks/useUserTrigger.ts
@@ -105,7 +105,9 @@ export const useUserTrigger = <
           id: { $ne: client.userID },
           ...mentionQueryParams.filters,
         },
-        { id: 1, ...mentionQueryParams.sort },
+        Array.isArray(mentionQueryParams.sort)
+          ? [{ id: 1 }, ...mentionQueryParams.sort]
+          : { id: 1, ...mentionQueryParams.sort },
         { limit: 10, ...mentionQueryParams.options },
       );
 


### PR DESCRIPTION
### 🎯 Goal

Sort configuration can be an array of objects or an object. This should be checked when merging the custom `mentionQueryParams.sort` value into the resulting `client.queryUsers` call params.

fixes #1862