### PR TITLE
customSearchFunction example in docs is not correct

### DIFF
--- a/docusaurus/docs/React/guides/customization/channel-search.mdx
+++ b/docusaurus/docs/React/guides/customization/channel-search.mdx
@@ -317,26 +317,37 @@ To override the search method, completely use the `searchFunction` prop. This pr
 and for only channels that the current logged in user is a member of. See the example below for this.
 
 ```jsx
-const customSearchFunction = async (props: ChannelSearchFunctionParams, event: { target: { value: SetStateAction<string>; }; }) => {
-  const { setResults, setResultsOpen, setSearching, setQuery } = props;
-  const { client } = useChatContext();
+const customSearchFunction = async (
+  props: ChannelSearchFunctionParams,
+  event: { target: { value: SetStateAction<string> } },
+  client: StreamChat
+) => {
+  const { setResults, setSearching, setQuery } = props;
+  const value = event.target.value;
 
   const filters = {
-      name: { $autocomplete: event.target.value },
+      name: { $autocomplete: value },
       members: { $in: client.userID }
   }
 
   setSearching(true);
-  setQuery(event.target.value);
-  const channels = await chatClient.queryChannels(filters);
+  setQuery(value);
+  const channels = await client.queryChannels(filters);
   setResults(channels);
-  setResultsOpen(true);
   setSearching(false);
 };
+```
+
+```jsx
+const { client } = useChatContext();
 
 <ChannelList
+  additionalChannelSearchProps={{
+    searchFunction: (params, event) => {
+      return customSearchFunction(params, event, client);
+    },
+  }}
   showChannelSearch
-  additionalChannelSearchProps={{searchFunction: customSearchFunction}}
 />
 ```
 


### PR DESCRIPTION
### 🎯 Goal

Improve the customSearchFunction example in [docs](https://getstream.io/chat/docs/sdk/react/guides/customization/channel_search/#the-searchfunction-prop) is not correct.

- Use of hook (`useChatContext`) within regular async function (no hook or component).
- `chatClient` is not defined.
- setResultsOpen doesn't exist.

### 🛠 Implementation details

Errors fixed:

- React Hook "useChatContext" is called in function "customSearchFunction" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use"

- `chatClient` doesn’t exist ➜ should be client.

- Provided `client` as prop instead of the use of a hook within a regular function. 

- Re-used `e.target.value` assigned to var ➜ improves re-usability.
