### PR TITLE
feat(MessageInput): extend mentionQueryParams to accept `filters` function 

### DIFF
--- a/docusaurus/docs/React/components/utility-components/channel-search.mdx
+++ b/docusaurus/docs/React/components/utility-components/channel-search.mdx
@@ -313,6 +313,8 @@ Custom UI component to display the search loading state. Rendered within the `Se
 
 Object containing filters/sort/options overrides for user / channel search.
 
+The `filters` attribute (`SearchQueryParams.userFilters.filters`) can be either `UserFilters` object describing the filter query or a function with a single argument of the search / filter (query) string. The function is then expected to derive and return the `UserFilters` from the provided query string.
+
 | Type                                    |
 |-----------------------------------------|
 | `SearchQueryParams<StreamChatGenerics>` |

--- a/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -42,7 +42,9 @@ export type SearchQueryParams<
     sort?: ChannelSort<StreamChatGenerics>;
   };
   userFilters?: {
-    filters?: UserFilters<StreamChatGenerics>;
+    filters?:
+      | UserFilters<StreamChatGenerics>
+      | ((query: string) => UserFilters<StreamChatGenerics>);
     options?: UserOptions;
     sort?: UserSort<StreamChatGenerics>;
   };

--- a/src/components/MessageInput/hooks/useUserTrigger.ts
+++ b/src/components/MessageInput/hooks/useUserTrigger.ts
@@ -103,7 +103,9 @@ export const useUserTrigger = <
         {
           $or: [{ id: { $autocomplete: query } }, { name: { $autocomplete: query } }],
           id: { $ne: client.userID },
-          ...mentionQueryParams.filters,
+          ...(typeof mentionQueryParams.filters === 'function'
+            ? mentionQueryParams.filters(query)
+            : mentionQueryParams.filters),
         },
         Array.isArray(mentionQueryParams.sort)
           ? [{ id: 1 }, ...mentionQueryParams.sort]


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

I want to be able to control `mentionQueryParams` by myself and have access to input query value

### 🛠 Implementation details

Just update `mentionQueryParams`, now it accepts function

