### PR TITLE
fix(renderText): specify linkifyjs types to look for (`email` and `url`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "hast-util-find-and-replace": "^4.1.2",
     "i18next": "^21.6.14",
     "isomorphic-ws": "^4.0.1",
-    "linkifyjs": "^2.1.9",
+    "linkifyjs": "^4.1.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "lodash.uniqby": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10235,6 +10235,11 @@ linkifyjs@^2.1.9:
   resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-2.1.9.tgz#af06e45a2866ff06c4766582590d098a4d584702"
   integrity sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==
 
+linkifyjs@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-4.1.0.tgz#0460bfcc37d3348fa80e078d92e7bbc82588db15"
+  integrity sha512-Ffv8VoY3+ixI1b3aZ3O+jM6x17cOsgwfB1Wq7pkytbo1WlyRp6ZO0YDMqiWT/gQPY/CmtiGuKfzDIVqxh1aCTA==
+
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"


### PR DESCRIPTION
### 🎯 Goal

Package `linkifyjs` uses plugins which are registered globally ([like this one - mentions](https://linkify.js.org/docs/plugin-mention.html)), so when integrators use compatible `linkifyjs` with custom compatible plugins for other purposes, it tampers with our implementation - in this case it broke mentions implementation which is handled by `ReactMarkdown` instead.

Fixes: #1851