### PR TITLE
chore: pin the react-player version to 2.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-image-gallery": "^1.2.7",
     "react-is": "^18.1.0",
     "react-markdown": "^8.0.3",
-    "react-player": "^2.10.1",
+    "react-player": "2.10.1",
     "react-popper": "^2.3.0",
     "react-textarea-autosize": "^8.3.0",
     "react-virtuoso": "^2.16.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13487,7 +13487,7 @@ react-markdown@^8.0.3:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
-react-player@^2.10.1:
+react-player@2.10.1:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.10.1.tgz#f2ee3ec31393d7042f727737545414b951ffc7e4"
   integrity sha512-ova0jY1Y1lqLYxOehkzbNEju4rFXYVkr5rdGD71nsiG4UKPzRXQPTd3xjoDssheoMNjZ51mjT5ysTrdQ2tEvsg==


### PR DESCRIPTION
### 🎯 Goal

It seems that react-player@2.11.1 has introduced a bug as reported in #1925. Therefore we are pinning to a working version of react-player@2.10.1.
