### PR TITLE
fix: make event optional for openThread in ChannelActionContext

### DIFF
--- a/src/context/ChannelActionContext.tsx
+++ b/src/context/ChannelActionContext.tsx
@@ -55,7 +55,10 @@ export type ChannelActionContextValue<
   loadMoreThread: () => Promise<void>;
   onMentionsClick: CustomMentionHandler<StreamChatGenerics>;
   onMentionsHover: CustomMentionHandler<StreamChatGenerics>;
-  openThread: (message: StreamMessage<StreamChatGenerics>, event: React.BaseSyntheticEvent) => void;
+  openThread: (
+    message: StreamMessage<StreamChatGenerics>,
+    event?: React.BaseSyntheticEvent,
+  ) => void;
   removeMessage: (message: StreamMessage<StreamChatGenerics>) => void;
   retrySendMessage: RetrySendMessage<StreamChatGenerics>;
   sendMessage: (


### PR DESCRIPTION
### 🎯 Goal

Adjust openThread definition in order the #1923 can work.

fix #1917