### PR TITLE
chore(deps): bump react-player from 2.10.1 to 2.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-image-gallery": "^1.2.7",
     "react-is": "^18.1.0",
     "react-markdown": "^8.0.3",
-    "react-player": "2.10.1",
+    "react-player": "2.11.0",
     "react-popper": "^2.3.0",
     "react-textarea-autosize": "^8.3.0",
     "react-virtuoso": "^2.16.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13487,10 +13487,10 @@ react-markdown@^8.0.3:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
-react-player@2.10.1:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.10.1.tgz#f2ee3ec31393d7042f727737545414b951ffc7e4"
-  integrity sha512-ova0jY1Y1lqLYxOehkzbNEju4rFXYVkr5rdGD71nsiG4UKPzRXQPTd3xjoDssheoMNjZ51mjT5ysTrdQ2tEvsg==
+react-player@2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.11.0.tgz#9afc75314eb915238e8d6615b2891fbe7170aeaa"
+  integrity sha512-fIrwpuXOBXdEg1FiyV9isKevZOaaIsAAtZy5fcjkQK9Nhmk1I2NXzY/hkPos8V0zb/ZX416LFy8gv7l/1k3a5w==
   dependencies:
     deepmerge "^4.0.0"
     load-script "^1.0.0"


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Currently 2.10.1 is broken and causes the following error:
```
./node_modules/react-player/es6/ReactPlayer.jsx
--
19:45:31.464 | Module parse failed: Unexpected token (140:8)
19:45:31.464 | You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
```

### 🛠 Implementation details

Update dependency in package.json and update yarn.lock file

### 🎨 UI Changes

None
