### PR TITLE
chore: use GITHUB_TOKEN to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn semantic-release


### PR DESCRIPTION
### 🎯 Goal

Authenticate the release on behalf of the user, who pushed the changes to master.

See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret