### PR TITLE
fix(emoji-mart): new reactions 

### DIFF
--- a/docusaurus/docs/React/_docusaurus-components/GHComponentLink.jsx
+++ b/docusaurus/docs/React/_docusaurus-components/GHComponentLink.jsx
@@ -1,7 +1,14 @@
 import React from 'react';
 
-const GHComponentLink = ({text, path}) => {
-  return <a target='_blank' href={`https://github.com/GetStream/stream-chat-react/blob/master/src/components${path}`}>{text}</a>
-}
+const GHComponentLink = ({ text, path, branch = 'master' }) => {
+  return (
+    <a
+      target='_blank'
+      href={`https://github.com/GetStream/stream-chat-react/blob/${branch}/src/components${path}`}
+    >
+      {text}
+    </a>
+  );
+};
 
 export default GHComponentLink;

--- a/docusaurus/docs/React/_docusaurus-components/GHComponentLink.jsx
+++ b/docusaurus/docs/React/_docusaurus-components/GHComponentLink.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-const GHComponentLink = ({ text, path, branch = 'master' }) => {
+const GHComponentLink = ({ text, as: As = React.Fragment, path, branch = 'master' }) => {
   return (
     <a
       target='_blank'
       href={`https://github.com/GetStream/stream-chat-react/blob/${branch}/src/components${path}`}
     >
-      {text}
+      <As>{text}</As>
     </a>
   );
 };

--- a/docusaurus/docs/React/components/message-components/reactions.mdx
+++ b/docusaurus/docs/React/components/message-components/reactions.mdx
@@ -7,26 +7,18 @@ title: Reactions
 import GHComponentLink from '../../_docusaurus-components/GHComponentLink';
 
 :::caution
-If you're moving from older versions to `11.0.0` then make sure to read ["New reactions" release guide](../../release-guides/new-reactions.mdx) to help you transition to the new implementation.
+If you're moving from older versions to `11.0.0` then make sure to read ["Reactions 11.0.0"](../../release-guides/reactions-v11.mdx) release guide to help you transition to the new implementation.
 :::
 
-The Stream Chat API provides built-in support for adding reactions to messages. The component library provides three default
-components to enable reaction selection and display:
+The Stream Chat API provides built-in support for adding reactions to messages. The component library provides three default components to enable reaction selection and display:
 
-- [`ReactionSelector`](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Reactions/ReactionSelector.tsx) - allows
-  the connected user to select a reaction on a message
-
-- [`ReactionsList`](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Reactions/ReactionsList.tsx) - displays
-  the reactions added to a message
-
-- [`SimpleReactionsList`](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Reactions/SimpleReactionsList.tsx) - displays
-  a minimal list of the reactions added to a message
+- [`ReactionSelector`](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Reactions/ReactionSelector.tsx) - allows the connected user to select a reaction on a message
+- [`ReactionsList`](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Reactions/ReactionsList.tsx) - displays the reactions added to a message
+- [`SimpleReactionsList`](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Reactions/SimpleReactionsList.tsx) - displays a minimal list of the reactions added to a message
 
 ## Basic Usage
 
-By default, the `ReactionSelector` and `ReactionsList` components are included within `MessageSimple`. To render reaction UI within a
-custom [Message UI](./message-ui.mdx) component, import both components (or `SimpleReactionsList` for a lightweight view) and render
-conditionally.
+By default, the `ReactionSelector` and `ReactionsList` components are included within `MessageSimple`. To render reaction UI within a custom [Message UI](./message-ui.mdx) component, import both components (or `SimpleReactionsList` for a lightweight view) and render conditionally.
 
 ```jsx
 const CustomMessage = () => {
@@ -61,17 +53,12 @@ Be default, the `ReactionSelector` component provides the following reaction opt
 - `sad`
 - `angry` - removed in `11.0.0`
 
-The `defaultMinimalEmojis` data set that populates the default reaction options can be found in the
-[emojiData](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Channel/emojiData.ts) file in the
-component library.
+The `defaultMinimalEmojis` data set that populates the default reaction options can be found in the <GHComponentLink as="code" text='emojiData' branch="v10.17.0" path='/Channel/emojiData.ts'/> file in the component library.
 
-To override the default selection set, provide your own array of `MinimalEmoji` type objects and pass into the `reactionOptions`
-prop on the `ReactionSelector` component. You can also override the default [handleReaction](./components/contexts/message-context.mdx#handlereaction)
-function by adding the `handleReaction` prop.
+To override the default selection set, provide your own array of `MinimalEmoji` type objects and pass into the `reactionOptions` prop on the `ReactionSelector` component. You can also override the default [`handleReaction`](../contexts/message-context.mdx#handlereaction) function by adding the `handleReaction` prop.
 
 :::caution
-If custom `reactionOptions` are supplied to the `ReactionSelector` component, then the same data set needs to be delivered to the
-`ReactionsList` component so the display for processed reactions has the same emoji objects.
+If custom `reactionOptions` are supplied to the `ReactionSelector` component, then the same data set needs to be delivered to the `ReactionsList` component so the display for processed reactions has the same emoji objects.
 :::
 
 ```jsx
@@ -109,8 +96,7 @@ const CustomMessage = () => {
 </Chat>;
 ```
 
-To completely override the `ReactionSelector` and `ReactionsList` components in `MessageSimple`, pass your own custom components as props
-to the [`Channel`](./components/core-components/channel.mdx).
+To completely override the `ReactionSelector` and `ReactionsList` components in `MessageSimple`, pass your own custom components as props to the [`Channel`](../core-components/channel.mdx).
 
 ```jsx
 const CustomReactionSelector = (props) => {
@@ -137,7 +123,7 @@ const CustomReactionsList = (props) => {
 
 ### additionalEmojiProps (removed in `11.0.0`)
 
-Additional props to be passed to the [NimbleEmoji](https://github.com/missive/emoji-mart/blob/master/src/components/emoji/nimble-emoji.js) component from `emoji-mart`.
+Additional props to be passed to the [`NimbleEmoji`](https://github.com/missive/emoji-mart/blob/v3.0.1/src/components/emoji/nimble-emoji.js) component from `emoji-mart`.
 
 | Type   |
 | ------ |
@@ -163,9 +149,9 @@ If true, shows the user's avatar with the reaction.
 
 Function that adds/removes a reaction on a message (overrides the function stored in `MessageContext`).
 
-| Type                                                                      | Default                                                                                           |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| (reactionType: string, event: React.BaseSyntheticEvent) => Promise<void\> | [MessageContextValue['handleReaction']](./components/contexts/message-context.mdx#handlereaction) |
+| Type                                                                      | Default                                                                                 |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| (reactionType: string, event: React.BaseSyntheticEvent) => Promise<void\> | [MessageContextValue['handleReaction']](../contexts/message-context.mdx#handlereaction) |
 
 ### latest_reactions
 
@@ -197,7 +183,7 @@ A list of the currently supported reactions on a message.
 
 | Version | Type  | Default                                                                                                        |
 | ------- | ----- | -------------------------------------------------------------------------------------------------------------- |
-| >=4.0.0 | array | <GHComponentLink text='defaultMinimalEmojis' path='/Channel/emojiData.ts'/>                                    |
+| >=4.0.0 | array | <GHComponentLink text='defaultMinimalEmojis' branch="v10.17.0" path='/Channel/emojiData.ts'/>                  |
 | ^11.0.0 | array | <GHComponentLink text='defaultReactionOptions' branch="feat/reactions" path='/Reactions/reactionOptions.tsx'/> |
 
 ### reverse
@@ -212,7 +198,7 @@ If true, adds a CSS class that reverses the horizontal positioning of the select
 
 ### additionalEmojiProps (removed in `11.0.0`)
 
-Additional props to be passed to the [NimbleEmoji](https://github.com/missive/emoji-mart/blob/master/src/components/emoji/nimble-emoji.js) component from `emoji-mart`.
+Additional props to be passed to the [`NimbleEmoji`](https://github.com/missive/emoji-mart/blob/v3.0.1/src/components/emoji/nimble-emoji.js) component from `emoji-mart`.
 
 | Type   |
 | ------ |
@@ -222,9 +208,9 @@ Additional props to be passed to the [NimbleEmoji](https://github.com/missive/em
 
 Custom on click handler for an individual reaction in the list (overrides the function stored in `MessageContext`).
 
-| Type                                                        | Default                                                                                                     |
-| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| (event: React.BaseSyntheticEvent) => Promise<void\> \| void | [MessageContextValue['onReactionListClick']](./components/contexts/message-context.mdx#onreactionlistclick) |
+| Type                                                        | Default                                                                                           |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| (event: React.BaseSyntheticEvent) => Promise<void\> \| void | [MessageContextValue['onReactionListClick']](../contexts/message-context.mdx#onreactionlistclick) |
 
 ### own_reactions
 
@@ -248,7 +234,7 @@ A list of the currently supported reactions on a message.
 
 | Version | Type  | Default                                                                                                        |
 | ------- | ----- | -------------------------------------------------------------------------------------------------------------- |
-| >=4.0.0 | array | <GHComponentLink text='defaultMinimalEmojis' path='/Channel/emojiData.ts'/>                                    |
+| >=4.0.0 | array | <GHComponentLink text='defaultMinimalEmojis' branch="v10.17.0" path='/Channel/emojiData.ts'/>                  |
 | ^11.0.0 | array | <GHComponentLink text='defaultReactionOptions' branch="feat/reactions" path='/Reactions/reactionOptions.tsx'/> |
 
 ### reactions
@@ -271,7 +257,7 @@ If true, adds a CSS class that reverses the horizontal positioning of the select
 
 ### additionalEmojiProps (removed in `11.0.0`)
 
-Additional props to be passed to the [NimbleEmoji](https://github.com/missive/emoji-mart/blob/master/src/components/emoji/nimble-emoji.js) component from `emoji-mart`.
+Additional props to be passed to the [`NimbleEmoji`](https://github.com/missive/emoji-mart/blob/v3.0.1/src/components/emoji/nimble-emoji.js) component from `emoji-mart`.
 
 | Type   |
 | ------ |
@@ -281,9 +267,9 @@ Additional props to be passed to the [NimbleEmoji](https://github.com/missive/em
 
 Function that adds/removes a reaction on a message (overrides the function stored in `MessageContext`).
 
-| Type                                                                      | Default                                                                                           |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| (reactionType: string, event: React.BaseSyntheticEvent) => Promise<void\> | [MessageContextValue['handleReaction']](./components/contexts/message-context.mdx#handlereaction) |
+| Type                                                                      | Default                                                                                 |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| (reactionType: string, event: React.BaseSyntheticEvent) => Promise<void\> | [MessageContextValue['handleReaction']](../contexts/message-context.mdx#handlereaction) |
 
 ### own_reactions
 
@@ -307,7 +293,7 @@ A list of the currently supported reactions on a message.
 
 | Version | Type  | Default                                                                                                        |
 | ------- | ----- | -------------------------------------------------------------------------------------------------------------- |
-| >=4.0.0 | array | <GHComponentLink text='defaultMinimalEmojis' path='/Channel/emojiData.ts'/>                                    |
+| >=4.0.0 | array | <GHComponentLink text='defaultMinimalEmojis' branch="v10.17.0" path='/Channel/emojiData.ts'/>                  |
 | ^11.0.0 | array | <GHComponentLink text='defaultReactionOptions' branch="feat/reactions" path='/Reactions/reactionOptions.tsx'/> |
 
 ### reactions

--- a/docusaurus/docs/React/components/message-components/reactions.mdx
+++ b/docusaurus/docs/React/components/message-components/reactions.mdx
@@ -6,6 +6,10 @@ title: Reactions
 
 import GHComponentLink from '../../_docusaurus-components/GHComponentLink';
 
+:::caution
+If you're moving from older versions to `11.0.0` then make sure to read ["New reactions" release guide](../../release-guides/new-reactions.mdx) to help you transition to the new implementation.
+:::
+
 The Stream Chat API provides built-in support for adding reactions to messages. The component library provides three default
 components to enable reaction selection and display:
 
@@ -55,7 +59,7 @@ Be default, the `ReactionSelector` component provides the following reaction opt
 - `haha`
 - `wow`
 - `sad`
-- `angry`
+- `angry` - removed in `11.0.0`
 
 The `defaultMinimalEmojis` data set that populates the default reaction options can be found in the
 [emojiData](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Channel/emojiData.ts) file in the
@@ -131,7 +135,7 @@ const CustomReactionsList = (props) => {
 
 ## ReactionSelector Props
 
-### additionalEmojiProps
+### additionalEmojiProps (removed in `11.0.0`)
 
 Additional props to be passed to the [NimbleEmoji](https://github.com/missive/emoji-mart/blob/master/src/components/emoji/nimble-emoji.js) component from `emoji-mart`.
 
@@ -191,9 +195,10 @@ An object that keeps track of the count of each type of reaction on a message (o
 
 A list of the currently supported reactions on a message.
 
-| Type  | Default                                                                     |
-| ----- | --------------------------------------------------------------------------- |
-| array | <GHComponentLink text='defaultMinimalEmojis' path='/Channel/emojiData.ts'/> |
+| Version | Type  | Default                                                                                                        |
+| ------- | ----- | -------------------------------------------------------------------------------------------------------------- |
+| >=4.0.0 | array | <GHComponentLink text='defaultMinimalEmojis' path='/Channel/emojiData.ts'/>                                    |
+| ^11.0.0 | array | <GHComponentLink text='defaultReactionOptions' branch="feat/reactions" path='/Reactions/reactionOptions.tsx'/> |
 
 ### reverse
 
@@ -205,7 +210,7 @@ If true, adds a CSS class that reverses the horizontal positioning of the select
 
 ## ReactionsList Props
 
-### additionalEmojiProps
+### additionalEmojiProps (removed in `11.0.0`)
 
 Additional props to be passed to the [NimbleEmoji](https://github.com/missive/emoji-mart/blob/master/src/components/emoji/nimble-emoji.js) component from `emoji-mart`.
 
@@ -241,9 +246,10 @@ An object that keeps track of the count of each type of reaction on a message (o
 
 A list of the currently supported reactions on a message.
 
-| Type  | Default                                                                     |
-| ----- | --------------------------------------------------------------------------- |
-| array | <GHComponentLink text='defaultMinimalEmojis' path='/Channel/emojiData.ts'/> |
+| Version | Type  | Default                                                                                                        |
+| ------- | ----- | -------------------------------------------------------------------------------------------------------------- |
+| >=4.0.0 | array | <GHComponentLink text='defaultMinimalEmojis' path='/Channel/emojiData.ts'/>                                    |
+| ^11.0.0 | array | <GHComponentLink text='defaultReactionOptions' branch="feat/reactions" path='/Reactions/reactionOptions.tsx'/> |
 
 ### reactions
 
@@ -263,7 +269,7 @@ If true, adds a CSS class that reverses the horizontal positioning of the select
 
 ## SimpleReactionsList Props
 
-### additionalEmojiProps
+### additionalEmojiProps (removed in `11.0.0`)
 
 Additional props to be passed to the [NimbleEmoji](https://github.com/missive/emoji-mart/blob/master/src/components/emoji/nimble-emoji.js) component from `emoji-mart`.
 
@@ -299,9 +305,10 @@ An object that keeps track of the count of each type of reaction on a message (o
 
 A list of the currently supported reactions on a message.
 
-| Type  | Default                                                                     |
-| ----- | --------------------------------------------------------------------------- |
-| array | <GHComponentLink text='defaultMinimalEmojis' path='/Channel/emojiData.ts'/> |
+| Version | Type  | Default                                                                                                        |
+| ------- | ----- | -------------------------------------------------------------------------------------------------------------- |
+| >=4.0.0 | array | <GHComponentLink text='defaultMinimalEmojis' path='/Channel/emojiData.ts'/>                                    |
+| ^11.0.0 | array | <GHComponentLink text='defaultReactionOptions' branch="feat/reactions" path='/Reactions/reactionOptions.tsx'/> |
 
 ### reactions
 

--- a/docusaurus/docs/React/guides/theming/reactions.mdx
+++ b/docusaurus/docs/React/guides/theming/reactions.mdx
@@ -7,6 +7,10 @@ title: Reaction Selector and List
 import CustomReactionSelector from '../../assets/CustomReactionSelector.png';
 import CustomReactionsList from '../../assets/CustomReactionsList.png';
 
+:::caution
+If you're moving from older versions to `11.0.0` then make sure to read ["Reactions 11.0.0"](../../release-guides/reactions-v11.mdx) release guide to help you transition to the new implementation.
+:::
+
 In this example, we will demonstrate how to override the library's default reaction set, which can be found stored as the
 [`defaultMinimalEmojis`](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Channel/emojiData.ts)
 variable. We will replace the default set with up and down arrows, simulating an up/down voting feature.
@@ -14,8 +18,8 @@ variable. We will replace the default set with up and down arrows, simulating an
 ### Choose Your Reactions
 
 Under the hood, our `ReactionSelector`, `ReactionsList`, and `SimpleReactionsList` components render individual emoji objects
-using the [`NimbleEmoji`](https://github.com/missive/emoji-mart/blob/master/src/components/emoji/nimble-emoji.js) component
-from [emoji-mart](https://www.npmjs.com/package/emoji-mart). Therefore, the object type of our custom reactions needs to
+using the [`NimbleEmoji`](https://github.com/missive/emoji-mart/blob/v3.0.1/src/components/emoji/nimble-emoji.js) component
+from [`emoji-mart`](https://www.npmjs.com/package/emoji-mart). Therefore, the object type of our custom reactions needs to
 conform to `NimbleEmoji` props.
 
 `NimbleEmoji` accepts an `emoji` prop, which pertains to the object mapping of your custom reaction. The `emoji` prop has
@@ -107,15 +111,12 @@ const customReactions = [
 ```
 
 :::caution
-If custom `reactionOptions` are supplied to the selector component, then the same data set needs to be delivered to the
-list component so the display for processed reactions has the same emoji objects.
+If custom `reactionOptions` are supplied to the selector component, then the same data set needs to be delivered to the list component so the display for processed reactions has the same emoji objects.
 :::
 
 ### The Final Code
 
-Putting all the pieces together and building upon the [custom message](./message-ui.mdx#how-it-fits-together)
-in the General Customization section, we are left with the following code for our [Message UI](../../components/message-components/message-ui.mdx)
-component:
+Putting all the pieces together and building upon the [custom message](./message-ui.mdx#how-it-fits-together) in the General Customization section, we are left with the following code for our [Message UI](../../components/message-components/message-ui.mdx) component:
 
 ```jsx
 import React, { useRef } from 'react';
@@ -186,9 +187,7 @@ export const CustomMessage = () => {
         <MessageText />
         <MessageStatus />
         {message.attachments && <Attachment attachments={message.attachments} />}
-        {hasReactions && (
-          <SimpleReactionsList reactionOptions={customReactions} />
-        )}
+        {hasReactions && <SimpleReactionsList reactionOptions={customReactions} />}
         <MessageRepliesCountButton reply_count={message.reply_count} />
       </div>
     </div>

--- a/docusaurus/docs/React/release-guides/new-reactions.mdx
+++ b/docusaurus/docs/React/release-guides/new-reactions.mdx
@@ -1,0 +1,244 @@
+---
+id: new-reactions
+sidebar_position: 2
+title: New reactions (11.0.0)
+keywords: [migration guide, upgrade, reactions, breaking changes, v11]
+---
+
+import GHComponentLink from '../_docusaurus-components/GHComponentLink';
+
+## Introducing new reactions (with breaking changes)
+
+When it came to developer experience regarding customization of the reaction components our team noticed that our integrators generally strugled to make more advanced adjustments to reactions without having to rebuild the whole [component set](../components/message-components/reactions.mdx). The whole process has been quite unintuitive and that's why this update aims at making adjusting your reactions much easier.
+
+### Main reasons for a revamp
+
+- inability to reuse default (Stream supplied reactions) with your custom ones
+- strong reliance on [`EmojiMart`](https://github.com/missive/emoji-mart) and inability to use completely custom reactions out of the box
+- certain `additionalEmojiProps` did not work with Stream-supplied reactions
+
+```tsx
+// not exported directly (hidden, leading to poor DX)
+import { defaultMinimalEmojis } from 'stream-chat-react/dist/components/Channel/emojiData';
+
+export const customReactions = [
+  {
+    // relies on EmojiMart-supplied sprite sheet, "native" option does not work for Stream-supplied reactions
+    // you'd need to look up supported id's in stream-emoji.json under "emojis" key
+    id: 'bulb',
+  },
+  // unsupported
+  {
+    id: 'rick_roll',
+  },
+  // this wouldn't work
+  ...defaultMinimalEmojis,
+];
+```
+
+## New default setup and how it works
+
+SDK by default comes with five pre-defined reaction types (`haha`, `like`, `love`, `sad` and `wow`) which are newly rendered by <GHComponentLink text='StreamEmoji' branch="feat/reactions" path='/Reactions/StreamEmoji.tsx'/> component which utilises sprite sheet system and renders images for each reaction to make sure it works flawlessly on every system. Default reaction options are defined in <GHComponentLink text='defaultReactionOptions' branch="feat/reactions" path='/Reactions/reactionOptions.tsx'/> and these options are reused for both [`ReactionSelector`](../components/message-components/reactions.mdx) and [`ReactionsList`](../components/message-components/reactions.mdx) (as well as [`SimpleReactionsList`](../components/message-components/reactions.mdx)). These options come by default from the ComponentContext but local component property will be prioritised if defined. This is how it works under the hood:
+
+```ts
+contextReactionOptions = defaultReactionOptions;
+// ...
+const reactionOptions = propsReactionOptions ?? contextReactionOptions;
+```
+
+:::note
+Beware that sixth reaction type `angry` has been removed in this update, if you need to re-enable it, follow [this guide](#re-enabling-angry-reaction).
+:::
+
+## Custom reaction types and components
+
+It's possible to supply your own reaction types and components to represent such reactions - let's implement reaction of type `rick_roll` to render a Rick Roll GIF and define override for default type `love`:
+
+```tsx
+import { Channel } from 'stream-chat-react';
+
+const RickRollReaction = () => (
+  <img src='https://media.tenor.com/x8v1oNUOmg4AAAAM/rickroll-roll.gif' style={{ height: 20 }} />
+);
+
+const customReactionOptions = [
+  {
+    Component: RickRollReaction,
+    type: 'rick_roll',
+    name: 'Rick Roll',
+  },
+  {
+    Component: () => <>❤️</>
+    type: 'love',
+    name: "Heart"
+  }
+];
+```
+
+And then you can pass these newly created options to [`Channel`](../components/core-components/channel) component which will be then propagated to `ReactionSelector` and `ReactionsList`:
+
+```tsx
+<Channel reactionOptions={customReactionOptions}>{/*...*/}</Channel>
+```
+
+## EmojiMart integration
+
+If you're used to work with EmojiMart then integrating with new reaction system shouldn't be a big trouble as you can define how your components look and reach for context if you need to:
+
+```tsx
+// arbitrary EmojiMartContext (does not come with the SDK)
+import { useEmojiMartContext } from '../contexts';
+
+const CustomLikeComponent = () => {
+  const { selectedSkinTones, selectedSet } = useEmojiMartContext();
+
+  return <em-emoji id='+1' set={selectedSet} skin={selectedSkinTones['+1']} />;
+};
+
+const reactionOptions = [
+  {
+    type: 'like',
+    component: CustomLikeComponent,
+    name: 'EmojiMart like',
+  },
+];
+
+// pass reaction options to component context (Channel) or to ReactionSelector and ReactionsList
+```
+
+## Use of different reaction components for the same reaction types for `ReactionSelector` and `ReactionsList` components
+
+If you need more fine-grain tuning and want to - for example - enable only a certain subset of clickable reactions but want to display the full set then you'd do something like this:
+
+```tsx
+const JoyReaction = () => <>😂</>;
+const CatReaction = () => <>🐈</>;
+const ThumbsUpReaction = () => <>👍</>;
+const SmileReaction = () => <>🙂</>;
+
+// subset of clickable options available to the user
+const selectedReactionOptions = [
+  { type: 'haha', Component: JoyReaction },
+  { type: 'cat', Component: CatReaction },
+];
+
+// set of all available options to be rendered
+const completeReactionOptions = [
+  { type: 'haha', Component: JoyReaction },
+  { type: 'cat', Component: CatReaction },
+  { type: '+1', Component: ThumbsUpReaction },
+  { type: 'smile', Component: SmileReaction },
+];
+```
+
+Or if you just want bigger icons for `ReactionsList` while `ReactionSelector` uses regular:
+
+```tsx
+// arbitrary import (does not come with the SDK)
+import { ReactionComponent } from './CustomReactions';
+
+const selectorReactionOptions = [
+  {
+    type: 'like',
+    component: ReactionComponent.Like,
+    name: 'Like',
+  },
+];
+
+const listReactionOptions = [
+  {
+    type: 'like',
+    // in this example it's just different size of the emoji
+    component: ReactionComponent.LikeMedium,
+    name: 'Like medium',
+  },
+];
+```
+
+You can then apply these new options to `ReactionSelector` and `ReactionsList` directly:
+
+```tsx
+import { ReactionSelector, ReactionsList, Channel } from 'stream-chat-react';
+
+// ReactionSelector component requires forwarded reference
+const CustomReactionSelector = forwardRef((props, ref) => (
+  <ReactionSelector {...props} ref={ref} reactionOptions={selectorReactionOptions} />
+));
+
+const CustomReactionsList = (props) => (
+  <ReactionsList {...props} reactionOptions={listReactionOptions} />
+);
+```
+
+And then pass them down to component context (`Channel`) component:
+
+```tsx
+<Channel ReactionSelector={CustomReactionSelector} ReactionsList={CustomReactionsList}>
+  {/*...*/}
+</Channel>
+```
+
+## Use of `SpriteImage` component
+
+:::note
+We suggest using individual images per reaction type as multiple smaller requests is more bandwidth-friendly. Use this component only if you have no other choice.
+:::
+
+If you have a sprite sheet of emojis and there's no other way for you to implement your reactions, you can utilise <GHComponentLink text='SpriteImage' branch="feat/reactions" path='/Reactions/SpriteImage.tsx'/> utility component which comes with the SDK:
+
+```tsx
+import { SpriteImage } from 'stream-chat-react';
+
+const SPRITE_URL = 'https://getstream.imgix.net/images/emoji-sprite.png';
+
+const reactionOptions = [
+  {
+    type: 'joy',
+    component: () => (
+      <SpriteImage columns={2} rows={3} spriteUrl={SPRITE_URL} position={[0, 1]} fallback='😂' />
+    ), // renders fallback initially and then image when it successfully loads
+    name: 'ROFL',
+  },
+];
+
+// pass reaction options to component context (Channel) or to ReactionSelector and ReactionsList
+```
+
+## Transition from previous version of custom reactions
+
+### Default setup
+
+The transition is super easy:
+
+```tsx
+import { defaultReactionOptions } from 'stream-chat-react';
+
+// old custom options
+const reactionOptions = [{ id: 'bulb' /* ...extra properties... */ }, { id: '+1' }, { id: 'joy' }];
+
+// would newly become
+const newReactionOptions = [
+  { type: 'bulb', Component: () => <>💡</>, name: 'Bulb reaction' },
+  { type: '+1', Component: () => <>👍</> },
+  { type: 'joy', Component: () => <>🤣</>, name: 'ROFL' },
+  // reuse default ones if you want to
+  ...defaultReactionOptions,
+];
+```
+
+All of the extra options previously applied to `EmojiMart` emojis can now be directly applied to your custom components either manually or through your custom context. For more information see [EmojiMart integration](#emojimart-integration).
+
+### Re-enabling `angry` reaction
+
+For better compatibility with other SDKs we decided to consolidate default available types and remove `angry` type which was previously available only in the React SDK. Here's how you'd go about re-enabling it:
+
+```tsx
+import { StreamEmoji, defaultReactionOptions } from 'stream-chat-react';
+
+const reactionOptions = [
+  ...defaultReactionOptions,
+  { type: 'angry', Component: () => <StreamEmoji fallback='😠' type='angry' />, name: 'Angry' },
+];
+
+// pass reaction options to component context (Channel) or to ReactionSelector and ReactionsList
+```

--- a/docusaurus/docs/React/release-guides/new-reactions.mdx
+++ b/docusaurus/docs/React/release-guides/new-reactions.mdx
@@ -83,7 +83,7 @@ And then you can pass these newly created options to [`Channel`](../components/c
 
 ## EmojiMart integration
 
-If you're used to work with EmojiMart then integrating with new reaction system shouldn't be a big trouble as you can define how your components look and reach for context if you need to:
+If you're used to work with [EmojiMart emojis](https://github.com/missive/emoji-mart#-emoji-component) then integrating with new reaction system shouldn't be a big trouble as you can define how your components look and reach for context if you need to:
 
 ```tsx
 // arbitrary EmojiMartContext (does not come with the SDK)
@@ -92,6 +92,7 @@ import { useEmojiMartContext } from '../contexts';
 const CustomLikeComponent = () => {
   const { selectedSkinTones, selectedSet } = useEmojiMartContext();
 
+  // to use EmojiMart web components you'll need to go through initiation steps, see EmojiMart documentation
   return <em-emoji id='+1' set={selectedSet} skin={selectedSkinTones['+1']} />;
 };
 

--- a/docusaurus/docs/React/release-guides/reactions-v11.mdx
+++ b/docusaurus/docs/React/release-guides/reactions-v11.mdx
@@ -1,7 +1,7 @@
 ---
-id: new-reactions
+id: reactions-v11
 sidebar_position: 2
-title: New reactions (11.0.0)
+title: Reactions 11.0.0
 keywords: [migration guide, upgrade, reactions, breaking changes, v11]
 ---
 
@@ -81,7 +81,7 @@ And then you can pass these newly created options to [`Channel`](../components/c
 <Channel reactionOptions={customReactionOptions}>{/*...*/}</Channel>
 ```
 
-## EmojiMart integration
+## Emoji Mart integration
 
 If you're used to work with [EmojiMart emojis](https://github.com/missive/emoji-mart#-emoji-component) then integrating with new reaction system shouldn't be a big trouble as you can define how your components look and reach for context if you need to:
 
@@ -196,8 +196,15 @@ const reactionOptions = [
   {
     type: 'joy',
     component: () => (
-      <SpriteImage columns={2} rows={3} spriteUrl={SPRITE_URL} position={[0, 1]} fallback='😂' />
-    ), // renders fallback initially and then image when it successfully loads
+      // renders fallback initially and then image when it successfully loads
+      <SpriteImage
+        columns={2} // number of spritesheet columns
+        rows={3} // number of spritesheet rows
+        spriteUrl={SPRITE_URL} // source URL of the spritesheet
+        position={[0, 1]} // x and y axis positions, zero indexed
+        fallback='😂' // native emoji (or any string) to render while the sprite image is loading
+      />
+    ),
     name: 'ROFL',
   },
 ];

--- a/docusaurus/docs/React/release-guides/reactions-v11.mdx
+++ b/docusaurus/docs/React/release-guides/reactions-v11.mdx
@@ -14,7 +14,7 @@ When it came to developer experience regarding customization of the reaction com
 ### Main reasons for a revamp
 
 - inability to reuse default (Stream supplied reactions) with your custom ones
-- strong reliance on [`EmojiMart`](https://github.com/missive/emoji-mart) and inability to use completely custom reactions out of the box
+- strong reliance on [`emoji-mart`](https://github.com/missive/emoji-mart) and inability to use completely custom reactions out of the box
 - certain `additionalEmojiProps` did not work with Stream-supplied reactions
 
 ```tsx
@@ -38,7 +38,7 @@ export const customReactions = [
 
 ## New default setup and how it works
 
-SDK by default comes with five pre-defined reaction types (`haha`, `like`, `love`, `sad` and `wow`) which are newly rendered by <GHComponentLink text='StreamEmoji' branch="feat/reactions" path='/Reactions/StreamEmoji.tsx'/> component which utilises sprite sheet system and renders images for each reaction to make sure it works flawlessly on every system. Default reaction options are defined in <GHComponentLink text='defaultReactionOptions' branch="feat/reactions" path='/Reactions/reactionOptions.tsx'/> and these options are reused for both [`ReactionSelector`](../components/message-components/reactions.mdx) and [`ReactionsList`](../components/message-components/reactions.mdx) (as well as [`SimpleReactionsList`](../components/message-components/reactions.mdx)). These options come by default from the ComponentContext but local component property will be prioritised if defined. This is how it works under the hood:
+SDK by default comes with five pre-defined reaction types (`haha`, `like`, `love`, `sad` and `wow`) which are newly rendered by <GHComponentLink text='StreamEmoji' branch="feat/reactions" path='/Reactions/StreamEmoji.tsx'/> component which utilises sprite sheet system and renders images for each reaction to make sure it works flawlessly on every system. Default reaction options are defined in <GHComponentLink text='defaultReactionOptions' branch="feat/reactions" path='/Reactions/reactionOptions.tsx'/> and these options are reused for both [`ReactionSelector`](../components/message-components/reactions.mdx#reactionselector-props) and [`ReactionsList`](../components/message-components/reactions.mdx#reactionslist-props) (as well as [`SimpleReactionsList`](../components/message-components/reactions.mdx#simplereactionslist-props)). These options come by default from the ComponentContext but local component property will be prioritised if defined. This is how it works under the hood:
 
 ```ts
 contextReactionOptions = defaultReactionOptions;
@@ -75,7 +75,7 @@ const customReactionOptions = [
 ];
 ```
 
-And then you can pass these newly created options to [`Channel`](../components/core-components/channel) component which will be then propagated to `ReactionSelector` and `ReactionsList`:
+And then you can pass these newly created options to [`Channel`](../components/core-components/channel.mdx) component which will be then propagated to `ReactionSelector` and `ReactionsList`:
 
 ```tsx
 <Channel reactionOptions={customReactionOptions}>{/*...*/}</Channel>
@@ -234,7 +234,7 @@ const newReactionOptions = [
 ];
 ```
 
-All of the extra options previously applied to `EmojiMart` emojis can now be directly applied to your custom components either manually or through your custom context. For more information see [EmojiMart integration](#emojimart-integration).
+All of the extra options previously applied to `EmojiMart` emojis can now be directly applied to your custom components either manually or through your custom context. For more information see [EmojiMart integration](#emoji-mart-integration).
 
 ### Re-enabling `angry` reaction
 

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -186,8 +186,6 @@ type ChannelPropsForwardedToComponentContext<
 };
 
 type ChannelPropsForwardedToEmojiContext = {
-  /** Custom UI component to override default `NimbleEmoji` from `emoji-mart` */
-  Emoji?: EmojiContextValue['Emoji'];
   /** Custom prop to override default `facebook.json` emoji data set from `emoji-mart` */
   emojiData?: EmojiMartData;
   /** Custom UI component to override default `NimbleEmojiIndex` from `emoji-mart` */
@@ -1059,7 +1057,6 @@ const ChannelInner = <
 
   const emojiContextValue: EmojiContextValue = useMemo(
     () => ({
-      Emoji: props.Emoji,
       emojiConfig,
       EmojiIndex: props.EmojiIndex,
       EmojiPicker: props.EmojiPicker,

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -93,6 +93,10 @@ import {
   getVideoAttachmentConfiguration,
 } from '../Attachment/attachment-sizing';
 import type { URLEnrichmentConfig } from '../MessageInput/hooks/useLinkPreviews';
+import {
+  defaultReactionOptions,
+  ReactionOptions,
+} from '../../components/Reactions/reactionOptions';
 
 type ChannelPropsForwardedToComponentContext<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
@@ -159,6 +163,8 @@ type ChannelPropsForwardedToComponentContext<
   QuotedMessage?: ComponentContextValue<StreamChatGenerics>['QuotedMessage'];
   /** Custom UI component to override the message input's quoted message preview, defaults to and accepts same props as: [QuotedMessagePreview](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageInput/QuotedMessagePreview.tsx) */
   QuotedMessagePreview?: ComponentContextValue<StreamChatGenerics>['QuotedMessagePreview'];
+  /** Custom reaction options to be applied to ReactionSelector, ReactionList and SimpleReactionList components */
+  reactionOptions?: ReactionOptions;
   /** Custom UI component to display the reaction selector, defaults to and accepts same props as: [ReactionSelector](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Reactions/ReactionSelector.tsx) */
   ReactionSelector?: ComponentContextValue<StreamChatGenerics>['ReactionSelector'];
   /** Custom UI component to display the list of reactions on a message, defaults to and accepts same props as: [ReactionsList](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Reactions/ReactionsList.tsx) */
@@ -1037,6 +1043,7 @@ const ChannelInner = <
       PinIndicator: props.PinIndicator,
       QuotedMessage: props.QuotedMessage,
       QuotedMessagePreview: props.QuotedMessagePreview,
+      reactionOptions: props.reactionOptions ?? defaultReactionOptions,
       ReactionSelector: props.ReactionSelector,
       ReactionsList: props.ReactionsList,
       SendButton: props.SendButton,
@@ -1047,7 +1054,7 @@ const ChannelInner = <
       TypingIndicator: props.TypingIndicator,
       VirtualMessage: props.VirtualMessage,
     }),
-    [],
+    [props.reactionOptions],
   );
 
   const emojiContextValue: EmojiContextValue = useMemo(

--- a/src/components/Channel/__tests__/Channel.test.js
+++ b/src/components/Channel/__tests__/Channel.test.js
@@ -548,20 +548,15 @@ describe('Channel', () => {
         emojis: {},
       };
       const CustomEmojiPicker = () => <div />;
-      const CustomEmoji = () => <span />;
 
-      renderComponent(
-        { channel, chatClient, Emoji: CustomEmoji, emojiData, EmojiPicker: CustomEmojiPicker },
-        (ctx) => {
-          context = ctx;
-        },
-      );
+      renderComponent({ channel, chatClient, emojiData, EmojiPicker: CustomEmojiPicker }, (ctx) => {
+        context = ctx;
+      });
 
       await waitFor(() => {
         expect(context).toBeInstanceOf(Object);
         expect(context.emojiConfig.emojiData).toBe(emojiData);
         expect(context.EmojiPicker).toBe(CustomEmojiPicker);
-        expect(context.Emoji).toBe(CustomEmoji);
       });
     });
 

--- a/src/components/Message/__tests__/MessageSimple.test.js
+++ b/src/components/Message/__tests__/MessageSimple.test.js
@@ -19,18 +19,16 @@ import { EditMessageForm, MessageInput as MessageInputMock } from '../../Message
 import { getReadStates } from '../../MessageList';
 import { MML as MMLMock } from '../../MML';
 import { Modal as ModalMock } from '../../Modal';
+import { defaultReactionOptions } from '../../Reactions';
 
 import {
   ChannelActionProvider,
   ChannelStateProvider,
   ChatProvider,
   ComponentProvider,
-  EmojiProvider,
   TranslationProvider,
 } from '../../../context';
 import {
-  emojiComponentMock,
-  emojiDataMock,
   generateChannel,
   generateMessage,
   generateReaction,
@@ -75,9 +73,7 @@ async function renderMessageSimple({
 
   return renderer(
     <ChatProvider value={{ client, themeVersion: '1' }}>
-      <ChannelStateProvider
-        value={{ channel, channelCapabilities, channelConfig, emojiConfig: emojiDataMock }}
-      >
+      <ChannelStateProvider value={{ channel, channelCapabilities, channelConfig }}>
         <ChannelActionProvider
           value={{ openThread: openThreadMock, retrySendMessage: retrySendMessageMock }}
         >
@@ -87,25 +83,17 @@ async function renderMessageSimple({
                 Attachment: AttachmentMock,
                 // eslint-disable-next-line react/display-name
                 Message: () => <MessageSimple {...props} />,
+                reactionOptions: defaultReactionOptions,
                 ...components,
               }}
             >
-              <EmojiProvider
-                value={{
-                  Emoji: emojiComponentMock.Emoji,
-                  emojiConfig: emojiDataMock,
-                  EmojiIndex: emojiComponentMock.EmojiIndex,
-                  EmojiPicker: emojiComponentMock.EmojiPicker,
-                }}
-              >
-                <Message
-                  getMessageActions={() => Object.keys(MESSAGE_ACTIONS)}
-                  isMyMessage={() => true}
-                  message={message}
-                  threadList={false}
-                  {...props}
-                />
-              </EmojiProvider>
+              <Message
+                getMessageActions={() => Object.keys(MESSAGE_ACTIONS)}
+                isMyMessage={() => true}
+                message={message}
+                threadList={false}
+                {...props}
+              />
             </ComponentProvider>
           </TranslationProvider>
         </ChannelActionProvider>

--- a/src/components/Message/__tests__/MessageText.test.js
+++ b/src/components/Message/__tests__/MessageText.test.js
@@ -25,6 +25,7 @@ import {
 } from '../../../mock-builders';
 
 import { Attachment } from '../../Attachment';
+import { defaultReactionOptions } from '../../Reactions';
 import { Message } from '../Message';
 import { MessageOptions as MessageOptionsMock } from '../MessageOptions';
 import { MessageSimple } from '../MessageSimple';
@@ -89,6 +90,7 @@ async function renderMessageText({
                 Emoji: EmojiComponentMock,
                 // eslint-disable-next-line react/display-name
                 Message: () => <MessageSimple channelConfig={channelConfig} />,
+                reactionOptions: defaultReactionOptions,
               }}
             >
               <EmojiProvider value={{ emojiConfig: emojiDataMock }}>

--- a/src/components/Reactions/ReactionSelector.tsx
+++ b/src/components/Reactions/ReactionSelector.tsx
@@ -11,7 +11,7 @@ import { useMessageContext } from '../../context/MessageContext';
 import type { ReactionResponse } from 'stream-chat';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
-import { defaultReactionOptions, ReactionOptions } from './reactionOptions';
+import type { ReactionOptions } from './reactionOptions';
 
 export type ReactionSelectorProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
@@ -46,15 +46,20 @@ const UnMemoizedReactionSelector = React.forwardRef(
       latest_reactions: propLatestReactions,
       own_reactions: propOwnReactions,
       reaction_counts: propReactionCounts,
-      reactionOptions = defaultReactionOptions,
+      reactionOptions: propReactionOptions,
       reverse = false,
     } = props;
 
-    const { Avatar: contextAvatar } = useComponentContext<StreamChatGenerics>('ReactionSelector');
+    const {
+      Avatar: contextAvatar,
+      reactionOptions: contextReactionOptions,
+    } = useComponentContext<StreamChatGenerics>('ReactionSelector');
     const {
       handleReaction: contextHandleReaction,
       message,
     } = useMessageContext<StreamChatGenerics>('ReactionSelector');
+
+    const reactionOptions = propReactionOptions ?? contextReactionOptions;
 
     const Avatar = propAvatar || contextAvatar || DefaultAvatar;
     const handleReaction = propHandleReaction || contextHandleReaction;

--- a/src/components/Reactions/ReactionSelector.tsx
+++ b/src/components/Reactions/ReactionSelector.tsx
@@ -1,25 +1,21 @@
-import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import { isMutableRef } from './utils/utils';
 
 import { AvatarProps, Avatar as DefaultAvatar } from '../Avatar';
-import { getStrippedEmojiData, ReactionEmoji } from '../Channel/emojiData';
 
 import { useComponentContext } from '../../context/ComponentContext';
-import { useEmojiContext } from '../../context/EmojiContext';
 import { useMessageContext } from '../../context/MessageContext';
 
-import type { NimbleEmojiProps } from 'emoji-mart';
 import type { ReactionResponse } from 'stream-chat';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
+import { defaultReactionOptions, ReactionOptions } from './reactionOptions';
 
 export type ReactionSelectorProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = {
-  /** Additional props to be passed to the [NimbleEmoji](https://github.com/missive/emoji-mart/blob/master/src/components/emoji/nimble-emoji.js) component from `emoji-mart` */
-  additionalEmojiProps?: Partial<NimbleEmojiProps>;
   /** Custom UI component to display user avatar, defaults to and accepts same props as: [Avatar](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Avatar/Avatar.tsx) */
   Avatar?: React.ElementType<AvatarProps>;
   /** If true, shows the user's avatar with the reaction */
@@ -31,9 +27,9 @@ export type ReactionSelectorProps<
   /** An array of the own reaction objects to distinguish own reactions visually */
   own_reactions?: ReactionResponse<StreamChatGenerics>[];
   /** An object that keeps track of the count of each type of reaction on a message */
-  reaction_counts?: { [key: string]: number };
+  reaction_counts?: Record<string, number>;
   /** A list of the currently supported reactions on a message */
-  reactionOptions?: ReactionEmoji[];
+  reactionOptions?: ReactionOptions;
   /** If true, adds a CSS class that reverses the horizontal positioning of the selector */
   reverse?: boolean;
 };
@@ -44,38 +40,27 @@ const UnMemoizedReactionSelector = React.forwardRef(
     ref: React.ForwardedRef<HTMLDivElement | null>,
   ) => {
     const {
-      additionalEmojiProps = {},
       Avatar: propAvatar,
       detailedView = true,
       handleReaction: propHandleReaction,
       latest_reactions: propLatestReactions,
       own_reactions: propOwnReactions,
       reaction_counts: propReactionCounts,
-      reactionOptions: propReactionOptions,
+      reactionOptions = defaultReactionOptions,
       reverse = false,
     } = props;
 
     const { Avatar: contextAvatar } = useComponentContext<StreamChatGenerics>('ReactionSelector');
-    const { Emoji, emojiConfig } = useEmojiContext('ReactionSelector');
     const {
       handleReaction: contextHandleReaction,
       message,
     } = useMessageContext<StreamChatGenerics>('ReactionSelector');
-
-    const { defaultMinimalEmojis, emojiData: fullEmojiData, emojiSetDef } = emojiConfig || {};
 
     const Avatar = propAvatar || contextAvatar || DefaultAvatar;
     const handleReaction = propHandleReaction || contextHandleReaction;
     const latestReactions = propLatestReactions || message?.latest_reactions || [];
     const ownReactions = propOwnReactions || message?.own_reactions || [];
     const reactionCounts = propReactionCounts || message?.reaction_counts || {};
-    const reactionOptions = propReactionOptions || defaultMinimalEmojis;
-    const reactionsAreCustom = !!propReactionOptions?.length;
-
-    const emojiData = useMemo(
-      () => (reactionsAreCustom ? fullEmojiData : getStrippedEmojiData(fullEmojiData)),
-      [fullEmojiData, reactionsAreCustom],
-    );
 
     const [tooltipReactionType, setTooltipReactionType] = useState<string | null>(null);
     const [tooltipPositions, setTooltipPositions] = useState<{
@@ -165,64 +150,57 @@ const UnMemoizedReactionSelector = React.forwardRef(
           </div>
         )}
         <ul className='str-chat__message-reactions-list str-chat__message-reactions-options'>
-          {reactionOptions.map((reactionOption: ReactionEmoji) => {
-            const latestUser = getLatestUserForReactionType(reactionOption.id);
-            const count = reactionCounts && reactionCounts[reactionOption.id];
-            return (
-              <li key={`item-${reactionOption.id}`}>
-                <button
-                  aria-label={`Select Reaction: ${reactionOption.name}`}
-                  className={clsx(
-                    'str-chat__message-reactions-list-item str-chat__message-reactions-option',
-                    {
-                      'str-chat__message-reactions-option-selected': iHaveReactedWithReaction(
-                        reactionOption.id,
-                      ),
-                    },
-                  )}
-                  data-text={reactionOption.id}
-                  onClick={(event) => handleReaction(reactionOption.id, event)}
-                >
-                  {!!count && detailedView && (
-                    <div
-                      className='latest-user str-chat__message-reactions-last-user'
-                      onClick={hideTooltip}
-                      onMouseEnter={(e) => showTooltip(e, reactionOption.id)}
-                      onMouseLeave={hideTooltip}
-                    >
-                      {latestUser ? (
-                        <Avatar
-                          image={latestUser.image}
-                          name={latestUser.name}
-                          size={20}
-                          user={latestUser}
-                        />
-                      ) : (
-                        <div className='latest-user-not-found' />
-                      )}
-                    </div>
-                  )}
-                  {
-                    <Suspense fallback={null}>
-                      <span className='str-chat__message-reaction-emoji'>
-                        <Emoji
-                          data={emojiData}
-                          emoji={reactionOption}
-                          size={20}
-                          {...(reactionsAreCustom ? additionalEmojiProps : emojiSetDef)}
-                        />
-                      </span>
-                    </Suspense>
-                  }
-                  {Boolean(count) && detailedView && (
-                    <span className='str-chat__message-reactions-list-item__count'>
-                      {count || ''}
+          {Object.entries(reactionOptions).map(
+            ([reactionType, { Component, name: reactionName }]) => {
+              const latestUser = getLatestUserForReactionType(reactionType);
+              const count = reactionCounts && reactionCounts[reactionType];
+              return (
+                <li key={`item-${reactionType}`}>
+                  <button
+                    aria-label={`Select Reaction: ${reactionName || reactionType}`}
+                    className={clsx(
+                      'str-chat__message-reactions-list-item str-chat__message-reactions-option',
+                      {
+                        'str-chat__message-reactions-option-selected': iHaveReactedWithReaction(
+                          reactionType,
+                        ),
+                      },
+                    )}
+                    data-text={reactionType}
+                    onClick={(event) => handleReaction(reactionType, event)}
+                  >
+                    {!!count && detailedView && (
+                      <div
+                        className='latest-user str-chat__message-reactions-last-user'
+                        onClick={hideTooltip}
+                        onMouseEnter={(e) => showTooltip(e, reactionType)}
+                        onMouseLeave={hideTooltip}
+                      >
+                        {latestUser ? (
+                          <Avatar
+                            image={latestUser.image}
+                            name={latestUser.name}
+                            size={20}
+                            user={latestUser}
+                          />
+                        ) : (
+                          <div className='latest-user-not-found' />
+                        )}
+                      </div>
+                    )}
+                    <span className='str-chat__message-reaction-emoji'>
+                      <Component />
                     </span>
-                  )}
-                </button>
-              </li>
-            );
-          })}
+                    {Boolean(count) && detailedView && (
+                      <span className='str-chat__message-reactions-list-item__count'>
+                        {count || ''}
+                      </span>
+                    )}
+                  </button>
+                </li>
+              );
+            },
+          )}
         </ul>
       </div>
     );

--- a/src/components/Reactions/ReactionSelector.tsx
+++ b/src/components/Reactions/ReactionSelector.tsx
@@ -150,57 +150,55 @@ const UnMemoizedReactionSelector = React.forwardRef(
           </div>
         )}
         <ul className='str-chat__message-reactions-list str-chat__message-reactions-options'>
-          {Object.entries(reactionOptions).map(
-            ([reactionType, { Component, name: reactionName }]) => {
-              const latestUser = getLatestUserForReactionType(reactionType);
-              const count = reactionCounts && reactionCounts[reactionType];
-              return (
-                <li key={`item-${reactionType}`}>
-                  <button
-                    aria-label={`Select Reaction: ${reactionName || reactionType}`}
-                    className={clsx(
-                      'str-chat__message-reactions-list-item str-chat__message-reactions-option',
-                      {
-                        'str-chat__message-reactions-option-selected': iHaveReactedWithReaction(
-                          reactionType,
-                        ),
-                      },
-                    )}
-                    data-text={reactionType}
-                    onClick={(event) => handleReaction(reactionType, event)}
-                  >
-                    {!!count && detailedView && (
-                      <div
-                        className='latest-user str-chat__message-reactions-last-user'
-                        onClick={hideTooltip}
-                        onMouseEnter={(e) => showTooltip(e, reactionType)}
-                        onMouseLeave={hideTooltip}
-                      >
-                        {latestUser ? (
-                          <Avatar
-                            image={latestUser.image}
-                            name={latestUser.name}
-                            size={20}
-                            user={latestUser}
-                          />
-                        ) : (
-                          <div className='latest-user-not-found' />
-                        )}
-                      </div>
-                    )}
-                    <span className='str-chat__message-reaction-emoji'>
-                      <Component />
+          {reactionOptions.map(({ Component, name: reactionName, type: reactionType }) => {
+            const latestUser = getLatestUserForReactionType(reactionType);
+            const count = reactionCounts && reactionCounts[reactionType];
+            return (
+              <li key={reactionType}>
+                <button
+                  aria-label={`Select Reaction: ${reactionName || reactionType}`}
+                  className={clsx(
+                    'str-chat__message-reactions-list-item str-chat__message-reactions-option',
+                    {
+                      'str-chat__message-reactions-option-selected': iHaveReactedWithReaction(
+                        reactionType,
+                      ),
+                    },
+                  )}
+                  data-text={reactionType}
+                  onClick={(event) => handleReaction(reactionType, event)}
+                >
+                  {!!count && detailedView && (
+                    <div
+                      className='latest-user str-chat__message-reactions-last-user'
+                      onClick={hideTooltip}
+                      onMouseEnter={(e) => showTooltip(e, reactionType)}
+                      onMouseLeave={hideTooltip}
+                    >
+                      {latestUser ? (
+                        <Avatar
+                          image={latestUser.image}
+                          name={latestUser.name}
+                          size={20}
+                          user={latestUser}
+                        />
+                      ) : (
+                        <div className='latest-user-not-found' />
+                      )}
+                    </div>
+                  )}
+                  <span className='str-chat__message-reaction-emoji'>
+                    <Component />
+                  </span>
+                  {Boolean(count) && detailedView && (
+                    <span className='str-chat__message-reactions-list-item__count'>
+                      {count || ''}
                     </span>
-                    {Boolean(count) && detailedView && (
-                      <span className='str-chat__message-reactions-list-item__count'>
-                        {count || ''}
-                      </span>
-                    )}
-                  </button>
-                </li>
-              );
-            },
-          )}
+                  )}
+                </button>
+              </li>
+            );
+          })}
         </ul>
       </div>
     );

--- a/src/components/Reactions/ReactionsList.tsx
+++ b/src/components/Reactions/ReactionsList.tsx
@@ -101,10 +101,10 @@ const UnMemoizedReactionsList = <
     >
       <ul className='str-chat__message-reactions'>
         {latestReactionTypes.map((reactionType) => {
-          const [, Reaction] = getEmojiByReactionType(reactionType) ?? [];
+          const ReactionOption = getEmojiByReactionType(reactionType);
           const isOwnReaction = iHaveReactedWithReaction(reactionType);
           return (
-            Reaction && (
+            ReactionOption && (
               <li
                 className={clsx('str-chat__message-reaction', {
                   'str-chat__message-reaction-own': isOwnReaction,
@@ -118,7 +118,7 @@ const UnMemoizedReactionsList = <
                 >
                   {
                     <span className='str-chat__message-reaction-emoji'>
-                      <Reaction.Component />
+                      <ReactionOption.Component />
                     </span>
                   }
                   &nbsp;

--- a/src/components/Reactions/ReactionsList.tsx
+++ b/src/components/Reactions/ReactionsList.tsx
@@ -113,14 +113,13 @@ const UnMemoizedReactionsList = <
               >
                 <ButtonWithTooltip
                   aria-label={`Reactions: ${reactionType}`}
+                  data-testid={`reactions-list-button-${reactionType}`}
                   title={aggregatedUserNamesByType[reactionType].join(', ')}
                   type='button'
                 >
-                  {
-                    <span className='str-chat__message-reaction-emoji'>
-                      <ReactionOption.Component />
-                    </span>
-                  }
+                  <span className='str-chat__message-reaction-emoji'>
+                    <ReactionOption.Component />
+                  </span>
                   &nbsp;
                   <span
                     className='str-chat__message-reaction-count'

--- a/src/components/Reactions/SimpleReactionsList.tsx
+++ b/src/components/Reactions/SimpleReactionsList.tsx
@@ -110,13 +110,13 @@ const UnMemoizedSimpleReactionsList = <
         onMouseLeave={() => setTooltipReactionType(undefined)}
       >
         {latestReactionTypes.map((reactionType, i) => {
-          const [, Reaction] = getEmojiByReactionType(reactionType) ?? [];
+          const ReactionOption = getEmojiByReactionType(reactionType);
           const isOwnReaction = iHaveReactedWithReaction(reactionType);
           const tooltipVisible = tooltipReactionType === reactionType;
           const tooltipContent = getUsersPerReactionType(tooltipReactionType)?.join(', ');
 
           return (
-            Reaction && (
+            ReactionOption && (
               <li
                 className={clsx('str-chat__simple-reactions-list-item', {
                   'str-chat__message-reaction-own': isOwnReaction,
@@ -130,7 +130,7 @@ const UnMemoizedSimpleReactionsList = <
                   onMouseLeave={() => setTooltipReactionType(undefined)}
                   title={tooltipContent}
                 >
-                  <Reaction.Component />
+                  <ReactionOption.Component />
                   &nbsp;
                   {tooltipVisible && themeVersion === '1' && (
                     <div className='str-chat__simple-reactions-list-tooltip'>

--- a/src/components/Reactions/SimpleReactionsList.tsx
+++ b/src/components/Reactions/SimpleReactionsList.tsx
@@ -109,7 +109,7 @@ const UnMemoizedSimpleReactionsList = <
         data-testid='simple-reaction-list'
         onMouseLeave={() => setTooltipReactionType(undefined)}
       >
-        {latestReactionTypes.map((reactionType, i) => {
+        {latestReactionTypes.map((reactionType) => {
           const ReactionOption = getEmojiByReactionType(reactionType);
           const isOwnReaction = iHaveReactedWithReaction(reactionType);
           const tooltipVisible = tooltipReactionType === reactionType;
@@ -121,7 +121,7 @@ const UnMemoizedSimpleReactionsList = <
                 className={clsx('str-chat__simple-reactions-list-item', {
                   'str-chat__message-reaction-own': isOwnReaction,
                 })}
-                key={`${reactionType}-${i}`}
+                key={reactionType}
                 onClick={(event) => handleReaction(reactionType, event)}
                 onKeyUp={(event) => handleReaction(reactionType, event)}
               >

--- a/src/components/Reactions/SpriteImage.tsx
+++ b/src/components/Reactions/SpriteImage.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+
+import { getImageDimensions } from './utils/utils';
+
+export type SpriteImageProps = {
+  columns: number;
+  position: [number, number];
+  rows: number;
+  spriteUrl: string;
+  fallback?: React.ReactNode;
+  height?: number;
+  width?: number;
+};
+
+export const SpriteImage = ({
+  columns,
+  fallback,
+  height,
+  position,
+  rows,
+  spriteUrl,
+  width,
+}: SpriteImageProps) => {
+  const [[spriteWidth, spriteHeight], setSpriteDimensions] = useState([0, 0]);
+
+  useEffect(() => {
+    getImageDimensions(spriteUrl).then(setSpriteDimensions);
+  }, [spriteUrl]);
+
+  const [x, y] = position;
+  const spriteItemWidth = spriteWidth / columns;
+  const spriteItemHeight = spriteHeight / rows;
+
+  let resizeRatio = 1;
+
+  if (!width && height) resizeRatio = height / spriteItemHeight;
+  if (width && !height) resizeRatio = width / spriteItemWidth;
+
+  if (resizeRatio === Infinity) resizeRatio = 1;
+
+  if (!spriteHeight || !spriteWidth) return <>{fallback}</>;
+
+  return (
+    <div
+      style={{
+        backgroundImage: `url('${spriteUrl}')`,
+        backgroundPosition: `${x * (100 / (columns - 1))}% ${y * (100 / (rows - 1))}%`,
+        backgroundSize: `${columns * 100}% ${rows * 100}%`,
+        height: height ?? spriteItemHeight * resizeRatio,
+        width: width ?? spriteItemWidth * resizeRatio,
+      }}
+    />
+  );
+};

--- a/src/components/Reactions/SpriteImage.tsx
+++ b/src/components/Reactions/SpriteImage.tsx
@@ -24,7 +24,7 @@ export const SpriteImage = ({
   const [[spriteWidth, spriteHeight], setSpriteDimensions] = useState([0, 0]);
 
   useEffect(() => {
-    getImageDimensions(spriteUrl).then(setSpriteDimensions);
+    getImageDimensions(spriteUrl).then(setSpriteDimensions).catch(console.error);
   }, [spriteUrl]);
 
   const [x, y] = position;
@@ -42,6 +42,7 @@ export const SpriteImage = ({
 
   return (
     <div
+      data-testid='sprite-image'
       style={{
         backgroundImage: `url('${spriteUrl}')`,
         backgroundPosition: `${x * (100 / (columns - 1))}% ${y * (100 / (rows - 1))}%`,

--- a/src/components/Reactions/StreamEmoji.tsx
+++ b/src/components/Reactions/StreamEmoji.tsx
@@ -15,7 +15,7 @@ const StreamSpriteEmojiPositions = {
 
 type StreamEmojiType = keyof typeof StreamSpriteEmojiPositions;
 
-export const STREAM_SPRITE_URL = 'https://getstream.imgix.net/images/emoji-sprite.png';
+const STREAM_SPRITE_URL = 'https://getstream.imgix.net/images/emoji-sprite.png';
 
 export const StreamEmoji = ({
   fallback,

--- a/src/components/Reactions/StreamEmoji.tsx
+++ b/src/components/Reactions/StreamEmoji.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { SpriteImage, SpriteImageProps } from './SpriteImage';
+
+import type { Readable } from '../../types/types';
+
+const StreamSpriteEmojiPositions = {
+  angry: [1, 1],
+  haha: [1, 0],
+  like: [0, 0],
+  love: [1, 2],
+  sad: [0, 1],
+  wow: [0, 2],
+};
+
+type StreamEmojiType = keyof typeof StreamSpriteEmojiPositions;
+
+export const STREAM_SPRITE_URL = 'https://getstream.imgix.net/images/emoji-sprite.png';
+
+export const StreamEmoji = ({
+  fallback,
+  type,
+}: Readable<{ type: StreamEmojiType } & Pick<SpriteImageProps, 'fallback'>>) => {
+  const position = StreamSpriteEmojiPositions[type] as [number, number];
+  return (
+    <SpriteImage
+      columns={2}
+      fallback={fallback}
+      height={18}
+      position={position}
+      rows={3}
+      spriteUrl={STREAM_SPRITE_URL}
+    />
+  );
+};

--- a/src/components/Reactions/__tests__/ReactionSelector.test.js
+++ b/src/components/Reactions/__tests__/ReactionSelector.test.js
@@ -57,7 +57,7 @@ describe('ReactionSelector', () => {
     const { container, queryAllByTestId } = renderComponent();
 
     await waitFor(() => {
-      expect(queryAllByTestId('sprite-image')).toHaveLength(6);
+      expect(queryAllByTestId('sprite-image')).toHaveLength(5);
     });
 
     const results = await axe(container);
@@ -112,21 +112,21 @@ describe('ReactionSelector', () => {
 
   it('should render the count of reactions for each reaction', async () => {
     const love = 1;
-    const angry = 2;
+    const haha = 2;
     const { container, getByText } = renderComponent({
       reaction_counts: {
-        angry,
+        haha,
         love,
       },
     });
 
     const loveCount = getByText(`${love}`);
-    const angryCount = getByText(`${angry}`);
+    const hahaCount = getByText(`${haha}`);
 
     expect(loveCount).toBeInTheDocument();
-    expect(angryCount).toBeInTheDocument();
+    expect(hahaCount).toBeInTheDocument();
     expect(loveCount.parentElement).toHaveAttribute('data-text', 'love');
-    expect(angryCount.parentElement).toHaveAttribute('data-text', 'angry');
+    expect(hahaCount.parentElement).toHaveAttribute('data-text', 'haha');
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/src/components/Reactions/__tests__/ReactionSelector.test.js
+++ b/src/components/Reactions/__tests__/ReactionSelector.test.js
@@ -1,26 +1,20 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import EmojiComponentMock from 'emoji-mart/dist-modern/components/emoji/nimble-emoji';
 import { toHaveNoViolations } from 'jest-axe';
 import { axe } from '../../../../axe-helper';
 expect.extend(toHaveNoViolations);
 
 import { ReactionSelector } from '../ReactionSelector';
+import { defaultReactionOptions } from '../reactionOptions';
+import * as utils from '../utils/utils';
 
 import { Avatar as AvatarMock } from '../../Avatar';
-import { defaultMinimalEmojis } from '../../Channel/emojiData';
 
 import { ComponentProvider } from '../../../context/ComponentContext';
-import { EmojiProvider } from '../../../context/EmojiContext';
 import { MessageProvider } from '../../../context/MessageContext';
 
-import {
-  emojiComponentMock,
-  emojiDataMock,
-  generateReaction,
-  generateUser,
-} from '../../../mock-builders';
+import { generateReaction, generateUser } from '../../../mock-builders';
 
 jest.mock('emoji-mart/dist-modern/components/emoji/nimble-emoji', () =>
   jest.fn(({ emoji }) => <div data-testid={`emoji-${emoji.id}`} />),
@@ -45,18 +39,9 @@ const handleReactionMock = jest.fn();
 
 const renderComponent = (props) =>
   render(
-    <ComponentProvider value={{ Avatar: AvatarMock }}>
+    <ComponentProvider value={{ Avatar: AvatarMock, reactionOptions: defaultReactionOptions }}>
       <MessageProvider value={{}}>
-        <EmojiProvider
-          value={{
-            Emoji: emojiComponentMock.Emoji,
-            emojiConfig: emojiDataMock,
-            EmojiIndex: emojiComponentMock.EmojiIndex,
-            EmojiPicker: emojiComponentMock.EmojiPicker,
-          }}
-        >
-          <ReactionSelector handleReaction={handleReactionMock} {...props} />
-        </EmojiProvider>
+        <ReactionSelector handleReaction={handleReactionMock} {...props} />
       </MessageProvider>
     </ComponentProvider>,
   );
@@ -66,28 +51,42 @@ describe('ReactionSelector', () => {
     jest.clearAllMocks();
   });
 
-  it('should render each of default emojis if reactionOptions prop is not specified', async () => {
-    const { container } = renderComponent();
+  it('should render each of default emojis from image sprite', async () => {
+    jest.spyOn(utils, 'getImageDimensions').mockResolvedValue([128, 192]);
 
-    defaultMinimalEmojis.forEach((emoji) => {
-      expect(EmojiComponentMock).toHaveBeenCalledWith(expect.objectContaining({ emoji }), {});
+    const { container, queryAllByTestId } = renderComponent();
+
+    await waitFor(() => {
+      expect(queryAllByTestId('sprite-image')).toHaveLength(6);
     });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should render fallbacks of each of the default emojis if sprite did not load', async () => {
+    jest.spyOn(utils, 'getImageDimensions').mockRejectedValue('Error');
+    jest.spyOn(console, 'error').mockImplementation(null);
+
+    const { container, getByText } = renderComponent();
+
+    await waitFor(() => {
+      expect(getByText('❤️')).toBeInTheDocument();
+    });
+
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 
   it('should render each of reactionOptions if specified', async () => {
     const reactionOptions = [
-      { emoji: 'angry', id: 'angry' },
-      { emoji: 'banana', id: 'banana' },
+      { Component: jest.fn(() => null), type: 'test1' },
+      { Component: jest.fn(() => null), type: 'test2' },
     ];
     const { container } = renderComponent({ reactionOptions });
 
-    reactionOptions.forEach((emoji) => {
-      expect(EmojiComponentMock).toHaveBeenCalledWith(
-        expect.objectContaining({ emoji: expect.objectContaining(emoji) }),
-        {},
-      );
+    reactionOptions.forEach((option) => {
+      expect(option.Component).toHaveBeenCalledTimes(1);
     });
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -181,9 +180,9 @@ describe('ReactionSelector', () => {
   });
 
   it('should call handleReaction if an emoji is clicked', async () => {
-    const { container, getByTestId } = renderComponent();
+    const { container, getByText } = renderComponent();
 
-    const emoji = getByTestId('emoji-love');
+    const emoji = getByText('❤️');
 
     fireEvent.click(emoji);
 

--- a/src/components/Reactions/__tests__/ReactionsList.test.js
+++ b/src/components/Reactions/__tests__/ReactionsList.test.js
@@ -1,59 +1,46 @@
+/* eslint-disable react/display-name */
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import EmojiComponentMock from 'emoji-mart/dist-modern/components/emoji/nimble-emoji';
 import { toHaveNoViolations } from 'jest-axe';
+
 import { axe } from '../../../../axe-helper';
 expect.extend(toHaveNoViolations);
 
 import { ReactionsList } from '../ReactionsList';
-
-import { EmojiProvider } from '../../../context/EmojiContext';
+import * as utils from '../utils/utils';
 import { MessageProvider } from '../../../context/MessageContext';
 
-import { emojiComponentMock, emojiDataMock, generateReaction } from '../../../mock-builders';
+import { generateReaction } from '../../../mock-builders';
+import { ComponentProvider } from '../../../context';
+import { defaultReactionOptions } from '../reactionOptions';
 
-jest.mock('emoji-mart/dist-modern/components/emoji/nimble-emoji', () =>
-  jest.fn(({ emoji }) => <div data-testid={`emoji-${emoji.id}`} />),
-);
+const USER_ID = 'mark';
+
+const generateButtonTitle = (count) =>
+  Array.from({ length: count }, (_, i) => `${USER_ID}-${i}`).join(', ');
 
 const renderComponent = ({ reaction_counts = {}, ...props }) => {
-  const reactions = Object.entries(reaction_counts)
-    .map(([type, count]) =>
-      Array(count)
-        .fill()
-        .map(() => generateReaction({ type })),
-    )
-    .flat();
+  const reactions = Object.entries(reaction_counts).flatMap(([type, count]) =>
+    Array(count)
+      .fill()
+      .map((_, i) => generateReaction({ type, user: { id: `${USER_ID}-${i}` } })),
+  );
 
   return render(
-    <MessageProvider value={{}}>
-      <EmojiProvider
-        value={{
-          Emoji: emojiComponentMock.Emoji,
-          emojiConfig: emojiDataMock,
-          EmojiIndex: emojiComponentMock.EmojiIndex,
-          EmojiPicker: emojiComponentMock.EmojiPicker,
-        }}
-      >
-        <ReactionsList reaction_counts={reaction_counts} reactions={reactions} {...props} />
-      </EmojiProvider>
-      ,
-    </MessageProvider>,
-  );
-};
-
-const expectEmojiToHaveBeenRendered = (id) => {
-  expect(EmojiComponentMock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      emoji: expect.objectContaining({ id }),
-    }),
-    {},
+    <ComponentProvider value={{ reactionOptions: defaultReactionOptions }}>
+      <MessageProvider value={{}}>
+        <ReactionsList reaction_counts={reaction_counts} reactions={reactions} {...props} />,
+      </MessageProvider>
+    </ComponentProvider>,
   );
 };
 
 describe('ReactionsList', () => {
   afterEach(jest.clearAllMocks);
+
+  // disable warnings (unreachable context)
+  jest.spyOn(console, 'warn').mockImplementation(null);
 
   it('should render the total reaction count', async () => {
     const { container, getByText } = renderComponent({
@@ -71,14 +58,26 @@ describe('ReactionsList', () => {
 
   it('should render an emoji for each type of reaction', async () => {
     const reaction_counts = {
-      angry: 2,
+      haha: 2,
       love: 5,
     };
-    const { container } = renderComponent({ reaction_counts });
+    // make sure to render default fallbacks
+    jest.spyOn(utils, 'getImageDimensions').mockRejectedValue('Error');
+    jest.spyOn(console, 'error').mockImplementation(null);
 
-    expect(EmojiComponentMock).toHaveBeenCalledTimes(Object.keys(reaction_counts).length);
+    const { container, getByTestId } = renderComponent({ reaction_counts });
 
-    Object.keys(reaction_counts).forEach(expectEmojiToHaveBeenRendered);
+    const hahaButton = getByTestId('reactions-list-button-haha');
+    const loveButton = getByTestId('reactions-list-button-love');
+
+    expect(hahaButton).toHaveAttribute('title', generateButtonTitle(reaction_counts['haha']));
+    expect(hahaButton.lastChild).toHaveTextContent(reaction_counts['haha']);
+    expect(hahaButton.firstChild).toHaveTextContent('😂');
+
+    expect(loveButton).toHaveAttribute('title', generateButtonTitle(reaction_counts['love']));
+    expect(loveButton.lastChild).toHaveTextContent(reaction_counts['love']);
+    expect(loveButton.firstChild).toHaveTextContent('❤️');
+
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
@@ -89,17 +88,24 @@ describe('ReactionsList', () => {
       cowboy: 2,
     };
 
-    const { container } = renderComponent({
+    const { container, getByTestId } = renderComponent({
       reaction_counts,
       reactionOptions: [
-        { emoji: '🍌', id: 'banana' },
-        { emoji: '🤠', id: 'cowboy' },
+        { Component: () => <>🍌</>, type: 'banana' },
+        { Component: () => <>🤠</>, type: 'cowboy' },
       ],
     });
 
-    expect(EmojiComponentMock).toHaveBeenCalledTimes(Object.keys(reaction_counts).length);
+    const bananaButton = getByTestId('reactions-list-button-banana');
+    const cowboyButton = getByTestId('reactions-list-button-cowboy');
 
-    Object.keys(reaction_counts).forEach(expectEmojiToHaveBeenRendered);
+    expect(bananaButton).toHaveAttribute('title', generateButtonTitle(reaction_counts['banana']));
+    expect(bananaButton.lastChild).toHaveTextContent(reaction_counts['banana']);
+    expect(bananaButton.firstChild).toHaveTextContent('🍌');
+    expect(cowboyButton).toHaveAttribute('title', generateButtonTitle(reaction_counts['cowboy']));
+    expect(cowboyButton.lastChild).toHaveTextContent(reaction_counts['cowboy']);
+    expect(cowboyButton.firstChild).toHaveTextContent('🤠');
+
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
@@ -110,8 +116,8 @@ describe('ReactionsList', () => {
       cowboy: 2,
     };
     const reactionOptions = [
-      { emoji: '🍌', id: 'banana' },
-      { emoji: '🤠', id: 'cowboy' },
+      { Component: () => <>🍌</>, type: 'banana' },
+      { Component: () => <>🤠</>, type: 'cowboy' },
     ];
 
     expect(

--- a/src/components/Reactions/__tests__/ReactionsList.test.js
+++ b/src/components/Reactions/__tests__/ReactionsList.test.js
@@ -22,9 +22,9 @@ const generateButtonTitle = (count) =>
 
 const renderComponent = ({ reaction_counts = {}, ...props }) => {
   const reactions = Object.entries(reaction_counts).flatMap(([type, count]) =>
-    Array(count)
-      .fill()
-      .map((_, i) => generateReaction({ type, user: { id: `${USER_ID}-${i}` } })),
+    Array.from({ length: count }, (_, i) =>
+      generateReaction({ type, user: { id: `${USER_ID}-${i}` } }),
+    ),
   );
 
   return render(

--- a/src/components/Reactions/__tests__/__snapshots__/SimpleReactionsList.test.js.snap
+++ b/src/components/Reactions/__tests__/__snapshots__/SimpleReactionsList.test.js.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SimpleReactionsList v1 should handle custom reaction options 1`] = `<div />`;
+
+exports[`SimpleReactionsList v1 should render an emoji for each type of reaction 1`] = `
+<div>
+  <div
+    class="str-chat__message-reactions-container"
+  >
+    <ul
+      class="str-chat__simple-reactions-list str-chat__message-reactions"
+      data-testid="simple-reaction-list"
+    >
+      <li
+        class="str-chat__simple-reactions-list-item"
+      >
+        <span>
+          😂
+           
+        </span>
+      </li>
+      <li
+        class="str-chat__simple-reactions-list-item"
+      >
+        <span>
+          ❤️
+           
+        </span>
+      </li>
+      <li
+        class="str-chat__simple-reactions-list-item--last-number"
+      >
+        7
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`SimpleReactionsList v2 should handle custom reaction options 1`] = `<div />`;
+
+exports[`SimpleReactionsList v2 should render an emoji for each type of reaction 1`] = `
+<div>
+  <div
+    class="str-chat__message-reactions-container"
+  >
+    <ul
+      class="str-chat__simple-reactions-list str-chat__message-reactions"
+      data-testid="simple-reaction-list"
+    >
+      <li
+        class="str-chat__simple-reactions-list-item"
+      >
+        <span>
+          😂
+           
+        </span>
+      </li>
+      <li
+        class="str-chat__simple-reactions-list-item"
+      >
+        <span>
+          ❤️
+           
+        </span>
+      </li>
+      <li
+        class="str-chat__simple-reactions-list-item--last-number"
+      >
+        7
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/src/components/Reactions/hooks/useProcessReactions.tsx
+++ b/src/components/Reactions/hooks/useProcessReactions.tsx
@@ -37,7 +37,7 @@ export const useProcessReactions = <
   );
 
   const getEmojiByReactionType = useCallback(
-    (reactionType: string) => Object.entries(reactionOptions).find(([rt]) => rt === reactionType),
+    (reactionType: string) => reactionOptions.find(({ type }) => type === reactionType),
     [reactionOptions],
   );
 
@@ -54,7 +54,7 @@ export const useProcessReactions = <
 
   const supportedReactionMap = useMemo(
     () =>
-      Object.keys(reactionOptions).reduce<Record<string, boolean>>((map, reactionType) => {
+      reactionOptions.reduce<Record<string, boolean>>((map, { type: reactionType }) => {
         map[reactionType] = true;
         return map;
       }, {}),
@@ -62,7 +62,7 @@ export const useProcessReactions = <
   );
 
   const supportedReactionsArePresent = useMemo(
-    () => latestReactionTypes.some((type) => supportedReactionMap[type]),
+    () => latestReactionTypes.some((reactionType) => supportedReactionMap[reactionType]),
     [latestReactionTypes, supportedReactionMap],
   );
 

--- a/src/components/Reactions/hooks/useProcessReactions.tsx
+++ b/src/components/Reactions/hooks/useProcessReactions.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { useMessageContext } from '../../../context';
-import { defaultReactionOptions } from '../reactionOptions';
+import { useComponentContext, useMessageContext } from '../../../context';
 
 import type { ReactionsListProps } from '../ReactionsList';
 import type { DefaultStreamChatGenerics } from '../../../types/types';
@@ -22,11 +21,15 @@ export const useProcessReactions = <
   const {
     own_reactions: propOwnReactions,
     reaction_counts: propReactionCounts,
-    reactionOptions = defaultReactionOptions,
+    reactionOptions: propReactionOptions,
     reactions: propReactions,
   } = params;
-  const { message } = useMessageContext<StreamChatGenerics>('ReactionsList');
+  const { message } = useMessageContext<StreamChatGenerics>('useProcessReactions');
+  const { reactionOptions: contextReactionOptions } = useComponentContext<StreamChatGenerics>(
+    'useProcessReactions',
+  );
 
+  const reactionOptions = propReactionOptions ?? contextReactionOptions;
   const latestReactions = propReactions || message.latest_reactions || [];
   const ownReactions = propOwnReactions || message?.own_reactions || [];
   const reactionCounts = propReactionCounts || message.reaction_counts || {};

--- a/src/components/Reactions/index.ts
+++ b/src/components/Reactions/index.ts
@@ -1,3 +1,6 @@
 export * from './ReactionSelector';
 export * from './ReactionsList';
 export * from './SimpleReactionsList';
+export * from './SpriteImage';
+export * from './StreamEmoji';
+export * from './reactionOptions';

--- a/src/components/Reactions/reactionOptions.tsx
+++ b/src/components/Reactions/reactionOptions.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable react/display-name */
+import React from 'react';
+
+import { StreamEmoji } from './StreamEmoji';
+
+export type ReactionOptions = Record<
+  string,
+  { Component: React.ComponentType; aliases?: string[]; name?: string }
+>;
+
+export const defaultReactionOptions: ReactionOptions = {
+  angry: { Component: () => <StreamEmoji fallback='😠' type='angry' />, name: 'Angry' },
+  haha: { Component: () => <StreamEmoji fallback='😂' type='haha' />, name: 'Joy' },
+  like: { Component: () => <StreamEmoji fallback='👍' type='like' />, name: 'Thumbs up' },
+  love: { Component: () => <StreamEmoji fallback='❤️' type='love' />, name: 'Heart' },
+  sad: { Component: () => <StreamEmoji fallback='😔' type='sad' />, name: 'Sad' },
+  wow: { Component: () => <StreamEmoji fallback='😲' type='wow' />, name: 'Astonished' },
+};

--- a/src/components/Reactions/reactionOptions.tsx
+++ b/src/components/Reactions/reactionOptions.tsx
@@ -1,18 +1,20 @@
+/* eslint-disable sort-keys */
 /* eslint-disable react/display-name */
 import React from 'react';
 
 import { StreamEmoji } from './StreamEmoji';
 
-export type ReactionOptions = Record<
-  string,
-  { Component: React.ComponentType; aliases?: string[]; name?: string }
->;
+export type ReactionOptions = Array<{
+  Component: React.ComponentType;
+  type: string;
+  name?: string;
+}>;
 
-export const defaultReactionOptions: ReactionOptions = {
-  angry: { Component: () => <StreamEmoji fallback='😠' type='angry' />, name: 'Angry' },
-  haha: { Component: () => <StreamEmoji fallback='😂' type='haha' />, name: 'Joy' },
-  like: { Component: () => <StreamEmoji fallback='👍' type='like' />, name: 'Thumbs up' },
-  love: { Component: () => <StreamEmoji fallback='❤️' type='love' />, name: 'Heart' },
-  sad: { Component: () => <StreamEmoji fallback='😔' type='sad' />, name: 'Sad' },
-  wow: { Component: () => <StreamEmoji fallback='😲' type='wow' />, name: 'Astonished' },
-};
+export const defaultReactionOptions: ReactionOptions = [
+  { type: 'angry', Component: () => <StreamEmoji fallback='😠' type='angry' />, name: 'Angry' },
+  { type: 'haha', Component: () => <StreamEmoji fallback='😂' type='haha' />, name: 'Joy' },
+  { type: 'like', Component: () => <StreamEmoji fallback='👍' type='like' />, name: 'Thumbs up' },
+  { type: 'love', Component: () => <StreamEmoji fallback='❤️' type='love' />, name: 'Heart' },
+  { type: 'sad', Component: () => <StreamEmoji fallback='😔' type='sad' />, name: 'Sad' },
+  { type: 'wow', Component: () => <StreamEmoji fallback='😲' type='wow' />, name: 'Astonished' },
+];

--- a/src/components/Reactions/reactionOptions.tsx
+++ b/src/components/Reactions/reactionOptions.tsx
@@ -11,7 +11,6 @@ export type ReactionOptions = Array<{
 }>;
 
 export const defaultReactionOptions: ReactionOptions = [
-  { type: 'angry', Component: () => <StreamEmoji fallback='😠' type='angry' />, name: 'Angry' },
   { type: 'haha', Component: () => <StreamEmoji fallback='😂' type='haha' />, name: 'Joy' },
   { type: 'like', Component: () => <StreamEmoji fallback='👍' type='like' />, name: 'Thumbs up' },
   { type: 'love', Component: () => <StreamEmoji fallback='❤️' type='love' />, name: 'Heart' },

--- a/src/components/Reactions/utils/utils.tsx
+++ b/src/components/Reactions/utils/utils.tsx
@@ -6,3 +6,20 @@ export const isMutableRef = <T,>(
   }
   return false;
 };
+
+export const getImageDimensions = (source: string) =>
+  new Promise<[number, number]>((resolve, reject) => {
+    const image = new Image();
+
+    image.addEventListener(
+      'load',
+      () => {
+        resolve([image.width, image.height]);
+      },
+      { once: true },
+    );
+
+    image.addEventListener('error', reject, { once: true });
+
+    image.src = source;
+  });

--- a/src/components/Reactions/utils/utils.tsx
+++ b/src/components/Reactions/utils/utils.tsx
@@ -19,7 +19,9 @@ export const getImageDimensions = (source: string) =>
       { once: true },
     );
 
-    image.addEventListener('error', reject, { once: true });
+    image.addEventListener('error', () => reject(`Couldn't load image from ${source}`), {
+      once: true,
+    });
 
     image.src = source;
   });

--- a/src/context/ComponentContext.tsx
+++ b/src/context/ComponentContext.tsx
@@ -34,6 +34,7 @@ import type { TypingIndicatorProps } from '../components/TypingIndicator/TypingI
 import type { CustomTrigger, DefaultStreamChatGenerics, UnknownType } from '../types/types';
 import type { CooldownTimerProps } from '../components';
 import type { LinkPreviewListProps } from '../components/MessageInput/LinkPreviewList';
+import type { ReactionOptions } from '../components/Reactions/reactionOptions';
 
 export type ComponentContextValue<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -41,6 +42,7 @@ export type ComponentContextValue<
 > = {
   Attachment: React.ComponentType<AttachmentProps<StreamChatGenerics>>;
   Message: React.ComponentType<MessageUIComponentProps<StreamChatGenerics>>;
+  reactionOptions: ReactionOptions;
   AttachmentPreviewList?: React.ComponentType;
   AutocompleteSuggestionHeader?: React.ComponentType<SuggestionListHeaderProps>;
   AutocompleteSuggestionItem?: React.ComponentType<SuggestionItemProps<StreamChatGenerics>>;

--- a/src/context/EmojiContext.tsx
+++ b/src/context/EmojiContext.tsx
@@ -6,7 +6,6 @@ import type {
   Data as EmojiMartData,
   EmojiSheetSize,
   NimbleEmojiIndex,
-  NimbleEmojiProps,
   NimblePickerProps,
 } from 'emoji-mart';
 
@@ -44,12 +43,9 @@ export type EmojiConfig = {
 
 export type EmojiContextValue = {
   emojiConfig: EmojiConfig;
-  Emoji?: React.ComponentType<NimbleEmojiProps>;
   EmojiIndex?: NimbleEmojiIndex;
   EmojiPicker?: React.ComponentType<NimblePickerProps>;
 };
-
-const DefaultEmoji = React.lazy(() => import('./DefaultEmoji'));
 
 const DefaultEmojiPicker = React.lazy(() => import('./DefaultEmojiPicker'));
 
@@ -61,15 +57,9 @@ export const EmojiProvider = ({
 }: PropsWithChildren<{
   value: EmojiContextValue;
 }>) => {
-  const {
-    Emoji = DefaultEmoji,
-    emojiConfig,
-    EmojiIndex = DefaultEmojiIndex,
-    EmojiPicker = DefaultEmojiPicker,
-  } = value;
+  const { emojiConfig, EmojiIndex = DefaultEmojiIndex, EmojiPicker = DefaultEmojiPicker } = value;
 
   const emojiContextValue: Required<EmojiContextValue> = {
-    Emoji,
     emojiConfig,
     EmojiIndex,
     EmojiPicker,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -145,3 +145,8 @@ export type SendMessageOptions = {
 export type UpdateMessageOptions = {
   skip_enrich_url?: boolean;
 };
+
+export type Readable<T> = {
+  [key in keyof T]: T[key];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+} & {};


### PR DESCRIPTION
BREAKING CHANGE: `reactionOptions` signature has changed, see release guide for more information

### 🎯 Goal

Refactor and fix the way reactions work, introduce new way of customizing with better DX.

Fixes: #1935
Closes: #1637
Closes: #1437
Closes: #2159
Closes: https://github.com/GetStream/stream-chat-react-native/issues/2023

### 🛠 Implementation details

- ditch EmojiMart implementation, use native/sprite-sheet solution