### PR TITLE
feat(Attachments): introduce `UnsupportedAttachment` component

### DIFF
--- a/src/components/Attachment/AttachmentContainer.tsx
+++ b/src/components/Attachment/AttachmentContainer.tsx
@@ -9,6 +9,7 @@ import { Audio as DefaultAudio } from './Audio';
 import { Gallery as DefaultGallery, ImageComponent as DefaultImage } from '../Gallery';
 import { Card as DefaultCard } from './Card';
 import { FileAttachment as DefaultFile } from './FileAttachment';
+import { NullComponent as DefaultUnsupportedAttachment } from './UnsupportedAttachment';
 import {
   AttachmentContainerProps,
   isGalleryAttachmentType,
@@ -292,3 +293,14 @@ export const MediaContainer = <
     </AttachmentWithinContainer>
   );
 };
+
+export const UnsupportedAttachmentContainer = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>({
+  attachment,
+  UnsupportedAttachment = DefaultUnsupportedAttachment,
+}: RenderAttachmentProps<StreamChatGenerics>) => (
+  <>
+    <UnsupportedAttachment attachment={attachment} />
+  </>
+);

--- a/src/components/Attachment/UnsupportedAttachment.tsx
+++ b/src/components/Attachment/UnsupportedAttachment.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { Attachment } from 'stream-chat';
+import type { DefaultStreamChatGenerics } from '../../types/types';
+
+export type UnsupportedAttachmentProps<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+> = {
+  attachment: Attachment<StreamChatGenerics>;
+};
+
+export const UnsupportedAttachment = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>({
+  attachment,
+}: UnsupportedAttachmentProps<StreamChatGenerics>) => (
+  <div>
+    <div>
+      Unsupported attachment type <strong>{attachment.type ?? 'unknown'}</strong>
+    </div>
+    <code>{JSON.stringify(attachment, null, 4)}</code>;
+  </div>
+);
+
+export const NullComponent = () => null;

--- a/src/components/Attachment/index.ts
+++ b/src/components/Attachment/index.ts
@@ -3,5 +3,6 @@ export * from './AttachmentActions';
 export * from './AttachmentContainer';
 export * from './Audio';
 export * from './Card';
+export * from './UnsupportedAttachment';
 export * from './FileAttachment';
 export * from './utils';


### PR DESCRIPTION
### 🎯 Goal

Introduces `UnsupportedAttachment` component to handle unsupported attachment types.

### 🛠 Implementation details

This component is disabled by default, enable by passing `UnsupportedAttachment` component to `Attachment`'s `UnsupportedAttachment` property:

```tsx
import { Attachment, UnsupportedAttachment } from 'stream-chat-react';

const CustomAttachment = (props) => <Attachment {...props} UnsupportedAttachment={UnsupportedAttachment} />

/* ... */

<Channel Attachment={CustomAttachment} >
    /* ... */
</Channel>

```

### 🎨 UI Changes

![image](https://user-images.githubusercontent.com/43254280/221175741-d60aedbc-9470-441b-8818-b09d7d2ca43e.png)