### PR TITLE
feat(Attachments): add pre element for formatting

### DIFF
--- a/src/components/Attachment/UnsupportedAttachment.tsx
+++ b/src/components/Attachment/UnsupportedAttachment.tsx
@@ -17,7 +17,9 @@ export const UnsupportedAttachment = <
     <div>
       Unsupported attachment type <strong>{attachment.type ?? 'unknown'}</strong>
     </div>
-    <code>{JSON.stringify(attachment, null, 4)}</code>;
+    <pre>
+      <code>{JSON.stringify(attachment, null, 4)}</code>
+    </pre>
   </div>
 );
 


### PR DESCRIPTION
### 🎯 Goal

This PR wraps the `<code>` element on UnsupportedAttachment inside a `<pre>` element for formatting.
