### PR TITLE
build(ci): remove Node v14, add v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16]
+        node: [16, 18]
     name: Test with Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
On 30 April 2023, extended support for Node 14 LTS will end.