### PR TITLE
fix: update event handler upon channel config update

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -484,7 +484,7 @@ const ChannelInner = <
       client.off('user.deleted', handleEvent);
       notificationTimeouts.forEach(clearTimeout);
     };
-  }, [channel.cid, doMarkReadRequest]);
+  }, [channel.cid, doMarkReadRequest, channelConfig?.read_events]);
 
   useEffect(() => {
     if (!state.thread) return;


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

Discussion: https://getstream.slack.com/archives/C04L46T90HK/p1678217984091969?thread_ts=1677866241.515559&cid=C04L46T90HK

Fixes following bug:

- Use `Channel` component without `ChannelList` and Pass the `channel` as prop to Channel component without instantiating it. Now send a message to that channel from some other user and check that `markRead` call never happens

```tsx
const App = () => {
  const [ isReady, setIsReady ] = React.useState(false);
  const [ channel, setChannel ] = React.useState<StreamChatChannel>();
  React.useEffect(() => {
    const init = async () => {
      await chatClient.connectUser({ id: userId }, userToken);
      const _channel = chatClient.channel('messaging', 'sample-app-channel-999');
      setChannel(_channel);
      setIsReady(true);
    };
    init();
  }, []);

  if (!isReady) return <div>Loading...</div>;

  return (
  <Chat client={chatClient}>
    <Channel channel={channel}>
      <Window>
        <ChannelHeader />
        <MessageList />
        <MessageInput focus />
      </Window>
      <Thread />
    </Channel>
  </Chat>
)};
```

### 🛠 Implementation details

The issue occurs because after instantiating the channel using `channel.watch()`, our event handlers still carry stale value of `channelConfig`. And `channelConfig.read_events` stays undefined. Adding it as explicit dependency will fix this issue.

### 🎨 UI Changes

NA
