### PR TITLE
fix: do not increase count of prepended VirtualizedMessageList messages of status "sending" or "failed"

### DIFF
--- a/src/components/MessageList/hooks/usePrependMessagesCount.ts
+++ b/src/components/MessageList/hooks/usePrependMessagesCount.ts
@@ -45,16 +45,16 @@ export function usePrependedMessagesCount<
       // at non-existent index. Therefore, we ignore messages of status "sending" / "failed" in order they are
       // not considered as prepended messages.
       if (
-        !messages[i].status ||
+        messages[i]?.status &&
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        (STATUSES_EXCLUDED_FROM_PREPEND.includes(messages[i].status!) &&
-          messages[i].id !== firstMessageId.current)
+        STATUSES_EXCLUDED_FROM_PREPEND.includes(messages[i].status!) &&
+        messages[i].id !== firstMessageId.current
       ) {
         adjustPrependedMessageCount++;
       }
       if (messages[i].id === firstMessageId.current) {
         previousNumItemsPrepended.current = i - adjustPrependedMessageCount;
-        return i;
+        return previousNumItemsPrepended.current;
       }
     }
 

--- a/src/components/MessageList/hooks/usePrependMessagesCount.ts
+++ b/src/components/MessageList/hooks/usePrependMessagesCount.ts
@@ -30,9 +30,23 @@ export function usePrependedMessagesCount<
     earliestMessageId.current = currentFirstMessageId;
     // if new messages were prepended, find out how many
     // start with this number because there cannot be fewer prepended items than before
+    let countPrependedSendingMessages = 0;
     for (let i = previousNumItemsPrepended.current; i < messages.length; i += 1) {
+      // Optimistic UI update, when sending messages, can lead to a situation, when
+      // the order of the messages changes for a moment. This can happen, when a user
+      // sends multiple messages withing few milliseconds. E.g. we send a message A
+      // then message B. At first we have message array with both messages of status "sending"
+      // then response for message A is received with a new - later - created_at timestamp
+      // this leads to rearrangement of 1.B ("sending"), 2.A ("received"). Still firstMessageId.current
+      // points to message A, but now this message has index 1 => previousNumItemsPrepended.current === 1
+      // That in turn leads to incorrect index calculation in VirtualizedMessageList trying to access a message
+      // at non-existent index. Therefore, we ignore messages of status "sending" in order they are
+      // not considered as prepended messages.
+      if (messages[i].status === 'sending' && messages[i].id !== firstMessageId.current) {
+        countPrependedSendingMessages++;
+      }
       if (messages[i].id === firstMessageId.current) {
-        previousNumItemsPrepended.current = i;
+        previousNumItemsPrepended.current = i - countPrependedSendingMessages;
         return i;
       }
     }


### PR DESCRIPTION
### 🎯 Goal

This fix solves an edge case situation, when a user starts to send messages very quickly into an empty channel displaying messages with VirtualizedMessageList. VirtualizedMessageList calculates number of messages prepended in order it loads more messages from the history. Number of prepended messages was calculated incorrectly, when 2+ messages were sent in a range of few milliseconds (crazy typing and pressing Enter key). The reason for this situation to occur is that we use optimistic UI updates - we render message in the message list even before it was sent to & response received from the API. That leads to following:

1. sending message A that is committed to the channel state flagged with `status: "sending"` before the actual response is received from the API
2. sending message B  that is committed to the channel state flagged that is flagged with `status: "sending"` before the actual response is received from the API
3. Response for message A from API is received and committed to the channel state. Now the `created_at` value is few milliseconds greater that that of message B, which has not been confirmed from the API yet
4. The state now provides message array sorted as [B,A]
5. Suddenly message A seems to have a message prepended (Message B)
6. Virtualized message list tries to access message A under the index `numItemsPrepended + index - PREPEND_OFFSET`, where `numItemsPrepended` is 1 greater, that it should be => accessing non-existent index 2
7. Error is thrown
8. Response for message B should be returned and should be committed to state with new `created_at` value and status `"received"`, but app already threw an error

To prevent incorrect increase of `numItemsPrepended`, this fix instructs not to include in the count messages with status `sending` located before the first message of the first batch of messages.