### PR TITLE
feat: add video attachment component

### DIFF
--- a/docusaurus/docs/React/components/message-components/attachment.mdx
+++ b/docusaurus/docs/React/components/message-components/attachment.mdx
@@ -157,6 +157,37 @@ The SDK will try to display images and videos with their original aspect ratio, 
 The sizing logic for images and videos (the [`imageAttachmentSizeHandler`](../core-components/channel.mdx/#imageattachmentsizehandler) and [`videoAttachmentSizeHandler`](../core-components/channel.mdx/#videoattachmentsizehandler)) requires that host elements of images and videos (ususally `img` and `video` elements) have `max-height`/`height` and `max-width` properties defined and that these values can be computed to a valid pixel value using the [`getComputedStyle`](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle) (for more information refer to the [Maximum size](#maximum-size) section).
 :::
 
+
+### Rendering customized attachment components in quoted reply
+
+The `Attachment` component accepts prop [`isQuoted`](./#isQuoted). This prop is then propagated to the following underlying widget components:
+
+- `Audio`
+- `Card`
+- `File`
+- `Gallery`
+- `Image`
+
+That allows you to customize, how the attachment will be displayed in quoted reply and in the original message's attachment list.
+
+Example:
+
+```typescript jsx
+const CustomCard = ({isQuoted, ...attachment}: CardProps) => {
+  return isQuoted ? <CardContent attachment={attachment}  /> : <Card {...attachment} />
+}
+
+const CustomAttachment = (props: AttachmentProps) => (
+  <Attachment {...props}  Card={CustomCard}/>
+);
+
+const App = () => (
+...
+    <Channel Attachment={CustomAttachment}>
+...
+);
+```
+
 ## Props
 
 ### <div class="label required basic">Required</div> attachments
@@ -223,6 +254,14 @@ Custom UI component for displaying an image type attachment.
 | Type      | Default                                                   |
 | --------- | --------------------------------------------------------- |
 | component | <GHComponentLink text='Image' path='/Gallery/Image.tsx'/> |
+
+### isQuoted
+
+Optional flag that allows to signal rendering of an attachment component with customized markup if rendered as a part of a quoted message. The flag is passed to all the underlying attachment component types.
+
+|   Type    |
+| --------- |
+|  boolean  |
 
 ### Media
 

--- a/src/components/Attachment/Attachment.tsx
+++ b/src/components/Attachment/Attachment.tsx
@@ -30,6 +30,7 @@ import type { UnsupportedAttachmentProps } from './UnsupportedAttachment';
 import type { ActionHandlerReturnType } from '../Message/hooks/useActionHandler';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
+import type { VideoProps } from './Video';
 
 const CONTAINER_MAP = {
   audio: AudioContainer,
@@ -74,6 +75,8 @@ export type AttachmentProps<
   Media?: React.ComponentType<ReactPlayerProps>;
   /** Custom UI component for displaying unsupported attachment types, defaults to NullComponent */
   UnsupportedAttachment?: React.ComponentType<UnsupportedAttachmentProps>;
+  /** Custom UI component for displaying video attachments. The default implementation is a wrapper around the default Media attachment component. Defaults to and accepts same props as: [Video](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Attachment/Video.tsx) */
+  Video?: React.ComponentType<VideoProps>;
 };
 
 /**

--- a/src/components/Attachment/Attachment.tsx
+++ b/src/components/Attachment/Attachment.tsx
@@ -68,6 +68,8 @@ export type AttachmentProps<
   Gallery?: React.ComponentType<GalleryProps<StreamChatGenerics>>;
   /** Custom UI component for displaying an image type attachment, defaults to and accepts same props as: [Image](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Gallery/Image.tsx) */
   Image?: React.ComponentType<ImageProps>;
+  /** Optional flag to signal that an attachment is a displayed as a part of a quoted message */
+  isQuoted?: boolean;
   /** Custom UI component for displaying a media type attachment, defaults to `ReactPlayer` from 'react-player' */
   Media?: React.ComponentType<ReactPlayerProps>;
   /** Custom UI component for displaying unsupported attachment types, defaults to NullComponent */

--- a/src/components/Attachment/AttachmentContainer.tsx
+++ b/src/components/Attachment/AttachmentContainer.tsx
@@ -103,6 +103,7 @@ export const GalleryContainer = <
 >({
   attachment,
   Gallery = DefaultGallery,
+  isQuoted,
 }: RenderGalleryProps<StreamChatGenerics>) => {
   const imageElements = useRef<HTMLElement[]>([]);
   const { imageAttachmentSizeHandler } = useChannelStateContext();
@@ -135,7 +136,7 @@ export const GalleryContainer = <
 
   return (
     <AttachmentWithinContainer attachment={attachment} componentType='gallery'>
-      <Gallery images={images || []} innerRefs={imageElements} key='gallery' />
+      <Gallery images={images || []} innerRefs={imageElements} isQuoted={isQuoted} key='gallery' />
     </AttachmentWithinContainer>
   );
 };
@@ -145,7 +146,7 @@ export const ImageContainer = <
 >(
   props: RenderAttachmentProps<StreamChatGenerics>,
 ) => {
-  const { attachment, Image = DefaultImage } = props;
+  const { attachment, Image = DefaultImage, isQuoted } = props;
   const componentType = 'image';
   const imageElement = useRef<HTMLImageElement>(null);
   const { imageAttachmentSizeHandler } = useChannelStateContext();
@@ -162,6 +163,7 @@ export const ImageContainer = <
 
   const imageConfig = {
     ...attachment,
+    isQuoted,
     previewUrl: attachmentConfiguration?.url || 'about:blank',
     style: getCssDimensionsVariables(attachment.image_url || attachment.thumb_url || ''),
   };
@@ -189,14 +191,14 @@ export const CardContainer = <
 >(
   props: RenderAttachmentProps<StreamChatGenerics>,
 ) => {
-  const { attachment, Card = DefaultCard } = props;
+  const { attachment, Card = DefaultCard, isQuoted } = props;
   const componentType = 'card';
 
   if (attachment.actions && attachment.actions.length) {
     return (
       <AttachmentWithinContainer attachment={attachment} componentType={componentType}>
         <div className='str-chat__attachment'>
-          <Card {...attachment} />
+          <Card {...attachment} isQuoted={isQuoted} />
           <AttachmentActionsContainer {...props} />
         </div>
       </AttachmentWithinContainer>
@@ -205,7 +207,7 @@ export const CardContainer = <
 
   return (
     <AttachmentWithinContainer attachment={attachment} componentType={componentType}>
-      <Card {...attachment} />
+      <Card {...attachment} isQuoted={isQuoted} />
     </AttachmentWithinContainer>
   );
 };
@@ -215,12 +217,13 @@ export const FileContainer = <
 >({
   attachment,
   File = DefaultFile,
+  isQuoted,
 }: RenderAttachmentProps<StreamChatGenerics>) => {
   if (!attachment.asset_url) return null;
 
   return (
     <AttachmentWithinContainer attachment={attachment} componentType='file'>
-      <File attachment={attachment} />
+      <File attachment={attachment} isQuoted={isQuoted} />
     </AttachmentWithinContainer>
   );
 };
@@ -229,10 +232,11 @@ export const AudioContainer = <
 >({
   attachment,
   Audio = DefaultAudio,
+  isQuoted,
 }: RenderAttachmentProps<StreamChatGenerics>) => (
   <AttachmentWithinContainer attachment={attachment} componentType='audio'>
     <div className='str-chat__attachment'>
-      <Audio og={attachment} />
+      <Audio isQuoted={isQuoted} og={attachment} />
     </div>
   </AttachmentWithinContainer>
 );
@@ -299,8 +303,9 @@ export const UnsupportedAttachmentContainer = <
 >({
   attachment,
   UnsupportedAttachment = DefaultUnsupportedAttachment,
+  isQuoted,
 }: RenderAttachmentProps<StreamChatGenerics>) => (
   <>
-    <UnsupportedAttachment attachment={attachment} />
+    <UnsupportedAttachment attachment={attachment} isQuoted={isQuoted} />
   </>
 );

--- a/src/components/Attachment/AttachmentContainer.tsx
+++ b/src/components/Attachment/AttachmentContainer.tsx
@@ -17,14 +17,11 @@ import {
   RenderAttachmentProps,
   RenderGalleryProps,
 } from './utils';
+import { Video } from './Video';
 
 import { useChannelStateContext } from '../../context/ChannelStateContext';
 
-import type {
-  DefaultStreamChatGenerics,
-  ImageAttachmentConfiguration,
-  VideoAttachmentConfiguration,
-} from '../../types/types';
+import type { DefaultStreamChatGenerics, ImageAttachmentConfiguration } from '../../types/types';
 
 export const AttachmentWithinContainer = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
@@ -79,7 +76,7 @@ export const AttachmentActionsContainer = <
   );
 };
 
-function getCssDimensionsVariables(url: string) {
+export function getCssDimensionsVariables(url: string) {
   const cssVars = {
     '--original-height': 1000000,
     '--original-width': 1000000,
@@ -246,54 +243,19 @@ export const MediaContainer = <
 >(
   props: RenderAttachmentProps<StreamChatGenerics>,
 ) => {
-  const { attachment, Media = ReactPlayer } = props;
+  const { attachment, Media = ReactPlayer, isQuoted } = props;
   const componentType = 'media';
-  const { shouldGenerateVideoThumbnail, videoAttachmentSizeHandler } = useChannelStateContext();
-  const videoElement = useRef<HTMLDivElement>(null);
-  const [
-    attachmentConfiguration,
-    setAttachmentConfiguration,
-  ] = useState<VideoAttachmentConfiguration>();
-
-  useLayoutEffect(() => {
-    if (videoElement.current && videoAttachmentSizeHandler) {
-      const config = videoAttachmentSizeHandler(
-        attachment,
-        videoElement.current,
-        shouldGenerateVideoThumbnail,
-      );
-      setAttachmentConfiguration(config);
-    }
-  }, [videoElement, videoAttachmentSizeHandler, attachment]);
-
-  const content = (
-    <div
-      className='str-chat__player-wrapper'
-      data-testid='video-wrapper'
-      ref={videoElement}
-      style={getCssDimensionsVariables(attachment.thumb_url || '')}
-    >
-      <Media
-        className='react-player'
-        config={{ file: { attributes: { poster: attachmentConfiguration?.thumbUrl } } }}
-        controls
-        height='100%'
-        url={attachmentConfiguration?.url}
-        width='100%'
-      />
-    </div>
-  );
 
   return attachment.actions?.length ? (
     <AttachmentWithinContainer attachment={attachment} componentType={componentType}>
       <div className='str-chat__attachment str-chat__attachment-media'>
-        {content}
+        <Video attachment={attachment} isQuoted={isQuoted} VideoPlayer={Media} />
         <AttachmentActionsContainer {...props} />
       </div>
     </AttachmentWithinContainer>
   ) : (
     <AttachmentWithinContainer attachment={attachment} componentType={componentType}>
-      {content}
+      <Video attachment={attachment} isQuoted={isQuoted} VideoPlayer={Media} />
     </AttachmentWithinContainer>
   );
 };

--- a/src/components/Attachment/Audio.tsx
+++ b/src/components/Attachment/Audio.tsx
@@ -16,6 +16,8 @@ export type AudioProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = {
   og: Attachment<StreamChatGenerics>;
+  /** A boolean flag to signal whether the attachment will be rendered inside the quoted reply. */
+  isQuoted?: boolean;
 };
 
 const AudioV1 = ({ og }: AudioProps) => {
@@ -107,7 +109,7 @@ export const ProgressBar = ({ onClick, progress }: ProgressBarProps) => (
     role='progressbar'
     style={{
       background: `linear-gradient(
-		 to right, 
+		 to right,
 		 var(--str-chat__primary-color),
 		 var(--str-chat__primary-color) ${progress}%,
 		 var(--str-chat__disabled-color) ${progress}%,

--- a/src/components/Attachment/Card.tsx
+++ b/src/components/Attachment/Card.tsx
@@ -249,7 +249,10 @@ export const CardAudio = ({
   );
 };
 
-export type CardProps = RenderAttachmentProps['attachment'];
+export type CardProps = RenderAttachmentProps['attachment'] & {
+  /** A boolean flag to signal whether the attachment will be rendered inside the quoted reply. */
+  isQuoted?: boolean;
+};
 
 const UnMemoizedCard = (props: CardProps) => {
   const { themeVersion } = useChatContext('Card');

--- a/src/components/Attachment/FileAttachment.tsx
+++ b/src/components/Attachment/FileAttachment.tsx
@@ -14,6 +14,8 @@ export type FileAttachmentProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = {
   attachment: Attachment<StreamChatGenerics>;
+  /** A boolean flag to signal whether the attachment will be rendered inside the quoted reply. */
+  isQuoted?: boolean;
 };
 
 const UnMemoizedFileAttachmentV1 = <
@@ -53,15 +55,15 @@ const UnMemoizedFileAttachmentV2 = <
 
 const UnMemoizedFileAttachment = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
->({
-  attachment,
-}: FileAttachmentProps<StreamChatGenerics>) => {
+>(
+  props: FileAttachmentProps<StreamChatGenerics>,
+) => {
   const { themeVersion } = useChatContext('FileAttachment');
 
   return themeVersion === '2' ? (
-    <UnMemoizedFileAttachmentV2 attachment={attachment} />
+    <UnMemoizedFileAttachmentV2 {...props} />
   ) : (
-    <UnMemoizedFileAttachmentV1 attachment={attachment} />
+    <UnMemoizedFileAttachmentV1 {...props} />
   );
 };
 

--- a/src/components/Attachment/UnsupportedAttachment.tsx
+++ b/src/components/Attachment/UnsupportedAttachment.tsx
@@ -6,6 +6,8 @@ export type UnsupportedAttachmentProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = {
   attachment: Attachment<StreamChatGenerics>;
+  /** A boolean flag to signal whether the attachment will be rendered inside the quoted reply. */
+  isQuoted?: boolean;
 };
 
 export const UnsupportedAttachment = <

--- a/src/components/Attachment/Video.tsx
+++ b/src/components/Attachment/Video.tsx
@@ -1,0 +1,65 @@
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import ReactPlayer, { ReactPlayerProps } from 'react-player';
+
+import type { Attachment } from 'stream-chat';
+import type { DefaultStreamChatGenerics, VideoAttachmentConfiguration } from '../../types/types';
+import { useChannelStateContext } from '../../context';
+import { getCssDimensionsVariables } from './AttachmentContainer';
+
+export type VideoPlayerProps = {
+  className?: string;
+  url?: string;
+};
+
+export type VideoProps<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+> = {
+  attachment: Attachment<StreamChatGenerics>;
+  // todo: deprecate the use of ReactPlayerProps
+  VideoPlayer: React.ComponentType<ReactPlayerProps>;
+  /** A boolean flag to signal whether the attachment will be rendered inside the quoted reply. */
+  isQuoted?: boolean;
+};
+
+export const Video = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>({
+  attachment,
+  VideoPlayer = ReactPlayer,
+}: VideoProps<StreamChatGenerics>) => {
+  const { shouldGenerateVideoThumbnail, videoAttachmentSizeHandler } = useChannelStateContext();
+  const videoElement = useRef<HTMLDivElement>(null);
+  const [
+    attachmentConfiguration,
+    setAttachmentConfiguration,
+  ] = useState<VideoAttachmentConfiguration>();
+
+  useLayoutEffect(() => {
+    if (videoElement.current && videoAttachmentSizeHandler) {
+      const config = videoAttachmentSizeHandler(
+        attachment,
+        videoElement.current,
+        shouldGenerateVideoThumbnail,
+      );
+      setAttachmentConfiguration(config);
+    }
+  }, [videoElement, videoAttachmentSizeHandler, attachment]);
+
+  return (
+    <div
+      className='str-chat__player-wrapper'
+      data-testid='video-wrapper'
+      ref={videoElement}
+      style={getCssDimensionsVariables(attachment.thumb_url || '')}
+    >
+      <VideoPlayer
+        className='react-player'
+        config={{ file: { attributes: { poster: attachmentConfiguration?.thumbUrl } } }}
+        controls
+        height='100%'
+        url={attachmentConfiguration?.url}
+        width='100%'
+      />
+    </div>
+  );
+};

--- a/src/components/Attachment/__tests__/Attachment.test.js
+++ b/src/components/Attachment/__tests__/Attachment.test.js
@@ -18,14 +18,48 @@ import {
 import { Attachment } from '../Attachment';
 import { SUPPORTED_VIDEO_FORMATS } from '../utils';
 import { generateScrapedVideoAttachment } from '../../../mock-builders';
+import { ChannelStateProvider } from '../../../context';
 
-const Audio = (props) => <div data-testid='audio-attachment'>{props.customTestId}</div>;
-const Card = (props) => <div data-testid='card-attachment'>{props.customTestId}</div>;
-const Media = (props) => <div data-testid='media-attachment'>{props.customTestId}</div>;
+const TEST_IDS = {
+  audio: 'audio-attachment',
+  card: 'card-attachment',
+  file: 'file-attachment',
+  gallery: 'gallery-attachment',
+  image: 'image-attachment',
+  media: 'media-attachment',
+};
+
+const Audio = (props) => (
+  <div data-isquoted={props.isQuoted} data-testid={TEST_IDS.audio}>
+    {props.customTestId}
+  </div>
+);
+const Card = (props) => (
+  <div data-isquoted={props.isQuoted} data-testid={TEST_IDS.card}>
+    {props.customTestId}
+  </div>
+);
+const Media = (props) => (
+  <div data-isquoted={props.isQuoted} data-testid={TEST_IDS.media}>
+    {props.customTestId}
+  </div>
+);
 const AttachmentActions = () => <div data-testid='attachment-actions'></div>;
-const Image = (props) => <div data-testid='image-attachment'>{props.customTestId}</div>;
-const File = (props) => <div data-testid='file-attachment'>{props.customTestId}</div>;
-const Gallery = (props) => <div data-testid='gallery-attachment'>{props.customTestId}</div>;
+const Image = (props) => (
+  <div data-isquoted={props.isQuoted} data-testid={TEST_IDS.image}>
+    {props.customTestId}
+  </div>
+);
+const File = (props) => (
+  <div data-isquoted={props.isQuoted} data-testid={TEST_IDS.file}>
+    {props.customTestId}
+  </div>
+);
+const Gallery = (props) => (
+  <div data-isquoted={props.isQuoted} data-testid={TEST_IDS.gallery}>
+    {props.customTestId}
+  </div>
+);
 
 const ATTACHMENTS = {
   scraped: {
@@ -46,16 +80,18 @@ const ATTACHMENTS = {
 
 const renderComponent = (props) =>
   render(
-    <Attachment
-      AttachmentActions={AttachmentActions}
-      Audio={Audio}
-      Card={Card}
-      File={File}
-      Gallery={Gallery}
-      Image={Image}
-      Media={Media}
-      {...props}
-    />,
+    <ChannelStateProvider value={{}}>
+      <Attachment
+        AttachmentActions={AttachmentActions}
+        Audio={Audio}
+        Card={Card}
+        File={File}
+        Gallery={Gallery}
+        Image={Image}
+        Media={Media}
+        {...props}
+      />
+    </ChannelStateProvider>,
   );
 
 describe('attachment', () => {
@@ -236,6 +272,33 @@ describe('attachment', () => {
       await waitFor(() => {
         expect(container).toMatchSnapshot();
       });
+    });
+
+    it('should propagate isQuoted flag to all the attachment widgets', () => {
+      const { queryByTestId } = renderComponent({
+        attachments: [
+          ATTACHMENTS.uploaded.file,
+          ATTACHMENTS.uploaded.audio,
+          ATTACHMENTS.uploaded.video,
+          ATTACHMENTS.scraped.audio,
+          ATTACHMENTS.uploaded.image,
+        ],
+        isQuoted: true,
+      });
+
+      Object.entries(TEST_IDS).forEach(([attachmentType, testId]) => {
+        if (['gallery', 'media'].includes(attachmentType)) return;
+        expect(queryByTestId(testId)).toHaveAttribute('data-isquoted', 'true');
+      });
+    });
+
+    it('should propagate isQuoted flag to gallery the attachment widget', () => {
+      const { queryByTestId } = renderComponent({
+        attachments: [ATTACHMENTS.uploaded.image, ATTACHMENTS.uploaded.image],
+        isQuoted: true,
+      });
+
+      expect(queryByTestId(TEST_IDS.gallery)).toHaveAttribute('data-isquoted', 'true');
     });
   });
 

--- a/src/components/Attachment/index.ts
+++ b/src/components/Attachment/index.ts
@@ -6,3 +6,4 @@ export * from './Card';
 export * from './UnsupportedAttachment';
 export * from './FileAttachment';
 export * from './utils';
+export * from './Video';

--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -23,6 +23,8 @@ export type GalleryProps<
     | Attachment<StreamChatGenerics>
   ) & { previewUrl?: string; style?: CSSProperties })[];
   innerRefs?: MutableRefObject<(HTMLElement | null)[]>;
+  /** A boolean flag to signal whether the attachment will be rendered inside the quoted reply. */
+  isQuoted?: boolean;
 };
 
 const UnMemoizedGallery = <

--- a/src/components/Gallery/Image.tsx
+++ b/src/components/Gallery/Image.tsx
@@ -13,6 +13,8 @@ export type ImageProps<
 > = {
   dimensions?: Dimensions;
   innerRef?: MutableRefObject<HTMLImageElement | null>;
+  /** A boolean flag to signal whether the attachment will be rendered inside the quoted reply. */
+  isQuoted?: boolean;
   previewUrl?: string;
   style?: CSSProperties;
 } & (

--- a/src/components/Message/QuotedMessage.tsx
+++ b/src/components/Message/QuotedMessage.tsx
@@ -58,7 +58,9 @@ export const QuotedMessage = <
           />
         )}
         <div className='quoted-message-inner str-chat__quoted-message-bubble'>
-          {quotedMessageAttachment && <Attachment attachments={[quotedMessageAttachment]} />}
+          {quotedMessageAttachment && (
+            <Attachment attachments={[quotedMessageAttachment]} isQuoted />
+          )}
           <div>{quotedMessageText}</div>
         </div>
       </div>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -115,7 +115,7 @@ export type ImageAttachmentConfiguration = {
   url: string;
 };
 
-export type VideoAttachmentConfiguration = ImageAttachmentConfiguration & {
+export type VideoAttachmentConfiguration = Partial<ImageAttachmentConfiguration> & {
   thumbUrl?: string;
 };
 


### PR DESCRIPTION
### 🎯 Goal

Blocked by: #1977 

Provide the possibility to customize rendering of uploaded attachment. The crucial part is to encapsulate the fact that the default implementation uses `react-player` to play videos.

We are declaring, that the custom `Media` component passed as a prop to `Attachment`, accepts the same props as `ReactPlayer`. Unfortunately that is not true, because we are only passing the following props to the `Media` component:

```
className='react-player'
config={{ file: { attributes: { poster: attachmentConfiguration?.thumbUrl } } }}
controls
height='100%'
url={attachmentConfiguration?.url}
width='100%'
```

The goal is introduce this feature as a non-breaking change. 
