### PR TITLE
fix: update channel state on user.deleted event

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -377,7 +377,7 @@ const ChannelInner = <
 
   const markReadThrottled = throttle(markRead, 500, { leading: true, trailing: true });
 
-  const handleEvent = (event: Event<StreamChatGenerics>) => {
+  const handleEvent = async (event: Event<StreamChatGenerics>) => {
     if (event.message) {
       dispatch({
         channel,
@@ -432,6 +432,18 @@ const ChannelInner = <
           latestMessageDatesByChannels[cid] = messageDate;
         }
       }
+    }
+
+    if (event.type === 'user.deleted') {
+      const oldestID = channel.state?.messages?.[0]?.id;
+
+      /**
+       * As the channel state is not normalized we re-fetch the channel data. Thus we avoid having to search for user references in the channel state.
+       */
+      await channel.query({
+        messages: { id_lt: oldestID, limit: DEFAULT_NEXT_CHANNEL_PAGE_SIZE },
+        watchers: { limit: DEFAULT_NEXT_CHANNEL_PAGE_SIZE },
+      });
     }
 
     throttledCopyStateFromChannel();


### PR DESCRIPTION
### 🎯 Goal

Fix #1983 

### 🛠 Implementation details

Upon `user.deleted` event the entire channel state is re-fetched to reflect the state on the back-end.
