### PR TITLE
fix: cooldown timer

### DIFF
--- a/src/components/MessageInput/hooks/__tests__/useCooldownTimer.test.js
+++ b/src/components/MessageInput/hooks/__tests__/useCooldownTimer.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useCooldownTimer } from '../useCooldownTimer';
+
+import { ChannelStateProvider, ChatProvider } from '../../../../context';
+import { getTestClient } from '../../../../mock-builders';
+
+async function renderUseCooldownTimerHook({ channel, chatContext }) {
+  const client = await getTestClient();
+
+  const wrapper = ({ children }) => (
+    <ChatProvider value={{ client, ...chatContext }}>
+      <ChannelStateProvider value={{ channel }}>{children}</ChannelStateProvider>
+    </ChatProvider>
+  );
+  return renderHook(useCooldownTimer, { wrapper });
+}
+
+const cid = 'cid';
+const cooldown = 30;
+describe('useCooldownTimer', () => {
+  it('should set remaining cooldown time to if no channel.cooldown', async () => {
+    const channel = { cid };
+    const chatContext = { latestMessageDatesByChannels: {} };
+    const { result } = await renderUseCooldownTimerHook({ channel, chatContext });
+    expect(result.current.cooldownRemaining).toBe(0);
+  });
+  it('should set remaining cooldown time to 0 if skip-slow-mode is among own_capabilities', async () => {
+    const channel = { cid, data: { cooldown, own_capabilities: ['skip-slow-mode'] } };
+    const chatContext = { latestMessageDatesByChannels: { cid: new Date() } };
+    const { result } = await renderUseCooldownTimerHook({ channel, chatContext });
+    expect(result.current.cooldownRemaining).toBe(0);
+  });
+  it('should set remaining cooldown time to 0 if no previous messages sent', async () => {
+    const channel = { cid, data: { cooldown } };
+    const chatContext = { latestMessageDatesByChannels: {} };
+    const { result } = await renderUseCooldownTimerHook({ channel, chatContext });
+    expect(result.current.cooldownRemaining).toBe(0);
+  });
+  it('should set remaining cooldown time to 0 if previous messages sent earlier than channel.cooldown', async () => {
+    const channel = { cid, data: { cooldown } };
+    const chatContext = { latestMessageDatesByChannels: { cid: new Date('1970-1-1') } };
+    const { result } = await renderUseCooldownTimerHook({ channel, chatContext });
+    expect(result.current.cooldownRemaining).toBe(0);
+  });
+  it('should set remaining cooldown time to time left from previous messages sent', async () => {
+    const channel = { cid, data: { cooldown } };
+    const lastSentSecondsAgo = 5;
+    const chatContext = {
+      latestMessageDatesByChannels: {
+        cid: new Date(new Date().getTime() - lastSentSecondsAgo * 1000),
+      },
+    };
+    const { result } = await renderUseCooldownTimerHook({ channel, chatContext });
+    expect(result.current.cooldownRemaining).toBe(cooldown - lastSentSecondsAgo);
+  });
+});

--- a/src/components/MessageInput/hooks/useCooldownTimer.tsx
+++ b/src/components/MessageInput/hooks/useCooldownTimer.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
-
-import { useChatContext } from '../../../context/ChatContext';
-import { useChannelStateContext } from '../../../context/ChannelStateContext';
-
 import type { ChannelResponse } from 'stream-chat';
+
+import { useChannelStateContext, useChatContext } from '../../../context';
 
 import type { DefaultStreamChatGenerics } from '../../../types/types';
 
@@ -16,15 +14,16 @@ export type CooldownTimerState = {
 export const useCooldownTimer = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 >(): CooldownTimerState => {
-  const { latestMessageDatesByChannels } = useChatContext<StreamChatGenerics>('useCooldownTimer');
+  const { client, latestMessageDatesByChannels } = useChatContext<StreamChatGenerics>(
+    'useCooldownTimer',
+  );
   const { channel, messages = [] } = useChannelStateContext<StreamChatGenerics>('useCooldownTimer');
-  const { client } = useChatContext<StreamChatGenerics>('useCooldownTimer');
   const [cooldownRemaining, setCooldownRemaining] = useState<number>();
 
-  const { cooldown: cooldownInterval, own_capabilities } = (channel.data ||
+  const { cooldown: cooldownInterval = 0, own_capabilities } = (channel.data ||
     {}) as ChannelResponse<StreamChatGenerics>;
 
-  const skipCooldown = !own_capabilities?.includes('slow-mode');
+  const skipCooldown = own_capabilities?.includes('skip-slow-mode');
 
   const ownLatestMessageDate = useMemo(
     () =>
@@ -36,17 +35,19 @@ export const useCooldownTimer = <
   ) as Date;
 
   useEffect(() => {
-    if (skipCooldown || !cooldownInterval || !ownLatestMessageDate) return;
+    const timeSinceOwnLastMessage = ownLatestMessageDate
+      ? (new Date().getTime() - ownLatestMessageDate.getTime()) / 1000
+      : undefined;
 
-    const remainingCooldown = Math.round(
-      cooldownInterval - (new Date().getTime() - ownLatestMessageDate.getTime()) / 1000,
+    setCooldownRemaining(
+      !skipCooldown && timeSinceOwnLastMessage && cooldownInterval > timeSinceOwnLastMessage
+        ? Math.round(cooldownInterval - timeSinceOwnLastMessage)
+        : 0,
     );
-
-    if (remainingCooldown > 0) setCooldownRemaining(remainingCooldown);
   }, [cooldownInterval, ownLatestMessageDate, skipCooldown]);
 
   return {
-    cooldownInterval: cooldownInterval ?? 0,
+    cooldownInterval,
     cooldownRemaining,
     setCooldownRemaining,
   };


### PR DESCRIPTION
### 🎯 Goal

Adapt the cooldown timer enablement to the latest bug fix on the backend:

The `'slow-mode'` own capability was replaced by `'skip-slow-mode'`. This capability should only be used to determine if the user can skip cooldown mode and not to determine if the channel has cooldown enabled. The `channel.own_capabilities` array will contain capability `'skip-slow-mode'` if a user is assigned a role that has `skip-channel-cooldown` permission.

### 🛠 Implementation details
Cooldown mode enablement is signaled by the presence of `channel.cooldown` value (num of seconds).

When cooldown mode is enabled a user can send a message only if:
1.  in the cooldown period if `channel.own_capabilities` includes `'skip-slow-mode'`
2. the time elapsed since the last message sent is > `channel.cooldown`
3. no previous message was sent by the given user in the given channel 

Otherwise the user has to wait until the cooldown period has elapsed before sending next message.

#### Updating cooldown state
✅  If the cooldown is enabled during active user connection (`channel.updated` event contains `channel.cooldown` value), then the remaining cooldown time has to be recalculated based on the above criteria.
✅  If the cooldown period is updated (`channel.updated` event contains new `channel.cooldown` value), then the remaining cooldown time has to be recalculated based on the above criteria.
✅  If the cooldown is disabled (`channel.updated` event does not contain `channel.cooldown` value), then the remaining cooldown time has to be set to 0 immediately, thus enabling sending messages.

#### Known limitations
❌  Cooldown is not updated over WS if `skip-channel-cooldown`  perm is assigned to a role in dashboard. Channel data has to be queried anew to reflect that change.
❌  Cooldown is not updated over WS if `skip-channel-cooldown`  perm is removed from a role in dashboard. Channel data has to be queried anew to reflect that change.

