### PR TITLE
fix: extend i18n datetime locale config type

### DIFF
--- a/docusaurus/docs/React/guides/theming/translations.mdx
+++ b/docusaurus/docs/React/guides/theming/translations.mdx
@@ -149,6 +149,8 @@ The `setLanguage` method on the class instance of `Streami18n` is asynchronous, 
 awaited before the language translations can be updated.
 :::
 
+We can initialize the instance dynamically:
+
 ```tsx
 import zhTranslation from 'path/to/zh.json';
 
@@ -177,6 +179,111 @@ const App = () => {
 };
 ```
 
+Or we can have a pre-configured `Streami18n` instance:
+
+```tsx
+import zhTranslation from 'path/to/zh.json';
+
+const i18nInstance = new Streami18n({
+  language: 'zh',
+  translationsForLanguage: zhTranslations,
+  dayjsLocaleConfigForLanguage: {
+    // see the next section about Datetime translations
+    months: [...],
+    monthsShort: [...],
+    calendar: {
+      sameDay: ...'
+    }
+  }
+});
+
+const App = () => {
+  return (
+    <Chat client={client} i18nInstance={i18nInstance}>
+      ...
+    </Chat>
+  );
+};
+```
+
+### Datetime translations
+
+The SDK components use [`Dayjs`](https://day.js.org/en/) internally by default to format dates and times. It has [locale support](https://day.js.org/docs/en/i18n/i18n) being a lightweight alternative to `Momentjs` with the same modern API. `Dayjs` provides [locale config for plenty of languages](https://github.com/iamkun/dayjs/tree/dev/src/locale).
+
+You can either provide the `Dayjs` locale config while registering language with `Streami18n` (either via constructor or `registerTranslation()`) or you can provide your own `Dayjs` or `Momentjs` instance to `Streami18n` constructor, which will be then used internally (using the language locale) in components.
+
+:::note
+The `dayjsLocaleConfigForLanguage` object is a union of configuration objects for [`Dayjs` calendar plugin](https://day.js.org/docs/en/plugin/calendar) and `Dayjs` locale configuration(examples are available in [`Dayjs` default locale configurations](https://github.com/iamkun/dayjs/tree/dev/src/locale))
+:::
+
+1. Via language registration
+
+```js
+const i18n = new Streami18n({
+ language: 'nl',
+ dayjsLocaleConfigForLanguage: {
+   months: [...],
+   monthsShort: [...],
+   calendar: {
+     sameDay: ...'
+   }
+ }
+});
+```
+
+Similarly, you can add locale config for `Momentjs` while registering translation via `registerTranslation` function.
+
+```js
+const i18n = new Streami18n();
+
+i18n.registerTranslation(
+ 'mr',
+ {
+   'Nothing yet...': 'काहीही नाही  ...',
+   '{{ firstUser }} and {{ secondUser }} are typing...': '{{ firstUser }} आणि {{ secondUser }} टीपी करत आहेत ',
+ },
+ {
+   months: [...],
+   monthsShort: [...],
+   calendar: {
+     sameDay: ...'
+   }
+ }
+);
+```
+2. Provide your own `Momentjs` object
+
+```js
+import 'moment/locale/nl';
+import 'moment/locale/it';
+// or if you want to include all locales
+import 'moment/min/locales';
+
+import Moment from moment
+
+const i18n = new Streami18n({
+ language: 'nl',
+ DateTimeParser: Moment
+})
+```
+
+3. Provide your own Dayjs object
+
+```js
+import Dayjs from 'dayjs'
+
+import 'dayjs/locale/nl';
+import 'dayjs/locale/it';
+// or if you want to include all locales
+import 'dayjs/min/locales';
+
+const i18n = new Streami18n({
+ language: 'nl',
+ DateTimeParser: Dayjs
+})
+```
+If you would like to stick with english language for dates and times in Stream components, you can set `disableDateTimeTranslations` to true.
+
 ### Translating Messages
 
 Stream Chat provide the ability to run users' messages through automatic translation.
@@ -199,15 +306,17 @@ The `Streami18n` class wraps [`i18next`](https://www.npmjs.com/package/i18next) 
 
 ### Class Constructor Options
 
-| Option                       | Description                                                                          | Type     | Default    |
-| ---------------------------- | ------------------------------------------------------------------------------------ | -------- | ---------- |
-| language                     | connected user's language                                                            | string   | 'en'       |
-| translationsForLanguage      | overrides existing component text                                                    | object   | {}         |
-| disableDateTimeTranslations  | disables translation of date times                                                   | boolean  | false      |
-| debug                        | enables i18n debug mode                                                              | boolean  | false      |
-| logger                       | logs warnings/errors                                                                 | function | () => {}   |
-| dayjsLocaleConfigForLanguage | internal Day.js [config object](https://github.com/iamkun/dayjs/tree/dev/src/locale) | object   | 'enConfig' |
-| DateTimeParser               | custom date time parser                                                              | function | Day.js     |
+| Option                       | Description                                                                                                                                                          | Type     | Default    |
+|------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|------------|
+| language                     | connected user's language                                                                                                                                            | string   | 'en'       |
+| translationsForLanguage      | overrides existing component text                                                                                                                                    | object   | {}         |
+| disableDateTimeTranslations  | disables translation of date times                                                                                                                                   | boolean  | false      |
+| debug                        | enables i18n debug mode                                                                                                                                              | boolean  | false      |
+| logger                       | logs warnings/errors                                                                                                                                                 | function | () => {}   |
+| dayjsLocaleConfigForLanguage | internal Day.js [config object](https://github.com/iamkun/dayjs/tree/dev/src/locale) and [calendar locale config object](https://day.js.org/docs/en/plugin/calendar) | object   | 'enConfig' |
+| DateTimeParser               | custom date time parser                                                                                                                                              | function | Day.js     |
+
+####
 
 ### Class Instance Methods
 

--- a/src/i18n/Streami18n.ts
+++ b/src/i18n/Streami18n.ts
@@ -47,6 +47,15 @@ import 'dayjs/locale/tr';
 // to make sure I don't mess up language at other places in app.
 import 'dayjs/locale/en';
 
+type CalendarLocaleConfig = {
+  lastDay: string;
+  lastWeek: string;
+  nextDay: string;
+  nextWeek: string;
+  sameDay: string;
+  sameElse: string;
+};
+
 Dayjs.extend(updateLocale);
 
 Dayjs.updateLocale('de', {
@@ -224,7 +233,7 @@ const isDayJs = (dateTimeParser: typeof Dayjs | typeof moment): dateTimeParser i
 
 type Options = {
   DateTimeParser?: typeof Dayjs | typeof moment;
-  dayjsLocaleConfigForLanguage?: Partial<ILocale>;
+  dayjsLocaleConfigForLanguage?: Partial<ILocale> & { calendar?: CalendarLocaleConfig };
   debug?: boolean;
   disableDateTimeTranslations?: boolean;
   language?: TranslationLanguages;


### PR DESCRIPTION
### 🎯 Goal

1. Fix the type declaration of `dayjsLocaleConfigForLanguage` object passed to `Streami18n` constructor options.
2. Add missing documentation on how to customize the datetime locale translations
