### PR TITLE
fix: prevent ignoring the clearSearchOnClickOutside search param on mobile

### DIFF
--- a/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -141,7 +141,7 @@ export const useChannelSearch = <
 
       if (isInputClick) return;
 
-      if ((inputIsFocused && (!query || navOpen)) || clearSearchOnClickOutside) {
+      if ((inputIsFocused && !query) || clearSearchOnClickOutside) {
         exitSearch();
       }
     };

--- a/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -100,7 +100,7 @@ export const useChannelSearch = <
   searchQueryParams,
   setChannels,
 }: ChannelSearchControllerParams<StreamChatGenerics>): SearchController<StreamChatGenerics> => {
-  const { client, navOpen, setActiveChannel, themeVersion } = useChatContext<StreamChatGenerics>(
+  const { client, setActiveChannel, themeVersion } = useChatContext<StreamChatGenerics>(
     'useChannelSearch',
   );
 
@@ -148,7 +148,7 @@ export const useChannelSearch = <
 
     document.addEventListener('click', clickListener);
     return () => document.removeEventListener('click', clickListener);
-  }, [disabled, inputIsFocused, query, exitSearch, navOpen, clearSearchOnClickOutside]);
+  }, [disabled, inputIsFocused, query, exitSearch, clearSearchOnClickOutside]);
 
   useEffect(() => {
     if (!inputRef.current || disabled) return;


### PR DESCRIPTION
### 🎯 Goal

Fixes an issue where `clearSearchOnClickOutside` would be ignored when the navigation in mobile view is open.

