### PR TITLE
fix: enable search results scrolling

### DIFF
--- a/src/components/ChannelSearch/ChannelSearch.tsx
+++ b/src/components/ChannelSearch/ChannelSearch.tsx
@@ -1,6 +1,7 @@
+import clsx from 'clsx';
 import React from 'react';
 
-import { useChatContext } from '../../context/ChatContext';
+import { useChatContext } from '../../context';
 
 import { ChannelSearchControllerParams, useChannelSearch } from './hooks/useChannelSearch';
 
@@ -71,7 +72,12 @@ const UnMemoizedChannelSearch = <
   const showSearchBarV2 = themeVersion === '2';
 
   return (
-    <div className='str-chat__channel-search' data-testid='channel-search'>
+    <div
+      className={clsx('str-chat__channel-search', popupResults ? 'popup' : 'inline', {
+        'str-chat__channel-search--with-results': results.length > 0,
+      })}
+      data-testid='channel-search'
+    >
       {showSearchBarV2 ? (
         <SearchBar
           activateSearch={activateSearch}

--- a/src/components/ChannelSearch/__tests__/ChannelSearch.test.js
+++ b/src/components/ChannelSearch/__tests__/ChannelSearch.test.js
@@ -38,7 +38,7 @@ describe('ChannelSearch', () => {
     const { channelSearch } = await renderSearch({});
     expect(channelSearch).toMatchInlineSnapshot(`
       <div
-        class="str-chat__channel-search"
+        class="str-chat__channel-search inline"
         data-testid="channel-search"
       >
         <input
@@ -57,7 +57,7 @@ describe('ChannelSearch', () => {
     const { channelSearch } = await renderSearch({ props: { placeholder } });
     expect(channelSearch).toMatchInlineSnapshot(`
       <div
-        class="str-chat__channel-search"
+        class="str-chat__channel-search inline"
         data-testid="channel-search"
       >
         <input


### PR DESCRIPTION
### 🎯 Goal

Fix the bug in channel search results list to make it scrollable. If the channel search result list overflew the parent, it was not possible to scroll the list.

This fix depends on https://github.com/GetStream/stream-chat-css/pull/232