### PR TITLE
chore(deps): upgrade and pin version of the `react-image-gallery`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-dropzone": "^14.2.2",
     "react-fast-compare": "^3.2.0",
     "react-file-utils": "^1.2.0",
-    "react-image-gallery": "^1.2.7",
+    "react-image-gallery": "1.2.12",
     "react-is": "^18.1.0",
     "react-markdown": "^8.0.3",
     "react-player": "2.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12074,10 +12074,10 @@ react-file-utils@^1.2.0:
   dependencies:
     react-dropzone "^12.0.5"
 
-react-image-gallery@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/react-image-gallery/-/react-image-gallery-1.2.7.tgz#2dfb83c52f32828a5340ca565f91bca58241fcfe"
-  integrity sha512-ts7yMWykvZhslGMuvVAUk7a1dJIx9QtIwK6Clv8dOGxPsJid92FRrLvXbZDvkYcUyj48sHalnBhqU6mZNCB2jg==
+react-image-gallery@1.2.12:
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/react-image-gallery/-/react-image-gallery-1.2.12.tgz#b08a633cc336bab2a5afdb96941e023925043c6a"
+  integrity sha512-JIh85lh0Av/yewseGJb/ycg00Y/weQiZEC/BQueC2Z5jnYILGB6mkxnrOevNhsM2NdZJpvcDekCluhy6uzEoTA==
 
 "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.1.0:
   version "18.1.0"


### PR DESCRIPTION
### 🎯 Goal

Upgrade and pin the version of the `react-image-gallery` package due to breaking change released as minor version update. 

Goes hand in hand with: https://github.com/GetStream/stream-chat-css/pull/231