### PR TITLE
fix: namespace the ChannelSearch's root element "inline" and "popup" classes

### DIFF
--- a/src/components/ChannelSearch/ChannelSearch.tsx
+++ b/src/components/ChannelSearch/ChannelSearch.tsx
@@ -73,9 +73,13 @@ const UnMemoizedChannelSearch = <
 
   return (
     <div
-      className={clsx('str-chat__channel-search', popupResults ? 'popup' : 'inline', {
-        'str-chat__channel-search--with-results': results.length > 0,
-      })}
+      className={clsx(
+        'str-chat__channel-search',
+        popupResults ? 'str-chat__channel-search--popup' : 'str-chat__channel-search--inline',
+        {
+          'str-chat__channel-search--with-results': results.length > 0,
+        },
+      )}
       data-testid='channel-search'
     >
       {showSearchBarV2 ? (

--- a/src/components/ChannelSearch/__tests__/ChannelSearch.test.js
+++ b/src/components/ChannelSearch/__tests__/ChannelSearch.test.js
@@ -38,7 +38,7 @@ describe('ChannelSearch', () => {
     const { channelSearch } = await renderSearch({});
     expect(channelSearch).toMatchInlineSnapshot(`
       <div
-        class="str-chat__channel-search inline"
+        class="str-chat__channel-search str-chat__channel-search--inline"
         data-testid="channel-search"
       >
         <input
@@ -57,7 +57,7 @@ describe('ChannelSearch', () => {
     const { channelSearch } = await renderSearch({ props: { placeholder } });
     expect(channelSearch).toMatchInlineSnapshot(`
       <div
-        class="str-chat__channel-search inline"
+        class="str-chat__channel-search str-chat__channel-search--inline"
         data-testid="channel-search"
       >
         <input


### PR DESCRIPTION
### 🎯 Goal

Avoid conflicts with integrators' custom rules attached to `inline` class.

depends on https://github.com/GetStream/stream-chat-css/pull/234
fixes: https://github.com/GetStream/stream-chat-react/pull/2041#issuecomment-1635304125
