### PR TITLE
fix: provide default `members` filter param for channel search to avoid error response

### DIFF
--- a/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -217,6 +217,7 @@ export const useChannelSearch = <
           const channelResponse = client.queryChannels(
             // @ts-expect-error
             {
+              members: { $in: [client.userID] },
               name: { $autocomplete: text },
               ...searchQueryParams?.channelFilters?.filters,
             },


### PR DESCRIPTION
### 🎯 Goal

Provide minimum default `members` filter param for channel search to avoid error response:

`queryChannels failed with error: \"1 channels match your query but cannot be returned because you don't have access to them. Did you forget to include {members: $in: [\"<user_id>\"]}?\"`
