### PR TITLE
feat: show read receipts in VirtualizedMessageList

### DIFF
--- a/docusaurus/docs/React/components/core-components/virtualized-list.mdx
+++ b/docusaurus/docs/React/components/core-components/virtualized-list.mdx
@@ -199,6 +199,14 @@ The amount of extra content the list should render in addition to what's necessa
 |--------|---------|
 | number | 0       |
 
+### returnAllReadData
+
+Keep track of read receipts for each message sent by the user. When disabled, only the last own message delivery / read status is rendered.
+
+| Type    | Default |
+|---------|---------|
+| boolean | false   |
+
 ### scrollSeekPlaceHolder
 
 Custom data passed to the list that determines when message placeholders should be shown during fast scrolling.


### PR DESCRIPTION
### 🎯 Goal

Enable rendering of read receipts inside `VirtualizedMessageList`. This feature mirrors the read receipt behavior in `MessageList` component.

Integrators can now use a new `VirtualizedMessageList` prop `returnAllReadData`. This again mirrors the `MessageList` prop. 

close #2074 

### 🛠 Implementation details

The VML now starts to memoize the mapping of what other users have read which messages send by the local user. The logic is mirrored from `MessageList`.

