### PR TITLE
v10.9.0

### DIFF
--- a/docusaurus/docs/React/components/core-components/virtualized-list.mdx
+++ b/docusaurus/docs/React/components/core-components/virtualized-list.mdx
@@ -199,6 +199,14 @@ The amount of extra content the list should render in addition to what's necessa
 |--------|---------|
 | number | 0       |
 
+### returnAllReadData
+
+Keep track of read receipts for each message sent by the user. When disabled, only the last own message delivery / read status is rendered.
+
+| Type    | Default |
+|---------|---------|
+| boolean | false   |
+
 ### scrollSeekPlaceHolder
 
 Custom data passed to the list that determines when message placeholders should be shown during fast scrolling.

--- a/src/components/Message/__tests__/MessageSimple.test.js
+++ b/src/components/Message/__tests__/MessageSimple.test.js
@@ -16,14 +16,17 @@ import { MESSAGE_ACTIONS } from '../utils';
 import { Attachment as AttachmentMock } from '../../Attachment';
 import { Avatar as AvatarMock } from '../../Avatar';
 import { EditMessageForm, MessageInput as MessageInputMock } from '../../MessageInput';
+import { getReadStates } from '../../MessageList';
 import { MML as MMLMock } from '../../MML';
 import { Modal as ModalMock } from '../../Modal';
 
-import { ChannelActionProvider } from '../../../context/ChannelActionContext';
-import { ChannelStateProvider } from '../../../context/ChannelStateContext';
-import { ChatProvider } from '../../../context/ChatContext';
-import { ComponentProvider } from '../../../context/ComponentContext';
-import { TranslationProvider } from '../../../context/TranslationContext';
+import {
+  ChannelActionProvider,
+  ChannelStateProvider,
+  ChatProvider,
+  ComponentProvider,
+  TranslationProvider,
+} from '../../../context';
 import {
   emojiDataMock,
   generateChannel,
@@ -52,12 +55,13 @@ const openThreadMock = jest.fn();
 const tDateTimeParserMock = jest.fn((date) => Dayjs(date));
 const retrySendMessageMock = jest.fn();
 
-async function renderMessageSimple(
+async function renderMessageSimple({
   message,
   props = {},
   channelConfigOverrides = { reactions: true, replies: true },
   components = {},
-) {
+  renderer = render,
+}) {
   const channel = generateChannel({
     getConfig: () => channelConfigOverrides,
     state: { membership: {} },
@@ -66,7 +70,7 @@ async function renderMessageSimple(
   const channelConfig = channel.getConfig();
   const client = await getTestClientWithUser(alice);
 
-  return render(
+  return renderer(
     <ChatProvider value={{ client, themeVersion: '1' }}>
       <ChannelStateProvider
         value={{ channel, channelCapabilities, channelConfig, emojiConfig: emojiDataMock }}
@@ -118,7 +122,7 @@ describe('<MessageSimple />', () => {
 
   it('should not render anything if message is of custom type message.date', async () => {
     const message = generateAliceMessage({ customType: 'message.date' });
-    const { container } = await renderMessageSimple(message);
+    const { container } = await renderMessageSimple({ message });
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -126,7 +130,7 @@ describe('<MessageSimple />', () => {
     const deletedMessage = generateAliceMessage({
       deleted_at: new Date('2019-12-17T03:24:00'),
     });
-    const { container, getByTestId } = await renderMessageSimple(deletedMessage);
+    const { container, getByTestId } = await renderMessageSimple({ message: deletedMessage });
     expect(getByTestId('message-deleted-component')).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -137,8 +141,11 @@ describe('<MessageSimple />', () => {
       deleted_at: new Date('2019-12-25T03:24:00'),
     });
     const CustomMessageDeletedComponent = () => <p data-testid='custom-message-deleted'>Gone!</p>;
-    const { container, getByTestId } = await renderMessageSimple(deletedMessage, null, null, {
-      MessageDeleted: CustomMessageDeletedComponent,
+    const { container, getByTestId } = await renderMessageSimple({
+      components: {
+        MessageDeleted: CustomMessageDeletedComponent,
+      },
+      message: deletedMessage,
     });
     expect(getByTestId('custom-message-deleted')).toBeInTheDocument();
     const results = await axe(container);
@@ -150,8 +157,11 @@ describe('<MessageSimple />', () => {
     const CustomMessageTimestamp = () => (
       <div data-testid='custom-message-timestamp'>Timestamp</div>
     );
-    const { container, getByTestId } = await renderMessageSimple(message, null, null, {
-      MessageTimestamp: CustomMessageTimestamp,
+    const { container, getByTestId } = await renderMessageSimple({
+      components: {
+        MessageTimestamp: CustomMessageTimestamp,
+      },
+      message,
     });
     expect(getByTestId('custom-message-timestamp')).toBeInTheDocument();
     const results = await axe(container);
@@ -161,8 +171,11 @@ describe('<MessageSimple />', () => {
   it('should render message with custom replies count button when one is given', async () => {
     const message = generateAliceMessage({ reply_count: 1 });
     const CustomRepliesCount = () => <div data-testid='custom-message-replies-count'>Replies</div>;
-    const { container, getByTestId } = await renderMessageSimple(message, null, null, {
-      MessageRepliesCountButton: CustomRepliesCount,
+    const { container, getByTestId } = await renderMessageSimple({
+      components: {
+        MessageRepliesCountButton: CustomRepliesCount,
+      },
+      message,
     });
     expect(getByTestId('custom-message-replies-count')).toBeInTheDocument();
     const results = await axe(container);
@@ -172,8 +185,11 @@ describe('<MessageSimple />', () => {
   it('should render message with custom options component when one is given', async () => {
     const message = generateAliceMessage({ text: '' });
     const CustomOptions = () => <div data-testid='custom-message-options'>Options</div>;
-    const { container, getByTestId } = await renderMessageSimple(message, null, null, {
-      MessageOptions: CustomOptions,
+    const { container, getByTestId } = await renderMessageSimple({
+      components: {
+        MessageOptions: CustomOptions,
+      },
+      message,
     });
     expect(getByTestId('custom-message-options')).toBeInTheDocument();
     const results = await axe(container);
@@ -186,14 +202,13 @@ describe('<MessageSimple />', () => {
 
     const CustomEditMessageInput = () => <div>Edit Input</div>;
 
-    const { container } = await renderMessageSimple(
-      message,
-      { clearEditingState, editing: true },
-      null,
-      {
+    const { container } = await renderMessageSimple({
+      components: {
         EditMessageInput: CustomEditMessageInput,
       },
-    );
+      message,
+      props: { clearEditingState, editing: true },
+    });
 
     expect(MessageInputMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -214,11 +229,10 @@ describe('<MessageSimple />', () => {
       text: undefined,
     });
 
-    const { container, queryByTestId } = await renderMessageSimple(
+    const { container, queryByTestId } = await renderMessageSimple({
+      channelConfigOverrides: { reactions: false },
       message,
-      {},
-      { reactions: false },
-    );
+    });
     expect(queryByTestId('reaction-list')).not.toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -240,8 +254,11 @@ describe('<MessageSimple />', () => {
         })}
       </ul>
     );
-    const { container, getByTestId } = await renderMessageSimple(message, null, null, {
-      ReactionsList: CustomReactionsList,
+    const { container, getByTestId } = await renderMessageSimple({
+      components: {
+        ReactionsList: CustomReactionsList,
+      },
+      message,
     });
     expect(getByTestId('custom-reaction-list')).toBeInTheDocument();
     const results = await axe(container);
@@ -251,9 +268,12 @@ describe('<MessageSimple />', () => {
   it('should render an edit form in a modal when in edit mode', async () => {
     const message = generateAliceMessage();
     const clearEditingState = jest.fn();
-    const { container } = await renderMessageSimple(message, {
-      clearEditingState,
-      editing: true,
+    const { container } = await renderMessageSimple({
+      message,
+      props: {
+        clearEditingState,
+        editing: true,
+      },
     });
     expect(ModalMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -276,7 +296,7 @@ describe('<MessageSimple />', () => {
 
   it('should render no status when message not from the current user', async () => {
     const message = generateAliceMessage();
-    const { container, queryByTestId } = await renderMessageSimple(message);
+    const { container, queryByTestId } = await renderMessageSimple({ message });
     expect(queryByTestId(/message-status/)).not.toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -284,7 +304,7 @@ describe('<MessageSimple />', () => {
 
   it('should not render status when message is an error message', async () => {
     const message = generateAliceMessage({ type: 'error' });
-    const { container, queryByTestId } = await renderMessageSimple(message);
+    const { container, queryByTestId } = await renderMessageSimple({ message });
     expect(queryByTestId(/message-status/)).not.toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -292,7 +312,7 @@ describe('<MessageSimple />', () => {
 
   it('should render sending status when sending message', async () => {
     const message = generateAliceMessage({ status: 'sending' });
-    const { container, getByTestId } = await renderMessageSimple(message);
+    const { container, getByTestId } = await renderMessageSimple({ message });
     expect(getByTestId('message-status-sending')).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -300,18 +320,97 @@ describe('<MessageSimple />', () => {
 
   it('should render the "read by" status when the message is not part of a thread and was read by another chat members', async () => {
     const message = generateAliceMessage();
-    const { container, getByTestId } = await renderMessageSimple(message, {
-      readBy: [alice, bob],
+    const { container, getByTestId } = await renderMessageSimple({
+      message,
+      props: {
+        readBy: [alice, bob],
+      },
     });
     expect(getByTestId('message-status-read-by')).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 
+  it('should keep rendering the "received" status for already read message that was updated', async () => {
+    const message = generateAliceMessage({ created_at: new Date('1970-1-2'), status: 'received' });
+    const returnAllReadData = false;
+    const read = {
+      [bob.id]: {
+        last_read: new Date('1970-1-1'),
+        last_read_message_id: message.id,
+        unread_messages: 1,
+        user: bob,
+      },
+    };
+    let ownMessagesReadByOthers = getReadStates([message], read, returnAllReadData);
+    const { container, getByTestId, rerender } = await renderMessageSimple({
+      message,
+      props: {
+        lastReceivedId: message.id,
+        readBy: ownMessagesReadByOthers[message.id],
+      },
+    });
+    expect(getByTestId('message-status-received')).toBeInTheDocument();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+
+    const updatedMessage = { ...message, updated_at: new Date() };
+    ownMessagesReadByOthers = getReadStates([updatedMessage], read, returnAllReadData);
+    await renderMessageSimple({
+      message: updatedMessage,
+      props: {
+        lastReceivedId: message.id,
+        readBy: ownMessagesReadByOthers[message.id],
+      },
+      renderer: rerender,
+    });
+
+    expect(getByTestId('message-status-received')).toBeInTheDocument();
+  });
+
+  it('should keep rendering the "read by" status for already read message that was updated', async () => {
+    const message = generateAliceMessage({ created_at: new Date('1970-2-1'), status: 'received' });
+    const returnAllReadData = false;
+    const read = {
+      [bob.id]: {
+        last_read: new Date('1970-2-2'),
+        last_read_message_id: message.id,
+        unread_messages: 1,
+        user: bob,
+      },
+    };
+    let ownMessagesReadByOthers = getReadStates([message], read, returnAllReadData);
+    const { container, getByTestId, rerender } = await renderMessageSimple({
+      message,
+      props: {
+        lastReceivedId: message.id,
+        readBy: ownMessagesReadByOthers[message.id],
+      },
+    });
+    expect(getByTestId('message-status-read-by')).toBeInTheDocument();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+
+    const updatedMessage = { ...message, updated_at: new Date() };
+    ownMessagesReadByOthers = getReadStates([updatedMessage], read, returnAllReadData);
+    await renderMessageSimple({
+      message: updatedMessage,
+      props: {
+        lastReceivedId: message.id,
+        readBy: ownMessagesReadByOthers[message.id],
+      },
+      renderer: rerender,
+    });
+    expect(getByTestId('message-status-read-by')).toBeInTheDocument();
+  });
+
   it('should render the "read by many" status when the message is not part of a thread and was read by more than one other chat members', async () => {
     const message = generateAliceMessage();
-    const { container, getByTestId } = await renderMessageSimple(message, {
-      readBy: [alice, bob, carol],
+    const { container, getByTestId } = await renderMessageSimple({
+      message,
+      props: {
+        readBy: [alice, bob, carol],
+      },
     });
     expect(getByTestId('message-status-read-by-many')).toBeInTheDocument();
     const results = await axe(container);
@@ -320,8 +419,11 @@ describe('<MessageSimple />', () => {
 
   it('should render a received status when the message has a received status and it is the same message as the last received one', async () => {
     const message = generateAliceMessage({ status: 'received' });
-    const { container, getByTestId } = await renderMessageSimple(message, {
-      lastReceivedId: message.id,
+    const { container, getByTestId } = await renderMessageSimple({
+      message,
+      props: {
+        lastReceivedId: message.id,
+      },
     });
     expect(getByTestId('message-status-received')).toBeInTheDocument();
     const results = await axe(container);
@@ -330,9 +432,12 @@ describe('<MessageSimple />', () => {
 
   it('should not render status when rendered in a thread list and was read by other members', async () => {
     const message = generateAliceMessage();
-    const { container, queryByTestId } = await renderMessageSimple(message, {
-      readBy: [alice, bob, carol],
-      threadList: true,
+    const { container, queryByTestId } = await renderMessageSimple({
+      message,
+      props: {
+        readBy: [alice, bob, carol],
+        threadList: true,
+      },
     });
     expect(queryByTestId(/message-status/)).not.toBeInTheDocument();
     const results = await axe(container);
@@ -341,9 +446,12 @@ describe('<MessageSimple />', () => {
 
   it("should render the message user's avatar", async () => {
     const message = generateBobMessage();
-    const { container } = await renderMessageSimple(message, {
-      onUserClick: jest.fn(),
-      onUserHover: jest.fn(),
+    const { container } = await renderMessageSimple({
+      message,
+      props: {
+        onUserClick: jest.fn(),
+        onUserHover: jest.fn(),
+      },
     });
     expect(AvatarMock).toHaveBeenCalledWith(
       {
@@ -361,8 +469,11 @@ describe('<MessageSimple />', () => {
 
   it('should allow message to be retried when it failed', async () => {
     const message = generateAliceMessage({ status: 'failed' });
-    const { container, getByTestId } = await renderMessageSimple(message, {
-      handleRetry: retrySendMessageMock,
+    const { container, getByTestId } = await renderMessageSimple({
+      message,
+      props: {
+        handleRetry: retrySendMessageMock,
+      },
     });
     expect(retrySendMessageMock).not.toHaveBeenCalled();
     fireEvent.click(getByTestId('message-inner'));
@@ -373,8 +484,11 @@ describe('<MessageSimple />', () => {
 
   it('should render message options', async () => {
     const message = generateAliceMessage({ text: undefined });
-    const { container } = await renderMessageSimple(message, {
-      handleOpenThread: jest.fn(),
+    const { container } = await renderMessageSimple({
+      message,
+      props: {
+        handleOpenThread: jest.fn(),
+      },
     });
     // eslint-disable-next-line jest/prefer-called-with
     expect(MessageOptionsMock).toHaveBeenCalled();
@@ -385,7 +499,7 @@ describe('<MessageSimple />', () => {
   it('should render MML', async () => {
     const mml = '<mml>text</mml>';
     const message = generateAliceMessage({ mml });
-    const { container } = await renderMessageSimple(message);
+    const { container } = await renderMessageSimple({ message });
     expect(MMLMock).toHaveBeenCalledWith(
       expect.objectContaining({ align: 'right', source: mml }),
       {},
@@ -397,7 +511,10 @@ describe('<MessageSimple />', () => {
   it('should render MML on left for others', async () => {
     const mml = '<mml>text</mml>';
     const message = generateBobMessage({ mml });
-    const { container } = await renderMessageSimple(message, { isMyMessage: () => false });
+    const { container } = await renderMessageSimple({
+      message,
+      props: { isMyMessage: () => false },
+    });
     expect(MMLMock).toHaveBeenCalledWith(
       expect.objectContaining({ align: 'left', source: mml }),
       {},
@@ -421,10 +538,13 @@ describe('<MessageSimple />', () => {
       y: 0,
     };
     const unsafeHTML = false;
-    const { container } = await renderMessageSimple(message, {
-      actionsEnabled,
-      messageListRect,
-      unsafeHTML,
+    const { container } = await renderMessageSimple({
+      message,
+      props: {
+        actionsEnabled,
+        messageListRect,
+        unsafeHTML,
+      },
     });
     // eslint-disable-next-line jest/prefer-called-with
     expect(MessageTextMock).toHaveBeenCalled();
@@ -440,7 +560,7 @@ describe('<MessageSimple />', () => {
     const message = generateAliceMessage({
       attachments: [attachment, attachment, attachment],
     });
-    const { container, queryAllByTestId } = await renderMessageSimple(message);
+    const { container, queryAllByTestId } = await renderMessageSimple({ message });
     expect(queryAllByTestId('attachment-file')).toHaveLength(3);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -454,7 +574,7 @@ describe('<MessageSimple />', () => {
     const message = generateAliceMessage({
       attachments: [attachment, attachment, attachment],
     });
-    const { container, queryAllByTestId } = await renderMessageSimple(message);
+    const { container, queryAllByTestId } = await renderMessageSimple({ message });
     expect(queryAllByTestId('gallery-image')).toHaveLength(3);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -464,7 +584,7 @@ describe('<MessageSimple />', () => {
     const message = generateAliceMessage({
       reply_count: 1,
     });
-    const { container, getByTestId } = await renderMessageSimple(message);
+    const { container, getByTestId } = await renderMessageSimple({ message });
     expect(getByTestId('replies-count-button')).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -474,8 +594,11 @@ describe('<MessageSimple />', () => {
     const message = generateAliceMessage({
       reply_count: 1,
     });
-    const { container, getByTestId } = await renderMessageSimple(message, {
-      handleOpenThread: openThreadMock,
+    const { container, getByTestId } = await renderMessageSimple({
+      message,
+      props: {
+        handleOpenThread: openThreadMock,
+      },
     });
     expect(openThreadMock).not.toHaveBeenCalled();
     fireEvent.click(getByTestId('replies-count-button'));
@@ -488,8 +611,11 @@ describe('<MessageSimple />', () => {
 
   it("should display message's user name when message not from the current user", async () => {
     const message = generateBobMessage();
-    const { container, getByText } = await renderMessageSimple(message, {
-      isMyMessage: () => false,
+    const { container, getByText } = await renderMessageSimple({
+      message,
+      props: {
+        isMyMessage: () => false,
+      },
     });
     expect(getByText(bob.name)).toBeInTheDocument();
     const results = await axe(container);
@@ -501,7 +627,7 @@ describe('<MessageSimple />', () => {
     const message = generateAliceMessage({
       created_at: messageDate,
     });
-    const { container, getByText } = await renderMessageSimple(message);
+    const { container, getByText } = await renderMessageSimple({ message });
     expect(getByText('12/12/2019')).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/src/components/MessageList/utils.ts
+++ b/src/components/MessageList/utils.ts
@@ -177,7 +177,7 @@ export const getReadStates = <
 
     // loop messages sent by current user and add read data for other users in channel
     messages.forEach((msg) => {
-      if (msg.updated_at && msg.updated_at < readState.last_read) {
+      if (msg.created_at && msg.created_at < readState.last_read) {
         userLastReadMsgId = msg.id;
 
         // if true, save other user's read data for all messages they've read


### PR DESCRIPTION
- [fix: keep showing message read receipt once read #2080](https://github.com/GetStream/stream-chat-react/pull/2080)
- [feat: show read receipts in VirtualizedMessageList #2076](https://github.com/GetStream/stream-chat-react/pull/2076)