### PR TITLE
fix: enable sending reactions to frozen channel with UseFrozenChannel permission

### DIFF
--- a/docusaurus/docs/React/components/contexts/message-context.mdx
+++ b/docusaurus/docs/React/components/contexts/message-context.mdx
@@ -231,9 +231,9 @@ Function that returns whether or not a message belongs to the current user.
 | ------------- |
 | () => boolean |
 
-### isReactionEnabled
+### isReactionEnabled (deprecated)
 
-If true, reactions are enabled in the currently active channel.
+If true, sending reactions is enabled in the currently active channel.
 
 | Type    | Default |
 | ------- | ------- |

--- a/docusaurus/docs/React/components/message-components/message-ui.mdx
+++ b/docusaurus/docs/React/components/message-components/message-ui.mdx
@@ -351,9 +351,8 @@ Function that returns whether a message belongs to the current user (overrides t
 | ------------- |
 | () => boolean |
 
-### isReactionEnabled
-
-If true, reactions are enabled in the currently active channel (overrides the value stored in `MessageContext`).
+### isReactionEnabled (deprecated)
+If true, sending reactions is enabled in the currently active channel (overrides the value stored in `MessageContext`).
 
 | Type    | Default |
 | ------- | ------- |

--- a/docusaurus/docs/React/guides/theming/message-ui.mdx
+++ b/docusaurus/docs/React/guides/theming/message-ui.mdx
@@ -91,6 +91,7 @@ export const CustomMessage = () => {
 
   const messageWrapperRef = useRef(null);
 
+  const canReact = isReactionEnabled;
   const hasReactions = messageHasReactions(message);
   const hasAttachments = message.attachments && message.attachments.length > 0;
 
@@ -105,13 +106,13 @@ export const CustomMessage = () => {
             <MessageTimestamp />
           </div>
         </div>
-        {showDetailedReactions && isReactionEnabled && (
+        {showDetailedReactions && canReact && (
           <ReactionSelector ref={reactionSelectorRef} />
         )}
         <MessageText />
         <MessageStatus />
         {hasAttachments && <Attachment attachments={message.attachments} />}
-        {hasReactions && !showDetailedReactions && isReactionEnabled && <SimpleReactionsList />}
+        {hasReactions && <SimpleReactionsList />}
         <MessageRepliesCountButton reply_count={message.reply_count} />
       </div>
     </div>

--- a/docusaurus/docs/React/guides/theming/reactions.mdx
+++ b/docusaurus/docs/React/guides/theming/reactions.mdx
@@ -166,6 +166,7 @@ export const CustomMessage = () => {
 
   const messageWrapperRef = useRef(null);
 
+  const canReact = isReactionEnabled;
   const hasReactions = messageHasReactions(message);
 
   return (
@@ -179,13 +180,13 @@ export const CustomMessage = () => {
             <MessageTimestamp />
           </div>
         </div>
-        {showDetailedReactions && isReactionEnabled && (
+        {showDetailedReactions && canReact && (
           <ReactionSelector reactionOptions={customReactions} ref={reactionSelectorRef} />
         )}
         <MessageText />
         <MessageStatus />
         {message.attachments && <Attachment attachments={message.attachments} />}
-        {hasReactions && !showDetailedReactions && isReactionEnabled && (
+        {hasReactions && (
           <SimpleReactionsList reactionOptions={customReactions} />
         )}
         <MessageRepliesCountButton reply_count={message.reply_count} />

--- a/src/components/Message/MessageSimple.tsx
+++ b/src/components/Message/MessageSimple.tsx
@@ -84,6 +84,14 @@ const MessageSimpleWithContext = <
     return <MessageDeleted message={message} />;
   }
 
+  /** FIXME: isReactionEnabled should be removed with next major version and a proper centralized permissions logic should be put in place
+   * With the current permissions implementation it would be sth like:
+   * const messageActions = getMessageActions();
+   * const canReact = messageActions.includes(MESSAGE_ACTIONS.react);
+   */
+  const canReact = isReactionEnabled;
+  const canShowReactions = hasReactions;
+
   const showMetadata = !groupedByUser || endOfGroup;
   const showReplyCountButton = !threadList && !!message.reply_count;
   const allowRetry = message.status === 'failed' && message.errorStatusCode !== 403;
@@ -100,8 +108,7 @@ const MessageSimpleWithContext = <
       'pinned-message': message.pinned,
       'str-chat__message--has-attachment': hasAttachment,
       'str-chat__message--highlighted': highlighted,
-      'str-chat__message--with-reactions str-chat__message-with-thread-link':
-        hasReactions && isReactionEnabled,
+      'str-chat__message--with-reactions str-chat__message-with-thread-link': canShowReactions,
       'str-chat__message-send-can-be-retried':
         message?.status === 'failed' && message?.errorStatusCode !== 403,
       'str-chat__virtual-message__wrapper--end': endOfGroup,
@@ -145,10 +152,8 @@ const MessageSimpleWithContext = <
           >
             <MessageOptions />
             <div className='str-chat__message-reactions-host'>
-              {hasReactions && isReactionEnabled && <ReactionsList reverse />}
-              {showDetailedReactions && isReactionEnabled && (
-                <ReactionSelector ref={reactionSelectorRef} />
-              )}
+              {canShowReactions && <ReactionsList reverse />}
+              {showDetailedReactions && canReact && <ReactionSelector ref={reactionSelectorRef} />}
             </div>
             <div className='str-chat__message-bubble'>
               {message.attachments?.length && !message.quoted_message ? (

--- a/src/components/Message/__tests__/MessageOptions.test.js
+++ b/src/components/Message/__tests__/MessageOptions.test.js
@@ -169,14 +169,17 @@ describe('<MessageOptions />', () => {
     const { getByTestId } = await renderMessageOptions({
       channelStateOpts: {
         channelCapabilities: { 'send-reaction': true },
-        channelConfig: { reactions: true },
       },
     });
     expect(getByTestId(reactionActionTestId)).toBeInTheDocument();
   });
 
   it('should not display reactions action when channel has reactions disabled', async () => {
-    const { queryByTestId } = await renderMessageOptions({ channelConfig: { reactions: false } });
+    const { queryByTestId } = await renderMessageOptions({
+      channelStateOpts: {
+        channelCapabilities: { 'send-reaction': false },
+      },
+    });
     expect(queryByTestId(reactionActionTestId)).not.toBeInTheDocument();
   });
 

--- a/src/components/Message/__tests__/MessageSimple.test.js
+++ b/src/components/Message/__tests__/MessageSimple.test.js
@@ -25,9 +25,11 @@ import {
   ChannelStateProvider,
   ChatProvider,
   ComponentProvider,
+  EmojiProvider,
   TranslationProvider,
 } from '../../../context';
 import {
+  emojiComponentMock,
   emojiDataMock,
   generateChannel,
   generateMessage,
@@ -87,13 +89,22 @@ async function renderMessageSimple({
                 ...components,
               }}
             >
-              <Message
-                getMessageActions={() => Object.keys(MESSAGE_ACTIONS)}
-                isMyMessage={() => true}
-                message={message}
-                threadList={false}
-                {...props}
-              />
+              <EmojiProvider
+                value={{
+                  Emoji: emojiComponentMock.Emoji,
+                  emojiConfig: emojiDataMock,
+                  EmojiIndex: emojiComponentMock.EmojiIndex,
+                  EmojiPicker: emojiComponentMock.EmojiPicker,
+                }}
+              >
+                <Message
+                  getMessageActions={() => Object.keys(MESSAGE_ACTIONS)}
+                  isMyMessage={() => true}
+                  message={message}
+                  threadList={false}
+                  {...props}
+                />
+              </EmojiProvider>
             </ComponentProvider>
           </TranslationProvider>
         </ChannelActionProvider>
@@ -222,7 +233,8 @@ describe('<MessageSimple />', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it('should not render reaction list if reaction is disabled in channel config', async () => {
+  // FIXME: test relying on deprecated channel config parameter
+  it('should render reaction list even though sending reactions is disabled in channel config', async () => {
     const bobReaction = generateReaction({ user: bob });
     const message = generateAliceMessage({
       latest_reactions: [bobReaction],
@@ -233,7 +245,7 @@ describe('<MessageSimple />', () => {
       channelConfigOverrides: { reactions: false },
       message,
     });
-    expect(queryByTestId('reaction-list')).not.toBeInTheDocument();
+    expect(queryByTestId('reaction-list')).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/src/components/Message/__tests__/MessageSimple.test.js
+++ b/src/components/Message/__tests__/MessageSimple.test.js
@@ -60,7 +60,8 @@ const retrySendMessageMock = jest.fn();
 async function renderMessageSimple({
   message,
   props = {},
-  channelConfigOverrides = { reactions: true, replies: true },
+  channelConfigOverrides = { replies: true },
+  channelCapabilities = { 'send-reaction': true },
   components = {},
   renderer = render,
 }) {
@@ -68,7 +69,7 @@ async function renderMessageSimple({
     getConfig: () => channelConfigOverrides,
     state: { membership: {} },
   });
-  const channelCapabilities = { 'send-reaction': true };
+
   const channelConfig = channel.getConfig();
   const client = await getTestClientWithUser(alice);
 
@@ -242,7 +243,7 @@ describe('<MessageSimple />', () => {
     });
 
     const { container, queryByTestId } = await renderMessageSimple({
-      channelConfigOverrides: { reactions: false },
+      channelCapabilities: { 'send-reaction': false },
       message,
     });
     expect(queryByTestId('reaction-list')).toBeInTheDocument();

--- a/src/components/Message/__tests__/MessageText.test.js
+++ b/src/components/Message/__tests__/MessageText.test.js
@@ -235,14 +235,15 @@ describe('<MessageText />', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it('should not show reaction list if disabled in channelConfig', async () => {
+  // FIXME: test relying on deprecated channel config parameter
+  it('should show reaction list even though sending reactions is disabled in channelConfig', async () => {
     const bobReaction = generateReaction({ user: bob });
     const message = generateAliceMessage({
       latest_reactions: [bobReaction],
     });
     const { container, queryByTestId } = await renderMessageText({ message }, { reactions: false });
 
-    expect(queryByTestId('reaction-list')).not.toBeInTheDocument();
+    expect(queryByTestId('reaction-list')).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/src/components/Message/__tests__/MessageText.test.js
+++ b/src/components/Message/__tests__/MessageText.test.js
@@ -55,13 +55,18 @@ function generateAliceMessage(messageOptions) {
   });
 }
 
-async function renderMessageText(customProps, channelConfigOverrides = {}, renderer = render) {
+async function renderMessageText({
+  customProps = {},
+  channelConfigOverrides = {},
+  renderer = render,
+  channelCapabilitiesOverrides = {},
+} = {}) {
   const client = await getTestClientWithUser(alice);
   const channel = generateChannel({
-    getConfig: () => ({ reactions: true, ...channelConfigOverrides }),
+    getConfig: () => channelConfigOverrides,
     state: { membership: {} },
   });
-  const channelCapabilities = { 'send-reaction': true };
+  const channelCapabilities = { 'send-reaction': true, ...channelCapabilitiesOverrides };
   const channelConfig = channel.getConfig();
   const customDateTimeParser = jest.fn(() => ({ format: jest.fn() }));
 
@@ -105,14 +110,18 @@ const reactionSelectorTestId = 'reaction-selector';
 describe('<MessageText />', () => {
   beforeEach(jest.clearAllMocks);
   it('should not render anything if message is not set', async () => {
-    const { container, queryByTestId } = await renderMessageText({ message: {} });
+    const { container, queryByTestId } = await renderMessageText({
+      customProps: { message: {} },
+    });
     expect(queryByTestId(messageTextTestId)).not.toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 
   it('should not render anything if message text is not set', async () => {
-    const { container, queryByTestId } = await renderMessageText({ message: {} });
+    const { container, queryByTestId } = await renderMessageText({
+      customProps: { message: {} },
+    });
     expect(queryByTestId(messageTextTestId)).not.toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -126,7 +135,7 @@ describe('<MessageText />', () => {
     const message = generateAliceMessage({
       attachments: [attachment, attachment, attachment],
     });
-    const { container, getByTestId } = await renderMessageText({ message });
+    const { container, getByTestId } = await renderMessageText({ customProps: { message } });
     expect(getByTestId(messageTextTestId).className).toContain('--has-attachment');
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -134,7 +143,7 @@ describe('<MessageText />', () => {
 
   it('should set emoji css class when message has text that is only emojis', async () => {
     const message = generateAliceMessage({ text: '🤖🤖🤖🤖' });
-    const { container, getByTestId } = await renderMessageText({ message });
+    const { container, getByTestId } = await renderMessageText({ customProps: { message } });
     expect(getByTestId(messageTextTestId).className).toContain('--is-emoji');
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -143,8 +152,10 @@ describe('<MessageText />', () => {
   it('should handle message mention mouse hover event', async () => {
     const message = generateAliceMessage({ mentioned_users: [bob] });
     const { container, getByTestId } = await renderMessageText({
-      message,
-      onMentionsHoverMessage: onMentionsHoverMock,
+      customProps: {
+        message,
+        onMentionsHoverMessage: onMentionsHoverMock,
+      },
     });
     expect(onMentionsHoverMock).not.toHaveBeenCalled();
     fireEvent.mouseOver(getByTestId(messageTextTestId));
@@ -156,8 +167,10 @@ describe('<MessageText />', () => {
   it('should handle message mention mouse click event', async () => {
     const message = generateAliceMessage({ mentioned_users: [bob] });
     const { container, getByTestId } = await renderMessageText({
-      message,
-      onMentionsClickMessage: onMentionsClickMock,
+      customProps: {
+        message,
+        onMentionsClickMessage: onMentionsClickMock,
+      },
     });
     expect(onMentionsClickMock).not.toHaveBeenCalled();
     fireEvent.click(getByTestId(messageTextTestId));
@@ -168,7 +181,7 @@ describe('<MessageText />', () => {
 
   it('should inform that message was not sent when message is has type "error"', async () => {
     const message = generateAliceMessage({ type: 'error' });
-    const { container, getByText } = await renderMessageText({ message });
+    const { container, getByText } = await renderMessageText({ customProps: { message } });
     expect(getByText('Error · Unsent')).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -176,7 +189,7 @@ describe('<MessageText />', () => {
 
   it('should inform that retry is possible when message has status "failed"', async () => {
     const message = generateAliceMessage({ status: 'failed' });
-    const { container, getByText } = await renderMessageText({ message });
+    const { container, getByText } = await renderMessageText({ customProps: { message } });
     expect(getByText('Message Failed · Click to try again')).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -187,8 +200,10 @@ describe('<MessageText />', () => {
       html: '<span data-testid="custom-html" />',
     });
     const { container, getByTestId } = await renderMessageText({
-      message,
-      unsafeHTML: true,
+      customProps: {
+        message,
+        unsafeHTML: true,
+      },
     });
     expect(getByTestId('custom-html')).toBeInTheDocument();
     const results = await axe(container);
@@ -198,7 +213,7 @@ describe('<MessageText />', () => {
   it('render message text', async () => {
     const text = 'Hello, world!';
     const message = generateAliceMessage({ text });
-    const { container, getByText } = await renderMessageText({ message });
+    const { container, getByText } = await renderMessageText({ customProps: { message } });
     expect(getByText(text)).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -211,7 +226,7 @@ describe('<MessageText />', () => {
       text,
     });
 
-    const { container, getByText } = await renderMessageText({ message });
+    const { container, getByText } = await renderMessageText({ customProps: { message } });
 
     expect(getByText('hello')).toBeInTheDocument();
     const results = await axe(container);
@@ -226,7 +241,7 @@ describe('<MessageText />', () => {
 
     let container;
     await act(async () => {
-      const result = await renderMessageText({ message });
+      const result = await renderMessageText({ customProps: { message } });
       container = result.container;
     });
 
@@ -241,7 +256,10 @@ describe('<MessageText />', () => {
     const message = generateAliceMessage({
       latest_reactions: [bobReaction],
     });
-    const { container, queryByTestId } = await renderMessageText({ message }, { reactions: false });
+    const { container, queryByTestId } = await renderMessageText({
+      channelCapabilitiesOverrides: { 'send-reaction': false },
+      customProps: { message },
+    });
 
     expect(queryByTestId('reaction-list')).toBeInTheDocument();
     const results = await axe(container);
@@ -253,7 +271,9 @@ describe('<MessageText />', () => {
     const message = generateAliceMessage({
       latest_reactions: [bobReaction],
     });
-    const { container, getByTestId, queryByTestId } = await renderMessageText({ message });
+    const { container, getByTestId, queryByTestId } = await renderMessageText({
+      customProps: { message },
+    });
     expect(queryByTestId(reactionSelectorTestId)).not.toBeInTheDocument();
     await act(() => {
       fireEvent.click(getByTestId('reaction-list'));
@@ -274,8 +294,10 @@ describe('<MessageText />', () => {
   it('should render message options with custom props when those are set', async () => {
     const displayLeft = false;
     const { container } = await renderMessageText({
-      customOptionProps: {
-        displayLeft,
+      customProps: {
+        customOptionProps: {
+          displayLeft,
+        },
       },
     });
     // eslint-disable-next-line jest/prefer-called-with
@@ -287,7 +309,10 @@ describe('<MessageText />', () => {
   it('should render with a custom wrapper class when one is set', async () => {
     const customWrapperClass = 'custom-wrapper';
     const message = generateMessage({ text: 'hello world' });
-    const tree = await renderMessageText({ customWrapperClass, message }, {}, testRenderer.create);
+    const tree = await renderMessageText({
+      customProps: { customWrapperClass, message },
+      renderer: testRenderer.create,
+    });
     expect(tree.toJSON()).toMatchInlineSnapshot(`
       <div
         className="str-chat__message str-chat__message-simple str-chat__message--regular str-chat__message--received str-chat__message--other str-chat__message--has-text"
@@ -329,7 +354,10 @@ describe('<MessageText />', () => {
   it('should render with a custom inner class when one is set', async () => {
     const customInnerClass = 'custom-inner';
     const message = generateMessage({ text: 'hi mate' });
-    const tree = await renderMessageText({ customInnerClass, message }, {}, testRenderer.create);
+    const tree = await renderMessageText({
+      customProps: { customInnerClass, message },
+      renderer: testRenderer.create,
+    });
     expect(tree.toJSON()).toMatchInlineSnapshot(`
       <div
         className="str-chat__message str-chat__message-simple str-chat__message--regular str-chat__message--received str-chat__message--other str-chat__message--has-text"
@@ -370,7 +398,10 @@ describe('<MessageText />', () => {
 
   it('should render with custom theme identifier in generated css classes when theme is set', async () => {
     const message = generateMessage({ text: 'whatup?!' });
-    const tree = await renderMessageText({ message, theme: 'custom' }, {}, testRenderer.create);
+    const tree = await renderMessageText({
+      customProps: { message, theme: 'custom' },
+      renderer: testRenderer.create,
+    });
     expect(tree.toJSON()).toMatchInlineSnapshot(`
       <div
         className="str-chat__message str-chat__message-simple str-chat__message--regular str-chat__message--received str-chat__message--other str-chat__message--has-text"

--- a/src/components/Message/__tests__/QuotedMessage.test.js
+++ b/src/components/Message/__tests__/QuotedMessage.test.js
@@ -38,16 +38,16 @@ const Attachment = (props) => <div data-testid={props.attachments[0].testId} />;
 const alice = generateUser({ name: 'alice' });
 const jumpToMessageMock = jest.fn();
 
-async function renderQuotedMessage(customProps, channelConfigOverrides = {}, renderer = render) {
+async function renderQuotedMessage(customProps) {
   const client = await getTestClientWithUser(alice);
   const channel = generateChannel({
-    getConfig: () => ({ reactions: true, ...channelConfigOverrides }),
+    getConfig: () => {},
     state: { membership: {} },
   });
   const channelConfig = channel.getConfig();
   const customDateTimeParser = jest.fn(() => ({ format: jest.fn() }));
 
-  return renderer(
+  return render(
     <ChatProvider value={{ client }}>
       <ChannelStateProvider value={{ channel, channelConfig }}>
         <ChannelActionProvider value={{ jumpToMessage: jumpToMessageMock }}>

--- a/src/components/Message/hooks/__tests__/useReactionHandler.test.js
+++ b/src/components/Message/hooks/__tests__/useReactionHandler.test.js
@@ -167,14 +167,13 @@ describe('useReactionClick custom hook', () => {
   it('should return correct value for isReactionEnabled', () => {
     const channel = generateChannel();
     const channelCapabilities = { 'send-reaction': true };
-    const channelConfig = { reactions: true };
 
     const { rerender, result } = renderHook(
       () => useReactionClick(generateMessage(), React.createRef(), React.createRef()),
       {
         // eslint-disable-next-line react/display-name
         wrapper: ({ children }) => (
-          <ChannelStateProvider value={{ channel, channelCapabilities, channelConfig }}>
+          <ChannelStateProvider value={{ channel, channelCapabilities }}>
             {children}
           </ChannelStateProvider>
         ),
@@ -186,10 +185,6 @@ describe('useReactionClick custom hook', () => {
     rerender();
     expect(result.current.isReactionEnabled).toBe(false);
     channelCapabilities['send-reaction'] = true;
-    channelConfig['reactions'] = false;
-    rerender();
-    expect(result.current.isReactionEnabled).toBe(false);
-    channelConfig['reactions'] = true;
     rerender();
     expect(result.current.isReactionEnabled).toBe(true);
   });

--- a/src/components/Message/hooks/useReactionHandler.ts
+++ b/src/components/Message/hooks/useReactionHandler.ts
@@ -139,7 +139,7 @@ export const useReactionClick = <
   messageWrapperRef?: RefObject<HTMLDivElement | null>,
   closeReactionSelectorOnClick?: boolean,
 ) => {
-  const { channelCapabilities = {}, channelConfig } = useChannelStateContext<StreamChatGenerics>(
+  const { channelCapabilities = {} } = useChannelStateContext<StreamChatGenerics>(
     'useReactionClick',
   );
 
@@ -147,8 +147,7 @@ export const useReactionClick = <
 
   const hasListener = useRef(false);
 
-  const isReactionEnabled =
-    channelConfig?.reactions !== false && channelCapabilities['send-reaction'];
+  const isReactionEnabled = channelCapabilities['send-reaction'];
 
   const messageDeleted = !!message?.deleted_at;
 

--- a/src/context/MessageContext.tsx
+++ b/src/context/MessageContext.tsx
@@ -58,7 +58,9 @@ export type MessageContextValue<
   handleRetry: ChannelActionContextValue<StreamChatGenerics>['retrySendMessage'];
   /** Function that returns whether or not the Message belongs to the current user */
   isMyMessage: () => boolean;
-  /** Whether or not reactions are enabled for the active channel */
+  /** @deprecated will be removed in the next major release.
+   *  Whether sending reactions is enabled for the active channel.
+   */
   isReactionEnabled: boolean;
   /** The message object */
   message: StreamMessage<StreamChatGenerics>;


### PR DESCRIPTION
### 🎯 Goal

The PR introduces two changes:

1. allow to send reactions to frozen channel for users who have `UseFrozenChannel` permission
2. the prop / value of `isReactionEnabled` should be used to determine permission to send reactions only. Not to view them. This is to achieve parity with other SDKs that use only channel's own capability `send-reaction` to determine, whether reactions can be send. Angular neither RN SDK have notion of enabling reactions (meaning read + write). This seems like a legacy code from times, when `channelConfig.reactions` was used to control reactions. This change means that existing reactions will be always visible in the default implementation of `MessageSimple`. The integrators however can still override the prop on the `MessageSimple` level.

