### PR TITLE
feat: add messageDeliveryStatus prop to ChannelListPreview

### DIFF
--- a/docusaurus/docs/React/components/utility-components/channel-preview-ui.mdx
+++ b/docusaurus/docs/React/components/utility-components/channel-preview-ui.mdx
@@ -109,6 +109,40 @@ Latest message preview to display. Will be either a string or a JSX.Element rend
 | --------------------- |
 | string \| JSX.Element |
 
+### messageDeliveryStatus
+
+Status describing whether own message has been delivered or read by another. If the last message is not an own message, then the status is undefined. The value is calculated from `channel.read` data on mount and updated on every `message.new` resp. `message.read` WS event.
+
+| Type                    |
+|-------------------------|
+| `MessageDeliveryStatus` |
+
+Use `MessageDeliveryStatus` enum to determine the current delivery status, for example:
+
+```typescript jsx
+import { MessageDeliveryStatus } from 'stream-chat-react';
+import {
+    DoubleCheckMarkIcon,
+    SingleCheckMarkIcon,
+} from '../icons';
+
+type MessageDeliveryStatusIndicator = {
+    messageDeliveryStatus: MessageDeliveryStatus;
+}
+
+export const MessageDeliveryStatusIndicator = ({ messageDeliveryStatus }: MessageDeliveryStatusIndicator) => {
+    // the last message is not an own message in the channel
+    if (!messageDeliveryStatus) return null;
+
+    return (
+        <div>
+            {messageDeliveryStatus === MessageDeliveryStatus.DELIVERED && <SingleCheckMarkIcon /> }
+            {messageDeliveryStatus === MessageDeliveryStatus.READ && <DoubleCheckMarkIcon /> }
+        </div>
+    );
+};
+```
+
 ### onSelect
 
 Custom handler invoked when the `ChannelPreview` is clicked. The SDK uses `ChannelPreview` to display items of channel search results. There, behind the scenes, the new active channel is set.

--- a/docusaurus/docs/React/guides/customization/channel-list-preview.mdx
+++ b/docusaurus/docs/React/guides/customization/channel-list-preview.mdx
@@ -141,7 +141,7 @@ import '@stream-io/stream-chat-css/dist/css/index.css';
 >
 ```
 
-Next, let's add a little bit more useful information to the component using more of the default props and a value pulled from the `ChatContext`, as well as some styling using custom CSS.
+Next, let's add a bit more useful information to the component using more of the default props and a value pulled from the `ChatContext`, as well as some styling using custom CSS.
 This context also exposes the client which makes it possible to use API methods.
 
 :::note

--- a/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/src/components/ChannelPreview/ChannelPreview.tsx
@@ -7,6 +7,7 @@ import { getLatestMessagePreview } from './utils';
 
 import { ChatContextValue, useChatContext } from '../../context/ChatContext';
 import { useTranslationContext } from '../../context/TranslationContext';
+import { MessageDeliveryStatus, useMessageDeliveryStatus } from './hooks/useMessageDeliveryStatus';
 
 import type { Channel, Event } from 'stream-chat';
 
@@ -29,6 +30,8 @@ export type ChannelPreviewUIComponentProps<
   lastMessage?: StreamMessage<StreamChatGenerics>;
   /** Latest message preview to display, will be a string or JSX element supporting markdown. */
   latestMessage?: string | JSX.Element;
+  /** Status describing whether own message has been delivered or read by another. If the last message is not an own message, then the status is undefined. */
+  messageDeliveryStatus?: MessageDeliveryStatus;
   /** Number of unread Messages */
   unread?: number;
 };
@@ -73,6 +76,10 @@ export const ChannelPreview = <
     channel.state.messages[channel.state.messages.length - 1],
   );
   const [unread, setUnread] = useState(0);
+  const { messageDeliveryStatus } = useMessageDeliveryStatus<StreamChatGenerics>({
+    channel,
+    lastMessage,
+  });
 
   const isActive = activeChannel?.cid === channel.cid;
   const { muted } = useIsChannelMuted(channel);
@@ -126,6 +133,7 @@ export const ChannelPreview = <
       displayTitle={displayTitle}
       lastMessage={lastMessage}
       latestMessage={latestMessage}
+      messageDeliveryStatus={messageDeliveryStatus}
       setActiveChannel={setActiveChannel}
       unread={unread}
     />

--- a/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
+++ b/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
@@ -20,7 +20,6 @@ const UnMemoizedChannelPreviewMessenger = <
     displayImage,
     displayTitle,
     latestMessage,
-    messageDeliveryStatus,
     onSelect: customOnSelectChannel,
     setActiveChannel,
     unread,
@@ -71,7 +70,6 @@ const UnMemoizedChannelPreviewMessenger = <
               {unread}
             </div>
           )}
-          {messageDeliveryStatus && <span>{messageDeliveryStatus}</span>}
         </div>
         <div className='str-chat__channel-preview-messenger--last-message'>{latestMessage}</div>
       </div>

--- a/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
+++ b/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
@@ -20,6 +20,7 @@ const UnMemoizedChannelPreviewMessenger = <
     displayImage,
     displayTitle,
     latestMessage,
+    messageDeliveryStatus,
     onSelect: customOnSelectChannel,
     setActiveChannel,
     unread,
@@ -70,6 +71,7 @@ const UnMemoizedChannelPreviewMessenger = <
               {unread}
             </div>
           )}
+          {messageDeliveryStatus && <span>{messageDeliveryStatus}</span>}
         </div>
         <div className='str-chat__channel-preview-messenger--last-message'>{latestMessage}</div>
       </div>

--- a/src/components/ChannelPreview/hooks/__tests__/useMessageDeliveryStatus.test.js
+++ b/src/components/ChannelPreview/hooks/__tests__/useMessageDeliveryStatus.test.js
@@ -321,6 +321,35 @@ describe('Message delivery status', () => {
       expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.READ);
     });
 
+    it('should ignore mark.read if the last message is not own', async () => {
+      const messages = [
+        generateMessage({ created_at: new Date('1970-01-01T00:00:02.00Z'), user: userB }),
+      ];
+      const lastMessage = messages[0];
+      const read = [
+        {
+          last_read: messages[0].created_at.toISOString(),
+          last_read_message_id: messages[0].id,
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read: messages[0].created_at.toISOString(),
+          unread_messages: 1,
+          user: userB,
+        },
+      ];
+
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      const { rerender, result } = renderComponent({ channel, client, lastMessage });
+
+      await act(() => {
+        dispatchMessageReadEvent(client, userB, channel);
+      });
+      rerender();
+      expect(result.current.messageDeliveryStatus).toBeUndefined();
+    });
+
     it('is kept "delivered" when the last unread message is updated', async () => {
       const messages = [
         generateMessage({ created_at: new Date('1970-01-01T00:00:02.00Z'), user: userA }),

--- a/src/components/ChannelPreview/hooks/__tests__/useMessageDeliveryStatus.test.js
+++ b/src/components/ChannelPreview/hooks/__tests__/useMessageDeliveryStatus.test.js
@@ -1,0 +1,459 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { MessageDeliveryStatus, useMessageDeliveryStatus } from '../useMessageDeliveryStatus';
+import { ChatContext } from '../../../../context';
+import {
+  dispatchMessageDeletedEvent,
+  dispatchMessageNewEvent,
+  dispatchMessageReadEvent,
+  dispatchMessageUpdatedEvent,
+  generateChannel,
+  generateMember,
+  generateMessage,
+  generateUser,
+  getOrCreateChannelApi,
+  getTestClientWithUser,
+  useMockedApis,
+} from '../../../../mock-builders';
+import { act } from '@testing-library/react';
+
+const userA = generateUser();
+const userB = generateUser();
+const getClientAndChannel = async (channelData = {}, user = userA) => {
+  const members = [generateMember({ user: userA }), generateMember({ user: userB })];
+  const client = await getTestClientWithUser(user);
+  const mockedChannel = generateChannel({
+    members,
+    ...channelData,
+  });
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useMockedApis(client, [getOrCreateChannelApi(mockedChannel)]);
+
+  const channel = client.channel('messaging', mockedChannel.channel.id);
+  await channel.watch();
+
+  return {
+    channel,
+    client,
+  };
+};
+
+const renderComponent = ({ channel, client, lastMessage }) => {
+  const wrapper = ({ children }) => (
+    <ChatContext.Provider value={{ client }}>{children}</ChatContext.Provider>
+  );
+
+  return renderHook(() => useMessageDeliveryStatus({ channel, lastMessage }), { wrapper });
+};
+
+describe('Message delivery status', () => {
+  describe('when initiated from channel state', () => {
+    it('is undefined if there are no messages in the channel', async () => {
+      const { channel, client } = await getClientAndChannel({ messages: [] });
+      const { result } = renderComponent({ channel, client });
+      expect(result.current.messageDeliveryStatus).toBeUndefined();
+    });
+
+    it('is undefined if the last message does not have creation date', async () => {
+      const messages = [generateMessage({ created_at: undefined, user: userA })];
+      const lastMessage = messages[0];
+      const read = [
+        {
+          last_read: lastMessage.created_at,
+          last_read_message_id: lastMessage.id,
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read: '1970-01-01T00:00:00.00Z',
+          unread_messages: 1,
+          user: userB,
+        },
+      ];
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      const { result } = renderComponent({ channel, client, lastMessage });
+      expect(result.current.messageDeliveryStatus).toBeUndefined();
+    });
+
+    it('is undefined if the last message was created by another user', async () => {
+      const messages = [
+        generateMessage({ created_at: new Date('1970-01-01T00:00:01.00Z'), user: userA }),
+        generateMessage({ created_at: new Date('1970-01-01T00:00:02.00Z'), user: userB }),
+      ];
+      const lastMessage = messages[1];
+      const read = [
+        {
+          last_read: messages[1].created_at.toISOString(),
+          last_read_message_id: messages[1].id,
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read: messages[0].created_at.toISOString(),
+          last_read_message_id: messages[0].id,
+          unread_messages: 1,
+          user: userB,
+        },
+      ];
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      const { result } = renderComponent({ channel, client, lastMessage });
+      expect(result.current.messageDeliveryStatus).toBeUndefined();
+    });
+
+    it('is "delivered" if the last message in channel was not read by any member other than me', async () => {
+      const messages = [
+        generateMessage({ created_at: new Date('1970-01-01T00:00:01.00Z'), user: userA }),
+        generateMessage({ created_at: new Date('1970-01-01T00:00:02.00Z'), user: userA }),
+      ];
+      const lastMessage = messages[1];
+      const read = [
+        {
+          last_read: messages[1].created_at.toISOString(),
+          last_read_message_id: messages[1].id,
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read: messages[0].created_at.toISOString(),
+          last_read_message_id: messages[0].id,
+          unread_messages: 1,
+          user: userB,
+        },
+      ];
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      const { result } = renderComponent({ channel, client, lastMessage });
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.DELIVERED);
+    });
+
+    it('is "read" if the last message in channel was read by at least 1 other member', async () => {
+      const messages = [
+        generateMessage({ created_at: new Date('1970-01-01T00:00:01.00Z'), user: userA }),
+        generateMessage({ created_at: new Date('1970-01-01T00:00:02.00Z'), user: userA }),
+      ];
+      const lastMessage = messages[1];
+      const last_read = '1970-01-01T00:00:03.00Z';
+      const read = [
+        {
+          last_read,
+          last_read_message_id: lastMessage.id,
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read,
+          last_read_message_id: lastMessage.id,
+          unread_messages: 0,
+          user: userB,
+        },
+      ];
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      const { result } = renderComponent({ channel, client, lastMessage });
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.READ);
+    });
+  });
+
+  describe('on message.new event when other user is muted', () => {
+    // message.read is not delivered over the WS, when the other is muted
+    it('is undefined if receives new message to empty channel', async () => {
+      const { channel, client } = await getClientAndChannel({ messages: [] });
+      client.mutedUsers = [{ target: userB }];
+      const { result } = renderComponent({ channel, client });
+      const newMessage = generateMessage({
+        created_at: new Date('1970-01-01T00:00:02.00Z'),
+        user: userB,
+      });
+      await act(() => {
+        dispatchMessageNewEvent(client, newMessage, channel);
+      });
+      expect(result.current.messageDeliveryStatus).toBeUndefined();
+    });
+
+    it('is "delivered" if received new message to a channel with last message from own user', async () => {
+      const messages = [
+        generateMessage({ created_at: new Date('1970-01-01T00:00:01.00Z'), user: userA }),
+      ];
+      const lastMessage = messages[0];
+      const read = [
+        {
+          last_read: messages[0].created_at.toISOString(),
+          last_read_message_id: messages[0],
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read: '1970-01-01T00:00:01.00Z',
+          unread_messages: 1,
+          user: userB,
+        },
+      ];
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      client.mutedUsers = [{ target: userB }];
+      const { rerender, result } = renderComponent({ channel, client, lastMessage });
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.DELIVERED);
+
+      const newMessage = generateMessage({
+        created_at: new Date('1970-01-01T00:00:02.00Z'),
+        user: userA,
+      });
+      await act(() => {
+        dispatchMessageNewEvent(client, newMessage, channel);
+      });
+      rerender();
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.DELIVERED);
+    });
+
+    it('is "delivered" if received new message to channel with last message from another user', async () => {
+      const messages = [
+        generateMessage({ created_at: new Date('1970-01-01T00:00:01.00Z'), user: userB }),
+      ];
+      const lastMessage = messages[0];
+      const read = [
+        {
+          last_read: messages[0].created_at.toISOString(),
+          last_read_message_id: messages[0],
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read: messages[0].created_at.toISOString(),
+          last_read_message_id: messages[0],
+          unread_messages: 0,
+          user: userB,
+        },
+      ];
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      client.mutedUsers = [{ target: userB }];
+      const { rerender, result } = renderComponent({ channel, client, lastMessage });
+      expect(result.current.messageDeliveryStatus).toBeUndefined();
+
+      const newMessage = generateMessage({
+        created_at: new Date('1970-01-01T00:00:02.00Z'),
+        user: userA,
+      });
+      await act(() => {
+        dispatchMessageNewEvent(client, newMessage, channel);
+      });
+      rerender();
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.DELIVERED);
+    });
+  });
+
+  describe('on event', () => {
+    it('is undefined if the new message was created by another user', async () => {
+      const last_read = '1970-01-01T00:00:02.00Z';
+      const read = [
+        {
+          last_read,
+          user: userA,
+        },
+        {
+          last_read,
+          user: userB,
+        },
+      ];
+      const { channel, client } = await getClientAndChannel({ messages: [], read });
+      const { rerender, result } = renderComponent({ channel, client });
+
+      const newMessage = generateMessage({
+        created_at: new Date('1970-01-01T00:00:02.00Z'),
+        user: userB,
+      });
+      await act(() => {
+        dispatchMessageNewEvent(client, newMessage, channel);
+      });
+      rerender();
+      expect(result.current.messageDeliveryStatus).toBeUndefined();
+    });
+
+    it('is "delivered" if the channel was not marked read by another user', async () => {
+      const last_read = '1970-01-01T00:00:02.00Z';
+      const read = [
+        {
+          last_read,
+          user: userA,
+        },
+        {
+          last_read,
+          user: userB,
+        },
+      ];
+      const { channel, client } = await getClientAndChannel({ messages: [], read });
+      const { rerender, result } = renderComponent({ channel, client });
+
+      const newMessage = generateMessage({
+        created_at: new Date('1970-01-01T00:00:02.00Z'),
+        user: userA,
+      });
+      await act(() => {
+        dispatchMessageNewEvent(client, newMessage, channel);
+      });
+      rerender();
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.DELIVERED);
+    });
+
+    it('is "read" if the channel was read by another user', async () => {
+      const messages = [
+        generateMessage({ created_at: new Date('1970-01-01T00:00:02.00Z'), user: userA }),
+      ];
+      const lastMessage = messages[0];
+      const read = [
+        {
+          last_read: messages[0].created_at.toISOString(),
+          last_read_message_id: messages[0].id,
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read: '1970-01-01T00:00:01.00Z',
+          unread_messages: 1,
+          user: userB,
+        },
+      ];
+
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      const { rerender, result } = renderComponent({ channel, client, lastMessage });
+
+      await act(() => {
+        dispatchMessageReadEvent(client, userB, channel);
+      });
+      rerender();
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.READ);
+    });
+
+    it('is kept "delivered" when the last unread message is updated', async () => {
+      const messages = [
+        generateMessage({ created_at: new Date('1970-01-01T00:00:02.00Z'), user: userA }),
+      ];
+      const lastMessage = messages[0];
+      const read = [
+        {
+          last_read: lastMessage.created_at.toISOString(),
+          last_read_message_id: lastMessage.id,
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read: '1970-01-01T00:00:02.00Z',
+          unread_messages: 1,
+          user: userB,
+        },
+      ];
+
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      const { rerender, result } = renderComponent({ channel, client, lastMessage });
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.DELIVERED);
+
+      const updatedMessage = {
+        ...lastMessage,
+        updated_at: new Date('1970-01-01T00:00:02.00Z'),
+      };
+
+      await act(() => {
+        dispatchMessageUpdatedEvent(client, updatedMessage, channel);
+      });
+      rerender();
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.DELIVERED);
+    });
+
+    it('does not regress to "delivered" when the last read message is updated', async () => {
+      const messages = [
+        generateMessage({ created_at: new Date('1970-01-01T00:00:01.00Z'), user: userA }),
+      ];
+      const lastMessage = messages[0];
+      const last_read = '1970-01-01T00:00:03.00Z';
+      const read = [
+        {
+          last_read,
+          last_read_message_id: lastMessage.id,
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read,
+          last_read_message_id: lastMessage.id,
+          unread_messages: 0,
+          user: userB,
+        },
+      ];
+
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      const { rerender, result } = renderComponent({ channel, client, lastMessage });
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.READ);
+
+      const updatedMessage = {
+        ...lastMessage,
+        updated_at: new Date('1970-01-01T00:00:02.00Z'),
+      };
+
+      await act(() => {
+        dispatchMessageUpdatedEvent(client, updatedMessage, channel);
+      });
+      rerender();
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.READ);
+    });
+
+    it('is kept "delivered" when the last unread message is deleted', async () => {
+      const messages = [
+        generateMessage({ created_at: new Date('1970-01-01T00:00:02.00Z'), user: userA }),
+      ];
+      const lastMessage = messages[0];
+      const read = [
+        {
+          last_read: lastMessage.created_at.toISOString(),
+          last_read_message_id: lastMessage.id,
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read: '1970-01-01T00:00:02.00Z',
+          unread_messages: 1,
+          user: userB,
+        },
+      ];
+
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      const { rerender, result } = renderComponent({ channel, client, lastMessage });
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.DELIVERED);
+
+      await act(() => {
+        dispatchMessageDeletedEvent(client, lastMessage, channel);
+      });
+      rerender();
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.DELIVERED);
+    });
+
+    it('does not regress to "delivered" when the last message is deleted', async () => {
+      const messages = [
+        generateMessage({ created_at: new Date('1970-01-01T00:00:01.00Z'), user: userA }),
+      ];
+      const lastMessage = messages[0];
+      const last_read = '1970-01-01T00:00:03.00Z';
+      const read = [
+        {
+          last_read,
+          last_read_message_id: lastMessage.id,
+          unread_messages: 0,
+          user: userA,
+        },
+        {
+          last_read,
+          last_read_message_id: lastMessage.id,
+          unread_messages: 0,
+          user: userB,
+        },
+      ];
+
+      const { channel, client } = await getClientAndChannel({ messages, read });
+      const { rerender, result } = renderComponent({ channel, client, lastMessage });
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.READ);
+
+      await act(() => {
+        dispatchMessageDeletedEvent(client, lastMessage, channel);
+      });
+
+      rerender();
+      expect(result.current.messageDeliveryStatus).toBe(MessageDeliveryStatus.READ);
+    });
+  });
+});

--- a/src/components/ChannelPreview/hooks/index.ts
+++ b/src/components/ChannelPreview/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useChannelPreviewInfo } from './useChannelPreviewInfo';
+export { MessageDeliveryStatus } from './useMessageDeliveryStatus';

--- a/src/components/ChannelPreview/hooks/useMessageDeliveryStatus.ts
+++ b/src/components/ChannelPreview/hooks/useMessageDeliveryStatus.ts
@@ -26,7 +26,9 @@ export const useMessageDeliveryStatus = <
   lastMessage,
 }: UseMessageStatusParamsChannelPreviewProps<StreamChatGenerics>) => {
   const { client } = useChatContext();
-  const [messageDeliveryStatus, setMessageDeliveryStatus] = useState<MessageDeliveryStatus | undefined>();
+  const [messageDeliveryStatus, setMessageDeliveryStatus] = useState<
+    MessageDeliveryStatus | undefined
+  >();
 
   const isOwnMessage = useCallback(
     (message?: StreamMessage<StreamChatGenerics>) =>

--- a/src/components/ChannelPreview/hooks/useMessageDeliveryStatus.ts
+++ b/src/components/ChannelPreview/hooks/useMessageDeliveryStatus.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import type { Channel, Event } from 'stream-chat';
+
+import type { DefaultStreamChatGenerics } from '../../../types/types';
+import type { StreamMessage } from '../../../context';
+import { useChatContext } from '../../../context';
+
+export enum MessageDeliveryStatus {
+  DELIVERED = 'delivered',
+  READ = 'read',
+}
+
+type UseMessageStatusParamsChannelPreviewProps<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+> = {
+  channel: Channel<StreamChatGenerics>;
+  /** The last message received in a channel */
+  lastMessage?: StreamMessage<StreamChatGenerics>;
+};
+
+export const useMessageDeliveryStatus = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>({
+  channel,
+  lastMessage,
+}: UseMessageStatusParamsChannelPreviewProps<StreamChatGenerics>) => {
+  const { client } = useChatContext();
+  const [messageDeliveryStatus, setMessageDeliveryStatus] = useState<MessageDeliveryStatus>();
+
+  const isOwnMessage = useCallback(
+    (message?: StreamMessage<StreamChatGenerics>) =>
+      client.user && message?.user?.id === client.user.id,
+    [client],
+  );
+
+  useEffect(() => {
+    const lastMessageIsOwn = isOwnMessage(lastMessage);
+    if (!lastMessage?.created_at || !lastMessageIsOwn) return;
+
+    const lastMessageCreatedAtDate =
+      typeof lastMessage.created_at === 'string'
+        ? new Date(lastMessage.created_at)
+        : lastMessage.created_at;
+
+    const channelReadByOthersAfterLastMessageUpdate = Object.values(channel.state.read).some(
+      ({ last_read: channelLastMarkedReadDate, user }) => {
+        const ignoreOwnReadStatus = client.user && user.id !== client.user.id;
+        return ignoreOwnReadStatus && lastMessageCreatedAtDate < channelLastMarkedReadDate;
+      },
+    );
+
+    setMessageDeliveryStatus(
+      channelReadByOthersAfterLastMessageUpdate
+        ? MessageDeliveryStatus.READ
+        : MessageDeliveryStatus.DELIVERED,
+    );
+  }, [channel.state.read, client, isOwnMessage, lastMessage?.created_at]);
+
+  useEffect(() => {
+    const handleMessageNew = (event: Event<StreamChatGenerics>) => {
+      // the last message is not mine, so do not show the delivery status
+      if (!isOwnMessage(event.message)) {
+        return setMessageDeliveryStatus(undefined);
+      }
+
+      return setMessageDeliveryStatus(MessageDeliveryStatus.DELIVERED);
+    };
+    const handleMarkRead = (event: Event<StreamChatGenerics>) => {
+      if (event.user?.id !== client.user?.id) setMessageDeliveryStatus(MessageDeliveryStatus.READ);
+    };
+
+    channel.on('message.new', handleMessageNew);
+    channel.on('message.read', handleMarkRead);
+
+    return () => {
+      channel.off('message.new', handleMessageNew);
+      channel.off('message.read', handleMarkRead);
+    };
+  }, [channel, client, lastMessage?.id, isOwnMessage]);
+
+  return {
+    messageDeliveryStatus,
+  };
+};

--- a/src/components/ChannelPreview/hooks/useMessageDeliveryStatus.ts
+++ b/src/components/ChannelPreview/hooks/useMessageDeliveryStatus.ts
@@ -26,7 +26,7 @@ export const useMessageDeliveryStatus = <
   lastMessage,
 }: UseMessageStatusParamsChannelPreviewProps<StreamChatGenerics>) => {
   const { client } = useChatContext();
-  const [messageDeliveryStatus, setMessageDeliveryStatus] = useState<MessageDeliveryStatus>();
+  const [messageDeliveryStatus, setMessageDeliveryStatus] = useState<MessageDeliveryStatus | undefined>();
 
   const isOwnMessage = useCallback(
     (message?: StreamMessage<StreamChatGenerics>) =>

--- a/src/mock-builders/api/getOrCreateChannel.js
+++ b/src/mock-builders/api/getOrCreateChannel.js
@@ -13,6 +13,7 @@ export const getOrCreateChannelApi = (
     members: [],
     messages: [],
     pinnedMessages: [],
+    read: [],
   },
 ) => {
   const result = {
@@ -21,6 +22,7 @@ export const getOrCreateChannelApi = (
     members: channel.members,
     messages: channel.messages,
     pinnedMessages: channel.pinnedMessages,
+    read: channel.read,
   };
 
   return mockedApiResponse(result, 'post');

--- a/src/mock-builders/event/index.js
+++ b/src/mock-builders/event/index.js
@@ -7,6 +7,7 @@ export { default as dispatchConnectionChangedEvent } from './connectionChanged';
 export { default as dispatchConnectionRecoveredEvent } from './connectionRecovered';
 export { default as dispatchMessageDeletedEvent } from './messageDeleted';
 export { default as dispatchMessageNewEvent } from './messageNew';
+export { default as dispatchMessageReadEvent } from './messageRead';
 export { default as dispatchMessageUpdatedEvent } from './messageUpdated';
 export { default as dispatchNotificationAddedToChannelEvent } from './notificationAddedToChannel';
 export { default as dispatchNotificationMessageNewEvent } from './notificationMessageNew';


### PR DESCRIPTION
### 🎯 Goal

Provide delivery status calculated value to for custom `ChannelPreview` UI component. The default UI component `ChannelPreviewMessenger` does not support the message delivery status visuals.

### 🛠 Implementation details

The `ChannelPreview` component does not have access to the information about a message being sent and not delivered yet and so can infer only the following two delivery states :

1. `DELIVERED`
2. `READ`

The states are exposed to the SDK users in an enum:

```tsx
export enum MessageDeliveryStatus {
  DELIVERED = 'delivered',
  READ = 'read',
}
```

The hook that performs that calculations *`useMessageDeliveryStatus`* is not exported for the SDK users to protect the SDK internals.

### Specs

- The delivery status is calculated only for the last message in the message set

- The delivery status is calculated only for own messages and not those sent by other users

- The delivery status is calculated from the field `read` (`ReadResponse` array) available on the `ChannelAPIResponse`.

- The status is undefined if the last message is not own message.

- The message is considered to be `DELIVERED` on `ChannelPreview` mount, if the channel’s `read` array does not contain `ReadResponse` newer than **the last message creation date**.

- The message is considered to be `DELIVERED` when the message creator receives the `message.new` WS event

- The message is considered to be `READ` on `ChannelPreview` mount, if the channel’s `read` array contains `ReadResponse` newer than **the last message creation date**.

- The message is considered to be `READ` when the message creator receives the the first `message.read` WS event

The status value changes are depicted on the state machine visualization below:

![message_delivery_status_state_machine](https://github.com/GetStream/stream-chat-react/assets/32706194/72a07f7e-93f4-4666-b95a-fa7247bd9406)


### 🎨 UI Changes

None