### PR TITLE
feat: add search debounce interval configuration param

### DIFF
--- a/docusaurus/docs/React/components/utility-components/channel-search.mdx
+++ b/docusaurus/docs/React/components/utility-components/channel-search.mdx
@@ -338,6 +338,14 @@ Custom search function to override default. The first argument should expect an 
 | --------------------------------------------------------------------------------------------------- |
 | (`params: ChannelSearchFunctionParams, event: React.BaseSyntheticEvent` ) => Promise<void\> \| void |
 
+### searchDebounceIntervalMs
+
+The number of milliseconds to debounce the search query.
+
+| Type     | Default |
+|----------|---------|
+| `number` | 300     |
+
 ### SearchInput
 
 Custom UI component to display the search text input.

--- a/docusaurus/docs/React/guides/customization/channel-search.mdx
+++ b/docusaurus/docs/React/guides/customization/channel-search.mdx
@@ -311,7 +311,7 @@ const additionalProps = {
 
 ### The searchFunction Prop:
 
-By default the `ChannelSearch` component searches just for users. Use the `searchForChannels` prop to also search for channels.
+By default, the `ChannelSearch` component searches just for users. Use the `searchForChannels` prop to also search for channels.
 
 To override the search method, completely use the `searchFunction` prop. This prop is useful, say, when you want to search just for channels
 and for only channels that the current logged in user is a member of. See the example below for this.

--- a/src/components/ChannelSearch/__tests__/ChannelSearch.test.js
+++ b/src/components/ChannelSearch/__tests__/ChannelSearch.test.js
@@ -3,71 +3,357 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import '@testing-library/jest-dom';
 
 import { ChannelSearch } from '../ChannelSearch';
-import { generateUser, getTestClientWithUser } from '../../../mock-builders';
-import { Chat } from '../../Chat';
+import {
+  generateChannel,
+  generateUser,
+  getTestClientWithUser,
+  queryUsersApi,
+  useMockedApis,
+} from '../../../mock-builders';
+import { ChatProvider } from '../../../context';
 
 let chatClient;
 const user = generateUser({ id: 'id', name: 'name' });
-const testId = 'channel-search';
+const channelResponseData = generateChannel();
 
-const renderSearch = async ({ props }) => {
-  await act(() => {
+const DEFAULT_DEBOUNCE_INTERVAL = 300;
+const TEST_ID = {
+  CHANNEL_SEARCH: 'channel-search',
+  CHANNEL_SEARCH_RESULTS_HEADER: 'channel-search-results-header',
+  CLEAR_INPUT_BUTTON: 'clear-input-button',
+  SEARCH_IN_PROGRESS_INDICATOR: 'search-in-progress-indicator',
+  SEARCH_INPUT: 'search-input',
+};
+const typedText = 'abc';
+
+const renderSearch = async ({ client, props } = { props: {} }) => {
+  chatClient = client || (await getTestClientWithUser(user));
+
+  const renderResult = await act(() => {
     render(
-      <Chat client={chatClient}>
+      <ChatProvider value={{ client: chatClient, themeVersion: '2' }}>
         <ChannelSearch {...props} />
-      </Chat>,
+      </ChatProvider>,
     );
   });
 
-  const channelSearch = await waitFor(() => screen.getByTestId(testId));
+  const channelSearch = await waitFor(() => screen.getByTestId(TEST_ID.CHANNEL_SEARCH));
+  const searchInput = await waitFor(() => screen.getByTestId(TEST_ID.SEARCH_INPUT));
 
   const typeText = (text) => {
-    fireEvent.change(channelSearch, { target: { value: text } });
+    fireEvent.change(searchInput, { target: { value: text } });
   };
-  return { channelSearch, typeText };
+  return { ...renderResult, channelSearch, chatClient, searchInput, typeText };
 };
 
 describe('ChannelSearch', () => {
-  beforeEach(async () => {
-    chatClient = await getTestClientWithUser(user);
-  });
-
   afterEach(cleanup);
 
   it('should render component without any props', async () => {
-    const { channelSearch } = await renderSearch({});
-    expect(channelSearch).toMatchInlineSnapshot(`
-      <div
-        class="str-chat__channel-search str-chat__channel-search--inline"
-        data-testid="channel-search"
-      >
-        <input
-          class="str-chat__channel-search-input"
-          data-testid="search-input"
-          placeholder="Search"
-          type="text"
-          value=""
-        />
-      </div>
-    `);
+    const { channelSearch } = await renderSearch();
+
+    expect(channelSearch).toMatchSnapshot();
   });
 
   it('displays custom placeholder', async () => {
     const placeholder = 'Custom placeholder';
     const { channelSearch } = await renderSearch({ props: { placeholder } });
-    expect(channelSearch).toMatchInlineSnapshot(`
-      <div
-        class="str-chat__channel-search str-chat__channel-search--inline"
-        data-testid="channel-search"
-      >
-        <input
-          class="str-chat__channel-search-input"
-          data-testid="search-input"
-          placeholder="Custom placeholder"
-          type="text"
-          value=""
-        />
-      </div>
-    `);
+    expect(channelSearch).toMatchSnapshot();
+  });
+
+  it('updates search query value upon each stroke', async () => {
+    const { searchInput, typeText } = await renderSearch();
+    await act(() => {
+      typeText(typedText);
+    });
+
+    await waitFor(() => {
+      expect(searchInput).toHaveValue(typedText);
+    });
+  });
+
+  it('does not update input search query value when disabled', async () => {
+    const { searchInput, typeText } = await renderSearch({ props: { disabled: true } });
+    await act(() => {
+      typeText(typedText);
+    });
+
+    await waitFor(() => {
+      expect(searchInput).toHaveValue('');
+    });
+  });
+
+  it('starts with "searching" flag disabled', async () => {
+    await renderSearch();
+    expect(screen.queryByTestId(TEST_ID.SEARCH_IN_PROGRESS_INDICATOR)).not.toBeInTheDocument();
+  });
+
+  it('sets "searching" flag on first typing stroke', async () => {
+    const { typeText } = await renderSearch();
+    await act(() => {
+      typeText(typedText);
+    });
+    expect(screen.queryByTestId(TEST_ID.SEARCH_IN_PROGRESS_INDICATOR)).toBeInTheDocument();
+  });
+
+  it('removes "searching" flag upon deleting the last character', async () => {
+    const { typeText } = await renderSearch();
+    await act(() => {
+      typeText(typedText);
+    });
+    expect(screen.queryByTestId(TEST_ID.SEARCH_IN_PROGRESS_INDICATOR)).toBeInTheDocument();
+    await act(() => {
+      typeText('');
+    });
+    expect(screen.queryByTestId(TEST_ID.SEARCH_IN_PROGRESS_INDICATOR)).not.toBeInTheDocument();
+  });
+
+  it('removes "searching" flag upon setting search results', async () => {
+    jest.useFakeTimers('modern');
+    const client = await getTestClientWithUser(user);
+    useMockedApis(client, [queryUsersApi([user])]);
+    const { typeText } = await renderSearch({ client });
+    await act(() => {
+      typeText(typedText);
+    });
+    expect(screen.queryByTestId(TEST_ID.SEARCH_IN_PROGRESS_INDICATOR)).toBeInTheDocument();
+    jest.advanceTimersByTime(1000);
+    await waitFor(() => {
+      expect(screen.queryByTestId(TEST_ID.SEARCH_IN_PROGRESS_INDICATOR)).not.toBeInTheDocument();
+    });
+    jest.useRealTimers();
+  });
+
+  it('search is performed by default on users and not channels', async () => {
+    jest.useFakeTimers('modern');
+    const client = await getTestClientWithUser(user);
+    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [user] });
+    jest.spyOn(client, 'queryChannels').mockImplementation();
+    const { typeText } = await renderSearch({ client });
+    await act(() => {
+      typeText(typedText);
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(client.queryUsers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        $or: [{ id: { $autocomplete: typedText } }, { name: { $autocomplete: typedText } }],
+        id: { $ne: 'id' },
+      }),
+      { id: 1 },
+      { limit: 8 },
+    );
+    expect(client.queryUsers).toHaveBeenCalledTimes(1);
+    expect(client.queryChannels).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
+  it('search is performed on users and channels if enabled', async () => {
+    jest.useFakeTimers('modern');
+    const client = await getTestClientWithUser(user);
+    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [user] });
+    jest.spyOn(client, 'queryChannels').mockResolvedValue([channelResponseData]);
+
+    const { typeText } = await renderSearch({ client, props: { searchForChannels: true } });
+    await act(() => {
+      typeText(typedText);
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(client.queryUsers).toHaveBeenCalledTimes(1);
+    expect(client.queryChannels).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
+  });
+
+  it('does not perform search queries when the search is disabled', async () => {
+    jest.useFakeTimers('modern');
+    const client = await getTestClientWithUser(user);
+    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [user] });
+    jest.spyOn(client, 'queryChannels').mockImplementation();
+    const { typeText } = await renderSearch({ client, props: { disabled: true } });
+    await act(() => {
+      typeText(typedText);
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(client.queryUsers).not.toHaveBeenCalled();
+    expect(client.queryChannels).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
+  it('ignores the queries in progress upon clearing the input', async () => {
+    jest.useFakeTimers('modern');
+    const client = await getTestClientWithUser(user);
+    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [user] });
+
+    const { typeText } = await renderSearch({ client });
+    await act(() => {
+      typeText(typedText);
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(DEFAULT_DEBOUNCE_INTERVAL);
+    });
+
+    await act(() => {
+      fireEvent.click(screen.getByTestId(TEST_ID.CLEAR_INPUT_BUTTON));
+    });
+
+    expect(client.queryUsers).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId(TEST_ID.CHANNEL_SEARCH_RESULTS_HEADER)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_ID.SEARCH_IN_PROGRESS_INDICATOR)).not.toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it('ignores the queries in progress upon deleting the last character', async () => {
+    jest.useFakeTimers('modern');
+    const client = await getTestClientWithUser(user);
+    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [user] });
+
+    const { typeText } = await renderSearch({ client });
+    await act(() => {
+      typeText(typedText);
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(DEFAULT_DEBOUNCE_INTERVAL);
+    });
+
+    await act(() => {
+      typeText('');
+    });
+
+    expect(client.queryUsers).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId(TEST_ID.CHANNEL_SEARCH_RESULTS_HEADER)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_ID.SEARCH_IN_PROGRESS_INDICATOR)).not.toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it('debounces the queries upon typing', async () => {
+    jest.useFakeTimers('modern');
+    const textToQuery = 'x';
+    const client = await getTestClientWithUser(user);
+    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [user] });
+
+    const { typeText } = await renderSearch({ client });
+    await act(() => {
+      typeText(typedText);
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(DEFAULT_DEBOUNCE_INTERVAL - 1);
+    });
+
+    expect(client.queryUsers).not.toHaveBeenCalled();
+
+    await act(() => {
+      typeText(textToQuery);
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(DEFAULT_DEBOUNCE_INTERVAL);
+    });
+
+    expect(client.queryUsers).toHaveBeenCalledTimes(1);
+    expect(client.queryUsers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        $or: [{ id: { $autocomplete: textToQuery } }, { name: { $autocomplete: textToQuery } }],
+        id: { $ne: 'id' },
+      }),
+      { id: 1 },
+      { limit: 8 },
+    );
+    jest.useRealTimers();
+  });
+
+  it('allows to configure the search query debounce interval', async () => {
+    jest.useFakeTimers('modern');
+    const textToQuery = 'x';
+    const newDebounceInterval = DEFAULT_DEBOUNCE_INTERVAL - 100;
+    const client = await getTestClientWithUser(user);
+    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [user] });
+
+    const { typeText } = await renderSearch({
+      client,
+      props: { searchDebounceIntervalMs: newDebounceInterval },
+    });
+    await act(() => {
+      typeText(typedText);
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(newDebounceInterval - 1);
+    });
+
+    expect(client.queryUsers).not.toHaveBeenCalled();
+
+    await act(() => {
+      typeText(textToQuery);
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(newDebounceInterval);
+    });
+
+    expect(client.queryUsers).toHaveBeenCalledTimes(1);
+    expect(client.queryUsers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        $or: [{ id: { $autocomplete: textToQuery } }, { name: { $autocomplete: textToQuery } }],
+        id: { $ne: 'id' },
+      }),
+      { id: 1 },
+      { limit: 8 },
+    );
+    jest.useRealTimers();
+  });
+
+  it('calls custom search function instead of the default', async () => {
+    jest.useFakeTimers('modern');
+    const searchFunction = jest.fn();
+    const client = await getTestClientWithUser(user);
+    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [user] });
+    const { typeText } = await renderSearch({ client, props: { searchFunction } });
+    await act(() => {
+      typeText(typedText);
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(DEFAULT_DEBOUNCE_INTERVAL);
+    });
+
+    expect(client.queryUsers).not.toHaveBeenCalled();
+    expect(searchFunction).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('calls custom onSearch callback', async () => {
+    jest.useFakeTimers('modern');
+    const onSearch = jest.fn();
+    const client = await getTestClientWithUser(user);
+    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [user] });
+    const { typeText } = await renderSearch({ client, props: { onSearch } });
+    await act(() => {
+      typeText(typedText);
+    });
+
+    await act(() => {
+      jest.advanceTimersByTime(DEFAULT_DEBOUNCE_INTERVAL);
+    });
+
+    expect(client.queryUsers).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
   });
 });

--- a/src/components/ChannelSearch/__tests__/__snapshots__/ChannelSearch.test.js.snap
+++ b/src/components/ChannelSearch/__tests__/__snapshots__/ChannelSearch.test.js.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ChannelSearch displays custom placeholder 1`] = `
+<div
+  class="str-chat__channel-search str-chat__channel-search--inline"
+  data-testid="channel-search"
+>
+  <div
+    class="str-chat__channel-search-bar"
+    data-testid="search-bar"
+  >
+    <div
+      class="str-chat__channel-search-input--wrapper"
+    >
+      <div
+        class="str-chat__channel-search-input--icon"
+      >
+        <svg
+          fill="none"
+          height="18"
+          viewBox="0 0 18 18"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12.7549 11.255H11.9649L11.6849 10.985C12.6649 9.845 13.2549 8.365 13.2549 6.755C13.2549 3.165 10.3449 0.255005 6.75488 0.255005C3.16488 0.255005 0.254883 3.165 0.254883 6.755C0.254883 10.345 3.16488 13.255 6.75488 13.255C8.36488 13.255 9.84488 12.665 10.9849 11.685L11.2549 11.965V12.755L16.2549 17.745L17.7449 16.255L12.7549 11.255ZM6.75488 11.255C4.26488 11.255 2.25488 9.245 2.25488 6.755C2.25488 4.26501 4.26488 2.255 6.75488 2.255C9.24488 2.255 11.2549 4.26501 11.2549 6.755C11.2549 9.245 9.24488 11.255 6.75488 11.255Z"
+            fill="#747881"
+          />
+        </svg>
+      </div>
+      <input
+        class="str-chat__channel-search-input"
+        data-testid="search-input"
+        placeholder="Custom placeholder"
+        type="text"
+        value=""
+      />
+      <button
+        class="str-chat__channel-search-input--clear-button"
+        data-testid="clear-input-button"
+        disabled=""
+      >
+        <svg
+          fill="none"
+          height="14"
+          viewBox="0 0 14 14"
+          width="14"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14 1.41L12.59 0L7 5.59L1.41 0L0 1.41L5.59 7L0 12.59L1.41 14L7 8.41L12.59 14L14 12.59L8.41 7L14 1.41Z"
+            fill="#747881"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ChannelSearch should render component without any props 1`] = `
+<div
+  class="str-chat__channel-search str-chat__channel-search--inline"
+  data-testid="channel-search"
+>
+  <div
+    class="str-chat__channel-search-bar"
+    data-testid="search-bar"
+  >
+    <div
+      class="str-chat__channel-search-input--wrapper"
+    >
+      <div
+        class="str-chat__channel-search-input--icon"
+      >
+        <svg
+          fill="none"
+          height="18"
+          viewBox="0 0 18 18"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12.7549 11.255H11.9649L11.6849 10.985C12.6649 9.845 13.2549 8.365 13.2549 6.755C13.2549 3.165 10.3449 0.255005 6.75488 0.255005C3.16488 0.255005 0.254883 3.165 0.254883 6.755C0.254883 10.345 3.16488 13.255 6.75488 13.255C8.36488 13.255 9.84488 12.665 10.9849 11.685L11.2549 11.965V12.755L16.2549 17.745L17.7449 16.255L12.7549 11.255ZM6.75488 11.255C4.26488 11.255 2.25488 9.245 2.25488 6.755C2.25488 4.26501 4.26488 2.255 6.75488 2.255C9.24488 2.255 11.2549 4.26501 11.2549 6.755C11.2549 9.245 9.24488 11.255 6.75488 11.255Z"
+            fill="#747881"
+          />
+        </svg>
+      </div>
+      <input
+        class="str-chat__channel-search-input"
+        data-testid="search-input"
+        placeholder="Search"
+        type="text"
+        value=""
+      />
+      <button
+        class="str-chat__channel-search-input--clear-button"
+        data-testid="clear-input-button"
+        disabled=""
+      >
+        <svg
+          fill="none"
+          height="14"
+          viewBox="0 0 14 14"
+          width="14"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14 1.41L12.59 0L7 5.59L1.41 0L0 1.41L5.59 7L0 12.59L1.41 14L7 8.41L12.59 14L14 12.59L8.41 7L14 1.41Z"
+            fill="#747881"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
### 🎯 Goal

- allow users to configure the debounce interval that would delay triggering of search requests to the backend
- change the search query delay method from throttle to debounce
- discard search responses when those are not relevant anymore (the input has been cleared)
