### PR TITLE
feat: allow complete channel list throttled reload on internet connection recovery

### DIFF
--- a/docusaurus/docs/React/components/core-components/channel-list.mdx
+++ b/docusaurus/docs/React/components/core-components/channel-list.mdx
@@ -357,6 +357,39 @@ Custom UI component to display the channel preview in the list.
 | --------- | ---------------------------------------------------------------------------------------------------- |
 | component | <GHComponentLink text='ChannelPreviewMessenger' path='/ChannelPreview/ChannelPreviewMessenger.tsx'/> |
 
+### recoveryThrottleIntervalMs
+
+Custom interval during which the recovery channel list queries will be prevented. This is to avoid firing unnecessary queries during internet connection fluctuation. Recovery channel query is triggered upon internet connection recovery and leads to complete channel list reload with pagination offset 0. The minimum throttle interval is 2000ms. The default throttle interval is 5000ms.
+
+The channel list recovery mechanism described here (applying `recoveryThrottleIntervalMs`) **is activated only if the `StreamChat` client's channel list recovery mechanism is disabled**. The `StreamChat` recovery mechanism can be disabled when initiating the client instance through the `options` parameter:
+
+```typescript jsx
+import { StreamChat } from 'stream-chat';
+import { ChannelList, Chat } from 'stream-chat-react';
+
+// ... get apiKey, filters, sort, options
+
+const client = new StreamChat(apiKey, {recoverStateOnReconnect: false});
+const App = () => (
+    <Chat client={client} >
+     {/** ... */}
+        <ChannelList
+        filters={filters}
+        sort={sort}
+        options={options}
+        recoveryThrottleIntervalMs={3000}
+        {/** other props... */}
+      />
+     {/** ... */}
+    </Chat>
+);
+
+```
+
+| Type   | Default |
+|--------|---------|
+| number | 5000    |
+
 ### renderChannels
 
 Function to override the default behavior when rendering channels, so this function is called instead of rendering the Preview directly.

--- a/src/components/ChannelList/ChannelList.tsx
+++ b/src/components/ChannelList/ChannelList.tsx
@@ -121,6 +121,13 @@ export type ChannelListProps<
   Paginator?: React.ComponentType<PaginatorProps | LoadMorePaginatorProps>;
   /** Custom UI component to display the channel preview in the list, defaults to and accepts same props as: [ChannelPreviewMessenger](https://github.com/GetStream/stream-chat-react/blob/master/src/components/ChannelPreview/ChannelPreviewMessenger.tsx) */
   Preview?: React.ComponentType<ChannelPreviewUIComponentProps<StreamChatGenerics>>;
+  /**
+   * Custom interval during which the recovery channel list queries will be prevented.
+   * This is to avoid firing unnecessary queries during internet connection fluctuation.
+   * Recovery channel query is triggered upon `connection.recovered` and leads to complete channel list reload with pagination offset 0.
+   * The minimum throttle interval is 2000ms. The default throttle interval is 5000ms.
+   */
+  recoveryThrottleIntervalMs?: number;
   /** Function to override the default behavior when rendering channels, so this function is called instead of rendering the Preview directly */
   renderChannels?: (
     channels: Channel<StreamChatGenerics>[],
@@ -167,6 +174,7 @@ const UnMemoizedChannelList = <
     options,
     Paginator = LoadMorePaginator,
     Preview,
+    recoveryThrottleIntervalMs,
     renderChannels,
     sendChannelsToList = false,
     setActiveChannelOnMount = true,
@@ -256,6 +264,7 @@ const UnMemoizedChannelList = <
     sort || DEFAULT_SORT,
     options || DEFAULT_OPTIONS,
     activeChannelHandler,
+    recoveryThrottleIntervalMs,
   );
 
   const loadedChannels = channelRenderFilterFn ? channelRenderFilterFn(channels) : channels;

--- a/src/components/ChannelList/__tests__/ChannelList.test.js
+++ b/src/components/ChannelList/__tests__/ChannelList.test.js
@@ -78,13 +78,13 @@ const SEARCH_RESULT_LIST_SELECTOR = '.str-chat__channel-search-result-list';
 const CHANNEL_LIST_SELECTOR = '.str-chat__channel-list-messenger';
 
 describe('ChannelList', () => {
-  let chatClientUthred;
+  let chatClient;
   let testChannel1;
   let testChannel2;
   let testChannel3;
 
   beforeEach(async () => {
-    chatClientUthred = await getTestClientWithUser({ id: 'uthred' });
+    chatClient = await getTestClientWithUser({ id: 'uthred' });
     testChannel1 = generateChannel();
     testChannel2 = generateChannel();
     testChannel3 = generateChannel();
@@ -103,7 +103,7 @@ describe('ChannelList', () => {
         List: ChannelListComponent,
         Preview: ChannelPreviewComponent,
       };
-      useMockedApis(chatClientUthred, [queryChannelsApi([])]);
+      useMockedApis(chatClient, [queryChannelsApi([])]);
     });
     it('should call `closeMobileNav` prop function, when clicked outside ChannelList', async () => {
       let result;
@@ -112,7 +112,7 @@ describe('ChannelList', () => {
           <ChatContext.Provider
             value={{
               channelsQueryState: channelsQueryStateMock,
-              client: chatClientUthred,
+              client: chatClient,
               closeMobileNav,
               navOpen: true,
             }}
@@ -143,7 +143,7 @@ describe('ChannelList', () => {
           <ChatContext.Provider
             value={{
               channelsQueryState: channelsQueryStateMock,
-              client: chatClientUthred,
+              client: chatClient,
               closeMobileNav,
               navOpen: false,
             }}
@@ -176,10 +176,10 @@ describe('ChannelList', () => {
       Preview: ChannelPreviewComponent,
     };
 
-    useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1])]);
+    useMockedApis(chatClient, [queryChannelsApi([testChannel1])]);
 
     const { container, getByRole, getByTestId, rerender } = render(
-      <Chat client={chatClientUthred}>
+      <Chat client={chatClient}>
         <ChannelList {...props} />
       </Chat>,
     );
@@ -189,9 +189,9 @@ describe('ChannelList', () => {
       expect(getByRole('list')).toBeInTheDocument();
     });
 
-    useMockedApis(chatClientUthred, [queryChannelsApi([testChannel2])]);
+    useMockedApis(chatClient, [queryChannelsApi([testChannel2])]);
     rerender(
-      <Chat client={chatClientUthred}>
+      <Chat client={chatClient}>
         <ChannelList {...props} filters={{ dummyFilter: true }} />
       </Chat>,
     );
@@ -215,10 +215,10 @@ describe('ChannelList', () => {
       Preview: ChannelPreviewComponent,
     };
 
-    useMockedApis(chatClientUthred, [queryChannelsApi([filteredChannel, testChannel1])]);
+    useMockedApis(chatClient, [queryChannelsApi([filteredChannel, testChannel1])]);
 
     const { container, getByRole, queryAllByRole } = render(
-      <Chat client={chatClientUthred}>
+      <Chat client={chatClient}>
         <ChannelList {...props} />
       </Chat>,
     );
@@ -234,11 +234,11 @@ describe('ChannelList', () => {
   });
 
   it('should render `LoadingErrorIndicator` when queryChannels api throws error', async () => {
-    useMockedApis(chatClientUthred, [erroredPostApi()]);
+    useMockedApis(chatClient, [erroredPostApi()]);
     jest.spyOn(console, 'warn').mockImplementationOnce(() => null);
 
     const { container, getByTestId } = render(
-      <Chat client={chatClientUthred}>
+      <Chat client={chatClient}>
         <ChannelList
           filters={{}}
           List={ChannelListComponent}
@@ -257,10 +257,10 @@ describe('ChannelList', () => {
   });
 
   it('ChannelPreview UI components should render `Avatar` when the custom prop is provided', async () => {
-    useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1])]);
+    useMockedApis(chatClient, [queryChannelsApi([testChannel1])]);
 
     const { getByTestId, rerender } = render(
-      <Chat client={chatClientUthred}>
+      <Chat client={chatClient}>
         <ChannelList
           Avatar={() => <div data-testid='custom-avatar-compact'>Avatar</div>}
           List={ChannelListComponent}
@@ -273,7 +273,7 @@ describe('ChannelList', () => {
     });
 
     rerender(
-      <Chat client={chatClientUthred}>
+      <Chat client={chatClient}>
         <ChannelList
           Avatar={() => <div data-testid='custom-avatar-last'>Avatar</div>}
           List={ChannelListComponent}
@@ -287,7 +287,7 @@ describe('ChannelList', () => {
     });
 
     rerender(
-      <Chat client={chatClientUthred}>
+      <Chat client={chatClient}>
         <ChannelList
           Avatar={() => <div data-testid='custom-avatar-messenger'>Avatar</div>}
           List={ChannelListComponent}
@@ -302,12 +302,12 @@ describe('ChannelList', () => {
   });
 
   it('when queryChannels api returns no channels, `EmptyStateIndicator` should be rendered', async () => {
-    useMockedApis(chatClientUthred, [queryChannelsApi([])]);
+    useMockedApis(chatClient, [queryChannelsApi([])]);
 
     const EmptyStateIndicator = () => <div data-testid='empty-state-indicator' role='listitem' />;
 
     const { container, getByTestId } = render(
-      <Chat client={chatClientUthred}>
+      <Chat client={chatClient}>
         <ChannelList
           EmptyStateIndicator={EmptyStateIndicator}
           filters={{}}
@@ -325,10 +325,10 @@ describe('ChannelList', () => {
   });
 
   it('should show unique channels', async () => {
-    useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1, testChannel2])]);
+    useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel2])]);
     const ChannelPreview = (props) => <div data-testid={props.channel.id} role='listitem' />;
     render(
-      <Chat client={chatClientUthred}>
+      <Chat client={chatClient}>
         <ChannelList filters={{}} options={{ limit: 2 }} Preview={ChannelPreview} />
       </Chat>,
     );
@@ -339,7 +339,7 @@ describe('ChannelList', () => {
       expect(screen.getAllByRole('listitem')).toHaveLength(2);
     });
 
-    useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1, testChannel3])]);
+    useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel3])]);
 
     await act(() => {
       fireEvent.click(screen.getByTestId('load-more-button'));
@@ -365,7 +365,7 @@ describe('ChannelList', () => {
 
     beforeEach(() => {
       setActiveChannel = jest.fn();
-      useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1, testChannel2])]);
+      useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel2])]);
     });
 
     it('should call `setActiveChannel` prop function with first channel as param', async () => {
@@ -373,7 +373,7 @@ describe('ChannelList', () => {
         <ChatContext.Provider
           value={{
             channelsQueryState: channelsQueryStateMock,
-            client: chatClientUthred,
+            client: chatClient,
             setActiveChannel,
           }}
         >
@@ -391,7 +391,7 @@ describe('ChannelList', () => {
         </ChatContext.Provider>,
       );
 
-      const channelInstance = chatClientUthred.channel(
+      const channelInstance = chatClient.channel(
         testChannel1.channel.type,
         testChannel1.channel.id,
       );
@@ -404,7 +404,7 @@ describe('ChannelList', () => {
         <ChatContext.Provider
           value={{
             channelsQueryState: channelsQueryStateMock,
-            client: chatClientUthred,
+            client: chatClient,
             setActiveChannel,
           }}
         >
@@ -420,7 +420,7 @@ describe('ChannelList', () => {
         </ChatContext.Provider>,
       );
 
-      const channelInstance = chatClientUthred.channel(
+      const channelInstance = chatClient.channel(
         testChannel2.channel.type,
         testChannel2.channel.id,
       );
@@ -433,7 +433,7 @@ describe('ChannelList', () => {
         <ChatContext.Provider
           value={{
             channelsQueryState: channelsQueryStateMock,
-            client: chatClientUthred,
+            client: chatClient,
             setActiveChannel,
           }}
         >
@@ -740,7 +740,7 @@ describe('ChannelList', () => {
   });
 
   it('should call `renderChannels` function prop, if provided', async () => {
-    useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1, testChannel2])]);
+    useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel2])]);
     const renderChannels = jest.fn();
     const channelListProps = {
       filters: {},
@@ -749,7 +749,7 @@ describe('ChannelList', () => {
       renderChannels,
     };
     const { container, getByRole } = render(
-      <Chat client={chatClientUthred}>
+      <Chat client={chatClient}>
         <ChannelList {...channelListProps} />
       </Chat>,
     );
@@ -778,19 +778,17 @@ describe('ChannelList', () => {
           user: generateUser(),
         });
 
-        act(() => dispatchMessageNewEvent(chatClientUthred, newMessage, testChannel3.channel));
+        act(() => dispatchMessageNewEvent(chatClient, newMessage, testChannel3.channel));
         return newMessage;
       };
 
       beforeEach(() => {
-        useMockedApis(chatClientUthred, [
-          queryChannelsApi([testChannel1, testChannel2, testChannel3]),
-        ]);
+        useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel2, testChannel3])]);
       });
 
       it('should move channel to top of the list', async () => {
         const { container, getAllByRole, getByRole, getByText } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...props} />
           </Chat>,
         );
@@ -816,7 +814,7 @@ describe('ChannelList', () => {
 
       it('should not alter order if `lockChannelOrder` prop is true', async () => {
         const { container, getAllByRole, getByRole, getByText } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...props} lockChannelOrder />
           </Chat>,
         );
@@ -844,10 +842,10 @@ describe('ChannelList', () => {
 
     describe('notification.message_new', () => {
       it('should move channel to top of the list by default', async () => {
-        useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1, testChannel2])]);
+        useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel2])]);
 
         const { container, getAllByRole, getByRole, getByTestId } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList
               filters={{}}
               List={ChannelListComponent}
@@ -862,9 +860,9 @@ describe('ChannelList', () => {
           expect(getByRole('list')).toBeInTheDocument();
         });
 
-        useMockedApis(chatClientUthred, [getOrCreateChannelApi(testChannel3)]);
+        useMockedApis(chatClient, [getOrCreateChannelApi(testChannel3)]);
 
-        act(() => dispatchNotificationMessageNewEvent(chatClientUthred, testChannel3.channel));
+        act(() => dispatchNotificationMessageNewEvent(chatClient, testChannel3.channel));
 
         await waitFor(() => {
           expect(getByTestId(testChannel3.channel.id)).toBeInTheDocument();
@@ -882,10 +880,10 @@ describe('ChannelList', () => {
       it('should call `onMessageNew` function prop, if provided', async () => {
         const onMessageNew = jest.fn();
 
-        useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1])]);
+        useMockedApis(chatClient, [queryChannelsApi([testChannel1])]);
 
         const { container, getByRole } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList
               filters={{}}
               List={ChannelListComponent}
@@ -901,9 +899,9 @@ describe('ChannelList', () => {
           expect(getByRole('list')).toBeInTheDocument();
         });
 
-        useMockedApis(chatClientUthred, [getOrCreateChannelApi(testChannel2)]);
+        useMockedApis(chatClient, [getOrCreateChannelApi(testChannel2)]);
 
-        act(() => dispatchNotificationMessageNewEvent(chatClientUthred, testChannel2.channel));
+        act(() => dispatchNotificationMessageNewEvent(chatClient, testChannel2.channel));
 
         await waitFor(() => {
           expect(onMessageNew).toHaveBeenCalledTimes(1);
@@ -922,13 +920,13 @@ describe('ChannelList', () => {
       };
 
       beforeEach(async () => {
-        chatClientUthred = await getTestClientWithUser({ id: 'vishal' });
-        useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1, testChannel2])]);
+        chatClient = await getTestClientWithUser({ id: 'vishal' });
+        useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel2])]);
       });
 
       it('should move channel to top of the list by default', async () => {
         const { container, getAllByRole, getByRole, getByTestId } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} />
           </Chat>,
         );
@@ -938,9 +936,9 @@ describe('ChannelList', () => {
           expect(getByRole('list')).toBeInTheDocument();
         });
 
-        useMockedApis(chatClientUthred, [getOrCreateChannelApi(testChannel3)]);
+        useMockedApis(chatClient, [getOrCreateChannelApi(testChannel3)]);
 
-        act(() => dispatchNotificationAddedToChannelEvent(chatClientUthred, testChannel3.channel));
+        act(() => dispatchNotificationAddedToChannelEvent(chatClient, testChannel3.channel));
 
         await waitFor(() => {
           expect(getByTestId(testChannel3.channel.id)).toBeInTheDocument();
@@ -958,7 +956,7 @@ describe('ChannelList', () => {
       it('should call `onAddedToChannel` function prop, if provided', async () => {
         const onAddedToChannel = jest.fn();
         const { container, getByRole } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} onAddedToChannel={onAddedToChannel} />
           </Chat>,
         );
@@ -968,7 +966,7 @@ describe('ChannelList', () => {
           expect(getByRole('list')).toBeInTheDocument();
         });
 
-        act(() => dispatchNotificationAddedToChannelEvent(chatClientUthred, testChannel3.channel));
+        act(() => dispatchNotificationAddedToChannelEvent(chatClient, testChannel3.channel));
 
         await waitFor(() => {
           expect(onAddedToChannel).toHaveBeenCalledTimes(1);
@@ -986,14 +984,12 @@ describe('ChannelList', () => {
       };
 
       beforeEach(() => {
-        useMockedApis(chatClientUthred, [
-          queryChannelsApi([testChannel1, testChannel2, testChannel3]),
-        ]);
+        useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel2, testChannel3])]);
       });
 
       it('should remove the channel from list by default', async () => {
         const { container, getByRole, getByTestId } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} />
           </Chat>,
         );
@@ -1003,7 +999,7 @@ describe('ChannelList', () => {
         });
         const nodeToBeRemoved = getByTestId(testChannel3.channel.id);
 
-        act(() => dispatchNotificationRemovedFromChannel(chatClientUthred, testChannel3.channel));
+        act(() => dispatchNotificationRemovedFromChannel(chatClient, testChannel3.channel));
 
         await waitFor(() => {
           expect(nodeToBeRemoved).not.toBeInTheDocument();
@@ -1015,7 +1011,7 @@ describe('ChannelList', () => {
       it('should call `onRemovedFromChannel` function prop, if provided', async () => {
         const onRemovedFromChannel = jest.fn();
         const { container, getByRole } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} onRemovedFromChannel={onRemovedFromChannel} />
           </Chat>,
         );
@@ -1024,7 +1020,7 @@ describe('ChannelList', () => {
           expect(getByRole('list')).toBeInTheDocument();
         });
 
-        act(() => dispatchNotificationRemovedFromChannel(chatClientUthred, testChannel3.channel));
+        act(() => dispatchNotificationRemovedFromChannel(chatClient, testChannel3.channel));
 
         await waitFor(() => {
           expect(onRemovedFromChannel).toHaveBeenCalledTimes(1);
@@ -1042,12 +1038,12 @@ describe('ChannelList', () => {
       };
 
       beforeEach(() => {
-        useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1, testChannel2])]);
+        useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel2])]);
       });
 
       it('should update the channel in list, by default', async () => {
         const { container, getByRole, getByText } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} />
           </Chat>,
         );
@@ -1059,7 +1055,7 @@ describe('ChannelList', () => {
 
         const newChannelName = nanoid();
         act(() =>
-          dispatchChannelUpdatedEvent(chatClientUthred, {
+          dispatchChannelUpdatedEvent(chatClient, {
             ...testChannel2.channel,
             name: newChannelName,
           }),
@@ -1075,7 +1071,7 @@ describe('ChannelList', () => {
       it('should call `onChannelUpdated` function prop, if provided', async () => {
         const onChannelUpdated = jest.fn();
         const { container, getByRole } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} onChannelUpdated={onChannelUpdated} />
           </Chat>,
         );
@@ -1088,7 +1084,7 @@ describe('ChannelList', () => {
         const newChannelName = nanoid();
 
         act(() =>
-          dispatchChannelUpdatedEvent(chatClientUthred, {
+          dispatchChannelUpdatedEvent(chatClient, {
             ...testChannel2.channel,
             name: newChannelName,
           }),
@@ -1110,12 +1106,12 @@ describe('ChannelList', () => {
       };
 
       beforeEach(() => {
-        useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1, testChannel2])]);
+        useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel2])]);
       });
 
       it('should remove channel from list, by default', async () => {
         const { container, getByRole, getByTestId } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} />
           </Chat>,
         );
@@ -1126,7 +1122,7 @@ describe('ChannelList', () => {
         });
 
         const nodeToBeRemoved = getByTestId(testChannel2.channel.id);
-        act(() => dispatchChannelDeletedEvent(chatClientUthred, testChannel2.channel));
+        act(() => dispatchChannelDeletedEvent(chatClient, testChannel2.channel));
 
         await waitFor(() => {
           expect(nodeToBeRemoved).not.toBeInTheDocument();
@@ -1138,7 +1134,7 @@ describe('ChannelList', () => {
       it('should call `onChannelDeleted` function prop, if provided', async () => {
         const onChannelDeleted = jest.fn();
         const { container, getByRole } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} onChannelDeleted={onChannelDeleted} />
           </Chat>,
         );
@@ -1148,7 +1144,7 @@ describe('ChannelList', () => {
           expect(getByRole('list')).toBeInTheDocument();
         });
 
-        act(() => dispatchChannelDeletedEvent(chatClientUthred, testChannel2.channel));
+        act(() => dispatchChannelDeletedEvent(chatClient, testChannel2.channel));
 
         await waitFor(() => {
           expect(onChannelDeleted).toHaveBeenCalledTimes(1);
@@ -1163,7 +1159,7 @@ describe('ChannelList', () => {
           <ChatContext.Provider
             value={{
               channelsQueryState: channelsQueryStateMock,
-              client: chatClientUthred,
+              client: chatClient,
               setActiveChannel,
             }}
           >
@@ -1180,7 +1176,7 @@ describe('ChannelList', () => {
           expect(getByRole('list')).toBeInTheDocument();
         });
 
-        act(() => dispatchChannelDeletedEvent(chatClientUthred, testChannel1.channel));
+        act(() => dispatchChannelDeletedEvent(chatClient, testChannel1.channel));
 
         await waitFor(() => {
           expect(setActiveChannel).toHaveBeenCalledTimes(1);
@@ -1198,12 +1194,12 @@ describe('ChannelList', () => {
       };
 
       beforeEach(() => {
-        useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1, testChannel2])]);
+        useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel2])]);
       });
 
       it('should remove channel from list, by default', async () => {
         const { container, getByRole, getByTestId } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} />
           </Chat>,
         );
@@ -1214,7 +1210,7 @@ describe('ChannelList', () => {
         });
 
         const nodeToBeRemoved = getByTestId(testChannel2.channel.id);
-        act(() => dispatchChannelHiddenEvent(chatClientUthred, testChannel2.channel));
+        act(() => dispatchChannelHiddenEvent(chatClient, testChannel2.channel));
 
         await waitFor(() => {
           expect(nodeToBeRemoved).not.toBeInTheDocument();
@@ -1229,7 +1225,7 @@ describe('ChannelList', () => {
           <ChatContext.Provider
             value={{
               channelsQueryState: channelsQueryStateMock,
-              client: chatClientUthred,
+              client: chatClient,
               setActiveChannel,
             }}
           >
@@ -1246,7 +1242,7 @@ describe('ChannelList', () => {
           expect(getByRole('list')).toBeInTheDocument();
         });
 
-        act(() => dispatchChannelHiddenEvent(chatClientUthred, testChannel1.channel));
+        act(() => dispatchChannelHiddenEvent(chatClient, testChannel1.channel));
 
         await waitFor(() => {
           expect(setActiveChannel).toHaveBeenCalledTimes(1);
@@ -1265,13 +1261,13 @@ describe('ChannelList', () => {
       };
 
       beforeEach(async () => {
-        chatClientUthred = await getTestClientWithUser({ id: 'jaap' });
-        useMockedApis(chatClientUthred, [queryChannelsApi([testChannel1, testChannel2])]);
+        chatClient = await getTestClientWithUser({ id: 'jaap' });
+        useMockedApis(chatClient, [queryChannelsApi([testChannel1, testChannel2])]);
       });
 
       it('should move channel to top of the list by default', async () => {
         const { container, getAllByRole, getByRole, getByTestId } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} />
           </Chat>,
         );
@@ -1281,9 +1277,9 @@ describe('ChannelList', () => {
           expect(getByRole('list')).toBeInTheDocument();
         });
 
-        useMockedApis(chatClientUthred, [getOrCreateChannelApi(testChannel3)]);
+        useMockedApis(chatClient, [getOrCreateChannelApi(testChannel3)]);
 
-        act(() => dispatchChannelVisibleEvent(chatClientUthred, testChannel3.channel));
+        act(() => dispatchChannelVisibleEvent(chatClient, testChannel3.channel));
 
         await waitFor(() => {
           expect(getByTestId(testChannel3.channel.id)).toBeInTheDocument();
@@ -1301,7 +1297,7 @@ describe('ChannelList', () => {
       it('should call `onChannelVisible` function prop, if provided', async () => {
         const onChannelVisible = jest.fn();
         const { container, getByRole } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} onChannelVisible={onChannelVisible} />
           </Chat>,
         );
@@ -1311,7 +1307,7 @@ describe('ChannelList', () => {
           expect(getByRole('list')).toBeInTheDocument();
         });
 
-        act(() => dispatchChannelVisibleEvent(chatClientUthred, testChannel3.channel));
+        act(() => dispatchChannelVisibleEvent(chatClient, testChannel3.channel));
 
         await waitFor(() => {
           expect(onChannelVisible).toHaveBeenCalledTimes(1);
@@ -1331,10 +1327,10 @@ describe('ChannelList', () => {
           Preview: ChannelPreviewComponent,
         };
 
-        useMockedApis(chatClientUthred, [queryChannelsApi([channel1])]);
+        useMockedApis(chatClient, [queryChannelsApi([channel1])]);
 
         const { container, getByRole, getByTestId } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} />
           </Chat>,
         );
@@ -1346,8 +1342,8 @@ describe('ChannelList', () => {
 
         const updateCount = parseInt(getByTestId('channelUpdateCount').textContent, 10);
 
-        useMockedApis(chatClientUthred, [queryChannelsApi([channel2])]);
-        act(() => dispatchConnectionRecoveredEvent(chatClientUthred));
+        useMockedApis(chatClient, [queryChannelsApi([channel2])]);
+        act(() => dispatchConnectionRecoveredEvent(chatClient));
 
         await waitFor(() => {
           expect(parseInt(getByTestId('channelUpdateCount').textContent, 10)).toBe(updateCount + 1);
@@ -1375,13 +1371,13 @@ describe('ChannelList', () => {
         message2 = generateMessage({ user: user1 });
         channel1 = generateChannel({ messages: [message1, message2] });
 
-        useMockedApis(chatClientUthred, [queryChannelsApi([channel1])]);
+        useMockedApis(chatClient, [queryChannelsApi([channel1])]);
       });
 
       it('should call `onChannelTruncated` function prop, if provided', async () => {
         const onChannelTruncated = jest.fn();
         const { container, getByRole } = render(
-          <Chat client={chatClientUthred}>
+          <Chat client={chatClient}>
             <ChannelList {...channelListProps} onChannelTruncated={onChannelTruncated} />
           </Chat>,
         );
@@ -1391,7 +1387,7 @@ describe('ChannelList', () => {
           expect(getByRole('list')).toBeInTheDocument();
         });
 
-        act(() => dispatchChannelTruncatedEvent(chatClientUthred, channel1.channel));
+        act(() => dispatchChannelTruncatedEvent(chatClient, channel1.channel));
 
         await waitFor(() => {
           expect(onChannelTruncated).toHaveBeenCalledTimes(1);
@@ -1399,6 +1395,235 @@ describe('ChannelList', () => {
         const results = await axe(container);
         expect(results).toHaveNoViolations();
       });
+    });
+  });
+
+  describe('on connection recovery', () => {
+    const RECOVER_LOADED_CHANNELS_THROTTLE_INTERVAL_IN_MS = 5000;
+    const MIN_RECOVER_LOADED_CHANNELS_THROTTLE_INTERVAL_IN_MS = 2000;
+    let queryChannelsMock;
+
+    beforeEach(() => {
+      chatClient.recoverStateOnReconnect = false;
+      queryChannelsMock = jest.spyOn(chatClient, 'queryChannels');
+    });
+
+    afterEach(() => {
+      queryChannelsMock.mockClear();
+    });
+
+    const renderUI = (client, channelListProps) =>
+      render(
+        <Chat client={client}>
+          <ChannelList filters={{}} options={{ limit: 2 }} {...channelListProps} />
+        </Chat>,
+      );
+
+    it('should not reload the channels on connection.recovered if client state recovery is enabled (default)', async () => {
+      chatClient.recoverStateOnReconnect = true;
+      renderUI(chatClient);
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(1);
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reload the channels on connection.recovered', async () => {
+      renderUI(chatClient);
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(1);
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(2);
+      expect(chatClient.queryChannels.mock.calls[1][2]).toStrictEqual(
+        expect.objectContaining({ offset: 0 }),
+      );
+    });
+
+    it('should execute recovery queries outside throttle interval', async () => {
+      renderUI(chatClient);
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(1);
+
+      const dateNowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(1)
+        .mockReturnValueOnce(RECOVER_LOADED_CHANNELS_THROTTLE_INTERVAL_IN_MS + 1);
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(2);
+      expect(chatClient.queryChannels.mock.calls[1][2]).toStrictEqual(
+        expect.objectContaining({ offset: 0 }),
+      );
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(3);
+      expect(chatClient.queryChannels.mock.calls[2][2]).toStrictEqual(
+        expect.objectContaining({ offset: 0 }),
+      );
+
+      dateNowSpy.mockRestore();
+    });
+
+    it('should throttle channel queries', async () => {
+      renderUI(chatClient);
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(1);
+
+      const dateNowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(1)
+        .mockReturnValueOnce(RECOVER_LOADED_CHANNELS_THROTTLE_INTERVAL_IN_MS);
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(2);
+      expect(chatClient.queryChannels.mock.calls[1][2]).toStrictEqual(
+        expect.objectContaining({ offset: 0 }),
+      );
+
+      dateNowSpy.mockRestore();
+    });
+
+    it('should circumvent the throttle interval if the last query failed', async () => {
+      renderUI(chatClient);
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(1);
+
+      jest.spyOn(console, 'warn').mockImplementationOnce(() => null);
+      queryChannelsMock.mockRejectedValueOnce(new Error());
+      const dateNowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(1)
+        .mockReturnValueOnce(RECOVER_LOADED_CHANNELS_THROTTLE_INTERVAL_IN_MS);
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(2);
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(3);
+      expect(chatClient.queryChannels.mock.calls[2][2]).toStrictEqual(
+        expect.objectContaining({ offset: 0 }),
+      );
+
+      dateNowSpy.mockRestore();
+    });
+
+    it('should allow custom recovery request throttle interval', async () => {
+      renderUI(chatClient, {
+        recoveryThrottleIntervalMs: MIN_RECOVER_LOADED_CHANNELS_THROTTLE_INTERVAL_IN_MS,
+      });
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(1);
+
+      const dateNowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(1)
+        .mockReturnValueOnce(MIN_RECOVER_LOADED_CHANNELS_THROTTLE_INTERVAL_IN_MS)
+        .mockReturnValueOnce(MIN_RECOVER_LOADED_CHANNELS_THROTTLE_INTERVAL_IN_MS + 1);
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(2);
+      expect(chatClient.queryChannels.mock.calls[1][2]).toStrictEqual(
+        expect.objectContaining({ offset: 0 }),
+      );
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(2);
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(3);
+      dateNowSpy.mockRestore();
+    });
+
+    it('should not allow recovery request throttle interval smaller than 2000ms', async () => {
+      const recoveryThrottleIntervalMs = MIN_RECOVER_LOADED_CHANNELS_THROTTLE_INTERVAL_IN_MS - 1;
+
+      renderUI(chatClient, { recoveryThrottleIntervalMs });
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(1);
+
+      const dateNowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(1)
+        .mockReturnValueOnce(recoveryThrottleIntervalMs + 1)
+        .mockReturnValueOnce(MIN_RECOVER_LOADED_CHANNELS_THROTTLE_INTERVAL_IN_MS + 1);
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(2);
+      expect(chatClient.queryChannels.mock.calls[1][2]).toStrictEqual(
+        expect.objectContaining({ offset: 0 }),
+      );
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(2);
+
+      await act(() => {
+        chatClient.dispatchEvent({
+          type: 'connection.recovered',
+        });
+      });
+      expect(chatClient.queryChannels).toHaveBeenCalledTimes(3);
+
+      dateNowSpy.mockRestore();
     });
   });
 });

--- a/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -96,7 +96,7 @@ export const usePaginatedChannels = <
 
     lastRecoveryTimestamp.current = now;
     queryChannels('reload');
-  }, [error, queryChannels, lastRecoveryTimestamp]);
+  }, [error, queryChannels, recoveryThrottleInterval]);
 
   const loadNextPage = () => {
     queryChannels();


### PR DESCRIPTION
### 🎯 Goal

Allow to load the most recent updates to the ChannelList after the internet connection loss. The `StreamChat` client's recovery mechanism has the following shortcomings:

- re-queries only the channels that have already been loaded into the UI
-  does not throttle the channel list queries.

On the other side, the SDK's recovery mechanism just reloads the channel list based on the filters, sort and options parameters originally provided to `ChannelList` through props.

This is an opt-in feature that has to be enabled as described in the documentation.

Currently it is not possible to load both the latest updates that would include new channels at the top and the originally loaded channels due to the fact that after re-querying the originally loaded channels we loose track of the next page for the channels pagination.


