### PR TITLE
fix: prevent flashing EmptyStateIndicator in ChannelList before the first channels page is loaded

### DIFF
--- a/src/components/ChannelList/ChannelList.tsx
+++ b/src/components/ChannelList/ChannelList.tsx
@@ -350,7 +350,10 @@ const UnMemoizedChannelList = <
           <List
             error={channelsQueryState.error}
             loadedChannels={sendChannelsToList ? loadedChannels : undefined}
-            loading={channelsQueryState.queryInProgress === 'reload'}
+            loading={
+              !!channelsQueryState.queryInProgress &&
+              ['reload', 'uninitialized'].includes(channelsQueryState.queryInProgress)
+            }
             LoadingErrorIndicator={LoadingErrorIndicator}
             LoadingIndicator={LoadingIndicator}
             setChannels={setChannels}

--- a/src/components/Chat/hooks/useChannelsQueryState.ts
+++ b/src/components/Chat/hooks/useChannelsQueryState.ts
@@ -1,18 +1,22 @@
 import { Dispatch, SetStateAction, useState } from 'react';
 import type { APIErrorResponse, ErrorFromResponse } from 'stream-chat';
 
-type ChannelQueryType = 'reload' | 'load-more';
+type ChannelQueryState =
+  | 'uninitialized' // the initial state before the first channels query is trigerred
+  | 'reload' // the initial channels query (loading the first page) is in progress
+  | 'load-more' // loading the next page of channels
+  | null; // at least one channels page has been loaded and there is no query in progress at the moment
 
 export interface ChannelsQueryState {
   error: ErrorFromResponse<APIErrorResponse> | null;
-  queryInProgress: ChannelQueryType | null;
+  queryInProgress: ChannelQueryState | null;
   setError: Dispatch<SetStateAction<ErrorFromResponse<APIErrorResponse> | null>>;
-  setQueryInProgress: Dispatch<SetStateAction<ChannelQueryType | null>>;
+  setQueryInProgress: Dispatch<SetStateAction<ChannelQueryState | null>>;
 }
 
 export const useChannelsQueryState = (): ChannelsQueryState => {
   const [error, setError] = useState<ErrorFromResponse<APIErrorResponse> | null>(null);
-  const [queryInProgress, setQueryInProgress] = useState<ChannelQueryType | null>(null);
+  const [queryInProgress, setQueryInProgress] = useState<ChannelQueryState>('uninitialized');
 
   return {
     error,


### PR DESCRIPTION
### 🎯 Goal

The `EmptyStateIndicator` was flashing before the first channels query used to be triggered. This is a strange UX. 

This was happening because before the first query there were 0 channels loaded and `channelsQueryState.queryInProgress` was initialized with `null` what translates to valid state of channels query returning 0 channels.

### 🛠 Implementation details

This PR introduces a new state / value for `ChatContext.channelsQueryState.queryInProgress` and that is `'uninitialized'`. We cannot use `'reload'` as the first value for `queryInProgress` state , because the `Channel` component also relies on this status. If the `Channel` was not rendered with `ChannelList` the state would never transition to `null` (done inside  `ChannelList`) thus never rendering the `Channel` contents.

With this PR, the `'uninitialized'` state would translate into rendering `LoadingIndicator` in the `ChannelList`. The new state, however, would not be reflected in the `Channel` (again, because of the possibility of rendering the `Channel` without `ChannelList`).

