### PR TITLE
feat: allow to configure channel query options

### DIFF
--- a/docusaurus/docs/React/components/core-components/channel.mdx
+++ b/docusaurus/docs/React/components/core-components/channel.mdx
@@ -176,6 +176,39 @@ Custom UI component to display a user's avatar.
 | --------- | ---------------------------------------------------------- |
 | component | <GHComponentLink text='Avatar' path='/Avatar/Avatar.tsx'/> |
 
+### channelQueryOptions
+
+Optional configuration parameters used for the initial channel query. Applied only if the value of `channel.initialized` is false. If the channel instance has already been initialized (channel has been queried), then the channel query will be skipped and channelQueryOptions will not be applied.
+
+In the example below, we specify, that the first page of messages when a channel is queried should have 20 messages (the default is 100). Note that the `channel` prop has to be passed along `channelQueryOptions`.
+
+```tsx
+import {ChannelQueryOptions} from "stream-chat";
+import {Channel, useChatContext} from "stream-chat-react";
+
+const channelQueryOptions: ChannelQueryOptions = {
+  messages: { limit: 20 },
+};
+
+type ChannelRendererProps = {
+    id: string;
+    type: string;
+};
+
+const ChannelRenderer = ({id, type}: ChannelRendererProps) => {
+  const { client } = useChatContext();
+  return (
+    <Channel channel={client.channel(type, id)} channelQueryOptions={channelQueryOptions}>
+      {/* Channel children */}
+    </Channel>
+  );
+}
+```
+
+| Type                  |
+|-----------------------|
+| `ChannelQueryOptions` |
+
 ### CooldownTimer
 
 Custom UI component to display the slow mode cooldown timer.

--- a/src/components/Channel/__tests__/Channel.test.js
+++ b/src/components/Channel/__tests__/Channel.test.js
@@ -272,7 +272,26 @@ describe('Channel', () => {
       renderComponent({ channel, chatClient });
     });
 
-    await waitFor(() => expect(watchSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(watchSpy).toHaveBeenCalledTimes(1);
+      expect(watchSpy).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  it('should apply channelQueryOptions to channel watch call', async () => {
+    const { channel, chatClient } = await initClient();
+    const watchSpy = jest.spyOn(channel, 'watch');
+    const channelQueryOptions = {
+      messages: { limit: 20 },
+    };
+    await act(() => {
+      renderComponent({ channel, channelQueryOptions, chatClient });
+    });
+
+    await waitFor(() => {
+      expect(watchSpy).toHaveBeenCalledTimes(1);
+      expect(watchSpy).toHaveBeenCalledWith(channelQueryOptions);
+    });
   });
 
   it('should not call watch the current channel on mount if channel is initialized', async () => {
@@ -375,7 +394,7 @@ describe('Channel', () => {
 
     // first, wait for the effect in which the channel is watched,
     // so we know the event listener is added to the document.
-    await waitFor(() => expect(watchSpy).toHaveBeenCalledWith());
+    await waitFor(() => expect(watchSpy).toHaveBeenCalledWith(undefined));
     setTimeout(() => fireEvent(document, new Event('visibilitychange')), 0);
 
     await waitFor(() => expect(markReadSpy).toHaveBeenCalledWith());

--- a/src/utils/getChannel.ts
+++ b/src/utils/getChannel.ts
@@ -1,4 +1,9 @@
-import type { Channel, QueryChannelAPIResponse, StreamChat } from 'stream-chat';
+import type {
+  Channel,
+  ChannelQueryOptions,
+  QueryChannelAPIResponse,
+  StreamChat,
+} from 'stream-chat';
 import type { DefaultStreamChatGenerics } from '../types/types';
 
 /**
@@ -17,12 +22,14 @@ type GetChannelParams<
   channel?: Channel<StreamChatGenerics>;
   id?: string;
   members?: string[];
+  options?: ChannelQueryOptions<StreamChatGenerics>;
   type?: string;
 };
 /**
  * Calls channel.watch() if it was not already recently called. Waits for watch promise to resolve even if it was invoked previously.
  * @param client
  * @param members
+ * @param options
  * @param type
  * @param id
  * @param channel
@@ -34,6 +41,7 @@ export const getChannel = async <
   client,
   id,
   members,
+  options,
   type,
 }: GetChannelParams<StreamChatGenerics>) => {
   if (!channel && !type) {
@@ -60,7 +68,7 @@ export const getChannel = async <
   if (queryPromise) {
     await queryPromise;
   } else {
-    WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid] = theChannel.watch();
+    WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid] = theChannel.watch(options);
     await WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
     delete WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
   }


### PR DESCRIPTION
### 🎯 Goal

At the moment, user cannot specify, how the first channel page will look like, when they pass uninitialized `Channel` instance into `Channel` component props. With this feature, the `ChannelQueryOptions` object will be propagated to all the `channel.watch()` calls inside the `Channel` component context.

**Note**
This PR does not tackle providing channel query options inside `ChannelList` context. There the `channel.watch()` call is performed on the following events:

- `notification.added_to_channel`
- `channel.visible`
- `notification.message_new`

In these cases, the users can pass custom handler functions, that can perform watch queries with custom query options.

