### PR TITLE
fix: calculate pagination stop from custom channel query message limit

### DIFF
--- a/src/components/Channel/channelState.ts
+++ b/src/components/Channel/channelState.ts
@@ -30,6 +30,7 @@ export type ChannelStateReducerAction<
     }
   | {
       channel: Channel<StreamChatGenerics>;
+      hasMore: boolean;
       type: 'initStateFromChannel';
     }
   | {
@@ -132,9 +133,10 @@ export const channelReducer = <
     }
 
     case 'initStateFromChannel': {
-      const { channel } = action;
+      const { channel, hasMore } = action;
       return {
         ...state,
+        hasMore,
         loading: false,
         members: { ...channel.state.members },
         messages: [...channel.state.messages],

--- a/src/components/InfiniteScrollPaginator/InfiniteScroll.tsx
+++ b/src/components/InfiniteScrollPaginator/InfiniteScroll.tsx
@@ -91,7 +91,7 @@ export const InfiniteScroll = (props: PropsWithChildren<InfiniteScrollProps>) =>
     }
 
     if (isLoading) return;
-
+    // FIXME: this triggers loadMore call when a user types messages in thread and the scroll container container expands
     if (
       reverseOffset < Number(threshold) &&
       typeof loadPreviousPageFn === 'function' &&

--- a/src/components/MessageList/utils.ts
+++ b/src/components/MessageList/utils.ts
@@ -318,5 +318,6 @@ export const getGroupStyles = <
 export const hasMoreMessagesProbably = (returnedCountMessages: number, limit: number) =>
   returnedCountMessages === limit;
 
+// @deprecated
 export const hasNotMoreMessages = (returnedCountMessages: number, limit: number) =>
   returnedCountMessages < limit;

--- a/src/components/Thread/Thread.tsx
+++ b/src/components/Thread/Thread.tsx
@@ -125,6 +125,7 @@ const ThreadInner = <
 
   useEffect(() => {
     if (thread?.id && thread?.reply_count) {
+      // FIXME: integrators can customize channel query options but cannot customize channel.getReplies() options
       loadMoreThread();
     }
   }, []);


### PR DESCRIPTION
### 🎯 Goal

The logic to determine whether there are more messages to be loaded from the API was flawed because it relied on the expectation that the first page size will be always constant determined by the SDK. But once the integrators perform the initial channel query outside the `Channel` component with custom query options different from the SDK constant default 
 or they specify this through `Channel` prop `channelQueryOptions`, then the custom value has to be taken into the consideration. Otherwise if the custom first page size was smaller then the default, the next page would not be loaded.

This PR brings a small optimization when the `hasMore` flag is set on the `Channel` component state immediately after the first query resp. also for already initialized channel in the layout effect.