### PR TITLE
fix: revert "feat: expose channels state on chat level (#2161)"

### DIFF
--- a/docusaurus/docs/React/components/contexts/chat-context.mdx
+++ b/docusaurus/docs/React/components/contexts/chat-context.mdx
@@ -33,34 +33,6 @@ The currently active channel, which populates the [`Channel`](../core-components
 | ------- |
 | Channel |
 
-### channels
-
-State representing the array of loaded channels. Channels query is executed by default only within the [`ChannelList` component](../core-components/channel-list.mdx) in the SDK.
-
-| Type        |
-|-------------|
-| `Channel[]` |
-
-### channelsQueryState
-
-Exposes API that:
-
-- indicates, whether and what channels query has been triggered within [`ChannelList` component](../core-components/channel-list.mdx) by its channels pagination controller - `queryInProgress` of type `ChannelQueryState`
-- allows to set the `queryInProgress` state with `setQueryInProgress` state setter
-- keeps track of error response from the channels query - `error`
-- allows to set the `error` state with `setError`
-
-The `queryInProgress` values are:
-
-- `uninitialized` - the initial state before the first channels query is triggered
-- `reload` - the initial channels query (loading the first page) is in progress
-- `load-more` - loading the next page of channels
-- `null` - at least one channels page has been loaded and there is no query in progress at the moment
-
-| Type                 |
-|----------------------|
-| `ChannelsQueryState` |
-
 ### closeMobileNav
 
 The function to close mobile navigation.
@@ -126,76 +98,6 @@ You can override the default behavior by pulling it from context and then utiliz
 | Type     |
 | -------- |
 | function |
-
-### setChannels
-
-Sets the list of `Channel` objects to be rendered by `ChannelList` component. One have to be careful, when to call `setChannels` as the first channels query executed by the `ChannelList` overrides the whole [`channels` state](#channels). In that case it is better to subscribe to `client` event `channels.queried` and only then set the channels.
-In the following example, we have a component that sets the active channel based on the id in the URL. It waits until the first channels page is loaded, and then it sets the active channel. If the channel is not present on the first page, it performs additional API request with `getChannel()`:
-
-```tsx
-import {useEffect} from 'react';
-import {useNavigate, useParams} from 'react-router-dom';
-import {ChannelList, getChannel, useChatContext} from 'stream-chat-react';
-import {ChannelFilters, ChannelOptions, ChannelSort, Event} from 'stream-chat';
-
-const DEFAULT_CHANNEL = 'general';
-const CHANNEL_TYPE = 'messaging';
-
-export const ChannelListWrapper = () => {
-  const { channelId } = useParams();
-  const navigate = useNavigate();
-  const { client, channel, setActiveChannel, setChannels } = useChatContext();
-
-  const filters: ChannelFilters = { type: CHANNEL_TYPE, members: { $in: [client.user?.id || ''] } };
-  const options: ChannelOptions = { state: true, presence: true, limit: 10 };
-  const sort: ChannelSort = { last_message_at: -1, updated_at: -1 };
-
-  // set active channel only if URL param changed
-  useEffect(() => {
-    if (!channelId) return navigate(`/${DEFAULT_CHANNEL}`);
-
-    if (channel?.id === channelId || !client) return;
-
-    let subscription: { unsubscribe: () => void } | undefined;
-    if(!channel?.id || channel?.id !== channelId) {
-      subscription = client.on('channels.queried', (event: Event) => {
-        // check, whether the channel has already been loaded with the first page
-        const loadedChannelData = event.queriedChannels?.channels.find((response) => response.channel.id === channelId);
-
-        if (loadedChannelData) {
-          setActiveChannel(client.channel( CHANNEL_TYPE, channelId));
-          subscription?.unsubscribe();
-          return;
-        }
-
-        return getChannel({client, id: channelId, type: CHANNEL_TYPE}).then((newActiveChannel) => {
-          setActiveChannel(newActiveChannel);
-          setChannels((channels) => {
-            return ([newActiveChannel, ...channels.filter((ch) => ch.data?.cid !== newActiveChannel.data?.cid)]);
-          });
-        });
-      });
-    }
-
-    return () => {
-      subscription?.unsubscribe();
-    };
-  }, [channel?.id, channelId, setChannels, client, navigate, setActiveChannel]);
-
-  return (
-    <ChannelList
-      setActiveChannelOnMount={false}
-      filters={filters}
-      sort={sort}
-      options={options}
-    />
-  );
-};
-```
-
-| Type                                  |
-|---------------------------------------|
-| `Dispatch<SetStateAction<Channel[]>>` |
 
 ### theme
 

--- a/docusaurus/docs/React/components/contexts/chat-context.mdx
+++ b/docusaurus/docs/React/components/contexts/chat-context.mdx
@@ -33,6 +33,26 @@ The currently active channel, which populates the [`Channel`](../core-components
 | ------- |
 | Channel |
 
+### channelsQueryState
+
+Exposes API that:
+
+- indicates, whether and what channels query has been triggered within [`ChannelList` component](../core-components/channel-list.mdx) by its channels pagination controller - `queryInProgress` of type `ChannelQueryState`
+- allows to set the `queryInProgress` state with `setQueryInProgress` state setter
+- keeps track of error response from the channels query - `error`
+- allows to set the `error` state with `setError`
+
+The `queryInProgress` values are:
+
+- `uninitialized` - the initial state before the first channels query is triggered
+- `reload` - the initial channels query (loading the first page) is in progress
+- `load-more` - loading the next page of channels
+- `null` - at least one channels page has been loaded and there is no query in progress at the moment
+
+| Type                 |
+|----------------------|
+| `ChannelsQueryState` |
+
 ### closeMobileNav
 
 The function to close mobile navigation.

--- a/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -26,11 +26,9 @@ export const usePaginatedChannels = <
   recoveryThrottleIntervalMs: number = RECOVER_LOADED_CHANNELS_THROTTLE_INTERVAL_IN_MS,
 ) => {
   const {
-    channels,
     channelsQueryState: { error, setError, setQueryInProgress },
-    setChannels,
-  } = useChatContext<StreamChatGenerics>('usePaginatedChannels');
-
+  } = useChatContext('usePaginatedChannels');
+  const [channels, setChannels] = useState<Array<Channel<StreamChatGenerics>>>([]);
   const [hasNextPage, setHasNextPage] = useState(true);
   const lastRecoveryTimestamp = useRef<number | undefined>();
 
@@ -117,7 +115,6 @@ export const usePaginatedChannels = <
     queryChannels('reload');
   }, [filterString, sortString]);
 
-  // FIXME: state refactor (breaking change) is needed - do not forward `channels` and `setChannel`
   return {
     channels,
     hasNextPage,

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -84,7 +84,6 @@ export const Chat = <
 
   const {
     channel,
-    channels,
     closeMobileNav,
     getAppSettings,
     latestMessageDatesByChannels,
@@ -92,7 +91,6 @@ export const Chat = <
     navOpen,
     openMobileNav,
     setActiveChannel,
-    setChannels,
     translators,
   } = useChat({ client, defaultLanguage, i18nInstance, initialNavOpen });
 
@@ -109,7 +107,6 @@ export const Chat = <
 
   const chatContextValue = useCreateChatContext({
     channel,
-    channels,
     channelsQueryState,
     client,
     closeMobileNav,
@@ -120,7 +117,6 @@ export const Chat = <
     navOpen,
     openMobileNav,
     setActiveChannel,
-    setChannels,
     theme,
     themeVersion,
     useImageFlagEmojisOnWindows,

--- a/src/components/Chat/hooks/useChannelsQueryState.ts
+++ b/src/components/Chat/hooks/useChannelsQueryState.ts
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, useState } from 'react';
 import type { APIErrorResponse, ErrorFromResponse } from 'stream-chat';
 
 type ChannelQueryState =
-  | 'uninitialized' // the initial state before the first channels query is triggered
+  | 'uninitialized' // the initial state before the first channels query is trigerred
   | 'reload' // the initial channels query (loading the first page) is in progress
   | 'load-more' // loading the next page of channels
   | null; // at least one channels page has been loaded and there is no query in progress at the moment

--- a/src/components/Chat/hooks/useChannelsQueryState.ts
+++ b/src/components/Chat/hooks/useChannelsQueryState.ts
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, useState } from 'react';
 import type { APIErrorResponse, ErrorFromResponse } from 'stream-chat';
 
 type ChannelQueryState =
-  | 'uninitialized' // the initial state before the first channels query is trigerred
+  | 'uninitialized' // the initial state before the first channels query is triggered
   | 'reload' // the initial channels query (loading the first page) is in progress
   | 'load-more' // loading the next page of channels
   | null; // at least one channels page has been loaded and there is no query in progress at the moment

--- a/src/components/Chat/hooks/useChat.ts
+++ b/src/components/Chat/hooks/useChat.ts
@@ -36,7 +36,6 @@ export const useChat = <
     userLanguage: 'en',
   });
 
-  const [channels, setChannels] = useState<Array<Channel<StreamChatGenerics>>>([]);
   const [channel, setChannel] = useState<Channel<StreamChatGenerics>>();
   const [mutes, setMutes] = useState<Array<Mute<StreamChatGenerics>>>([]);
   const [navOpen, setNavOpen] = useState(initialNavOpen);
@@ -124,7 +123,6 @@ export const useChat = <
 
   return {
     channel,
-    channels,
     closeMobileNav,
     getAppSettings,
     latestMessageDatesByChannels,
@@ -132,7 +130,6 @@ export const useChat = <
     navOpen,
     openMobileNav,
     setActiveChannel,
-    setChannels,
     translators,
   };
 };

--- a/src/components/Chat/hooks/useCreateChatContext.ts
+++ b/src/components/Chat/hooks/useCreateChatContext.ts
@@ -10,7 +10,6 @@ export const useCreateChatContext = <
 ) => {
   const {
     channel,
-    channels,
     channelsQueryState,
     client,
     closeMobileNav,
@@ -21,7 +20,6 @@ export const useCreateChatContext = <
     navOpen,
     openMobileNav,
     setActiveChannel,
-    setChannels,
     theme,
     themeVersion,
     useImageFlagEmojisOnWindows,
@@ -39,7 +37,6 @@ export const useCreateChatContext = <
   const chatContext: ChatContextValue<StreamChatGenerics> = useMemo(
     () => ({
       channel,
-      channels,
       channelsQueryState,
       client,
       closeMobileNav,
@@ -50,7 +47,6 @@ export const useCreateChatContext = <
       navOpen,
       openMobileNav,
       setActiveChannel,
-      setChannels,
       theme,
       themeVersion,
       useImageFlagEmojisOnWindows,
@@ -59,12 +55,10 @@ export const useCreateChatContext = <
       channelCid,
       channelsQueryError,
       channelsQueryInProgress,
-      channels,
       clientValues,
       getAppSettings,
       mutedUsersLength,
       navOpen,
-      setChannels,
     ],
   );
 

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -28,20 +28,38 @@ export type ThemeVersion = '1' | '2';
 export type ChatContextValue<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = {
+  /**
+   * Indicates, whether a channels query has been triggered within ChannelList by its channels pagination controller.
+   */
   channelsQueryState: ChannelsQueryState;
   closeMobileNav: () => void;
   getAppSettings: () => Promise<AppSettingsAPIResponse<StreamChatGenerics>> | null;
   latestMessageDatesByChannels: Record<ChannelCID, Date>;
   mutes: Array<Mute<StreamChatGenerics>>;
   openMobileNav: () => void;
+  /**
+   * Sets active channel to be rendered within Channel component.
+   * @param newChannel
+   * @param watchers
+   * @param event
+   */
   setActiveChannel: (
     newChannel?: Channel<StreamChatGenerics>,
     watchers?: { limit?: number; offset?: number },
     event?: React.BaseSyntheticEvent,
   ) => void;
+  /**
+   * Allows to opt out of the use of legacy CSS (version "1") and opt into the use of the latest SDK's CSS (version "2").
+   */
   themeVersion: ThemeVersion;
   useImageFlagEmojisOnWindows: boolean;
+  /**
+   * Active channel used to render the contents of the Channel component.
+   */
   channel?: Channel<StreamChatGenerics>;
+  /**
+   * Object through which custom classes can be set for main container components of the SDK.
+   */
   customClasses?: CustomClasses;
   navOpen?: boolean;
 } & Required<Pick<ChatProps<StreamChatGenerics>, 'theme' | 'client'>>;

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, PropsWithChildren, SetStateAction, useContext } from 'react';
+import React, { PropsWithChildren, useContext } from 'react';
 
 import type { AppSettingsAPIResponse, Channel, Mute } from 'stream-chat';
 
@@ -28,47 +28,20 @@ export type ThemeVersion = '1' | '2';
 export type ChatContextValue<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = {
-  /**
-   * State representing the array of loaded channels.
-   * Channels query is executed by default only by ChannelList component in the SDK.
-   */
-  channels: Channel<StreamChatGenerics>[];
-  /**
-   * Indicates, whether a channels query has been triggered within ChannelList by its channels pagination controller.
-   */
   channelsQueryState: ChannelsQueryState;
   closeMobileNav: () => void;
   getAppSettings: () => Promise<AppSettingsAPIResponse<StreamChatGenerics>> | null;
   latestMessageDatesByChannels: Record<ChannelCID, Date>;
   mutes: Array<Mute<StreamChatGenerics>>;
   openMobileNav: () => void;
-  /**
-   * Sets active channel to be rendered within Channel component.
-   * @param newChannel
-   * @param watchers
-   * @param event
-   */
   setActiveChannel: (
     newChannel?: Channel<StreamChatGenerics>,
     watchers?: { limit?: number; offset?: number },
     event?: React.BaseSyntheticEvent,
   ) => void;
-  /**
-   * Sets the list of Channel objects to be rendered by ChannelList component.
-   */
-  setChannels: Dispatch<SetStateAction<Channel<StreamChatGenerics>[]>>;
-  /**
-   * Allows to opt out of the use of legacy CSS (version "1") and opt into the use of the latest SDK's CSS (version "2").
-   */
   themeVersion: ThemeVersion;
   useImageFlagEmojisOnWindows: boolean;
-  /**
-   * Active channel used to render the contents of the Channel component.
-   */
   channel?: Channel<StreamChatGenerics>;
-  /**
-   * Object through which custom classes can be set for main container components of the SDK.
-   */
   customClasses?: CustomClasses;
   navOpen?: boolean;
 } & Required<Pick<ChatProps<StreamChatGenerics>, 'theme' | 'client'>>;


### PR DESCRIPTION
### 🎯 Goal

Moving the state away from the `ChannelList` prevents integrators from having multiple `ChannelList` components rendered inside `Chat`. The `setChannels` function and `channels` state will be exposed in the following PR.
