### PR TITLE
chore(ci): remove docs release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     name: Release from "${{ github.ref_name }}" branch
     runs-on: ubuntu-latest
     # GH does not allow to limit branches in the workflow_dispatch settings so this here is a safety measure
-    if: ${{ !inputs.docs_only && (github.ref_name == 'master' || github.ref_name == 'rc' || github.ref_name == 'release-v9' || github.ref_name == 'release-v10') }}
+    if: ${{ !inputs.docs_only && (github.ref_name == 'master' || github.ref_name == 'rc' || startsWith(github.ref_name, 'release-v') ) }}
     env:
       NODE_OPTIONS: --max_old_space_size=4096
     steps:
@@ -48,28 +48,3 @@ jobs:
         run: >
           yarn semantic-release
           ${{ inputs.dry_run && '--dry-run' || '' }}
-
-  docs_release:
-    name: Publish documentation from "${{ github.ref_name }}" branch to ${{ inputs.docs_env }}
-    runs-on: ubuntu-latest
-    # skip during dry runs, release to production only from master, release to staging from anywhere
-    if: ${{ !inputs.dry_run && ((inputs.docs_env == 'production' && github.ref_name == 'master') || (github.ref_name != 'master' && inputs.docs_env == 'staging')) }}
-    outputs:
-      target-version: $${{ steps.target-version.outputs }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile --ignore-engines --ignore-scripts
-      - name: Merge shared "@stream-io/stream-chat-css" docs
-        run: bash scripts/merge-stream-chat-css-docs.sh node_modules/@stream-io/stream-chat-css/docs
-      - name: Push to stream-chat-docusaurus
-        uses: GetStream/push-stream-chat-docusaurus-action@main
-        with:
-          target-branch: ${{ inputs.docs_env }}
-        env:
-          DOCUSAURUS_GH_TOKEN: ${{ secrets.DOCUSAURUS_GH_TOKEN }}


### PR DESCRIPTION
### 🎯 Goal

1. Remove docs release job
2. Allow to run release job for branches which name starts with `'release-v'`.
