### PR TITLE
feat: render BaseImage image fallback within the same img element

### DIFF
--- a/docusaurus/docs/React/components/contexts/component-context.mdx
+++ b/docusaurus/docs/React/components/contexts/component-context.mdx
@@ -71,15 +71,15 @@ Custom UI component to display a user's avatar.
 
 ### BaseImage
 
-Custom UI component to display `<img/>` elements resp. a fallback in case of load error. The  default resp. custom (from `ComponentContext`) `BaseImage` component is rendered by:
+Custom UI component to display image resp. a fallback in case of load error, in `<img/>` element. The  default resp. custom (from `ComponentContext`) `BaseImage` component is rendered by:
 
 - <GHComponentLink text='Image' path='/Gallery/Image.tsx'/> - single image attachment in message list
 - <GHComponentLink text='Gallery' path='/Gallery/Gallery.tsx'/> - group of image attachments in message list
 - <GHComponentLink text='AttachmentPreviewList' path='/MessageInput/AttachmentPreviewList.tsx'/> - image uploads preview in message input (composer)
 
-The `BaseImage` component accepts the same props as `<img/>` element and one additional prop `ImageFallback`. The custom `ImageFallback` should be a React component that again accepts the  `<img/>` element props passed to `BaseImage`.
+The `BaseImage` component accepts the same props as `<img/>` element.
 
-The [default `BaseImage` component](../../utility-components/base-image) tries to load and display an image and if the load fails, then the default or custom `ImageFallback` (passed through the prop) is rendered.
+The [default `BaseImage` component](../../utility-components/base-image) tries to load and display an image and if the load fails, then an SVG image fallback is applied to the `<img/>` element as a CSS mask targeting attached `str-chat__base-image--load-failed` class.
 
 | Type      | Default                                                               |
 |-----------|-----------------------------------------------------------------------|

--- a/docusaurus/docs/React/components/utility-components/base-image.mdx
+++ b/docusaurus/docs/React/components/utility-components/base-image.mdx
@@ -40,47 +40,55 @@ The default image fallbacks are rendered as follows:
 
 ## Usage
 
-The component props are internally forwarded to the underlying `<img/>`. The component supports forwarding `ref` as well.
+### Custom image fallback
+
+The default image fallback can be changed by applying a new CSS data image to the fallback mask in the `BaseImage`'s `<img/>` element. The data image has to be assigned to a CSS variable `--str-chat__image-fallback-icon` within the scope of `.str-chat` class. An example follows:
+
+```css
+
+.str-chat {
+  --str-chat__image-fallback-icon: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iOSIgdmlld0JveD0iMCAwIDEwIDkiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBkPSJNOS4xOTk0OSAwLjMwNTY3MUM4LjkzOTQ5IDAuMDQ1NjcwNyA4LjUxOTQ5IDAuMDQ1NjcwNyA4LjI1OTQ5IDAuMzA1NjcxTDQuOTk5NDkgMy41NTlMMS43Mzk0OSAwLjI5OTAwNEMxLjQ3OTQ5IDAuMDM5MDAzOSAxLjA1OTQ5IDAuMDM5MDAzOSAwLjc5OTQ5MiAwLjI5OTAwNEMwLjUzOTQ5MiAwLjU1OTAwNCAwLjUzOTQ5MiAwLjk3OTAwNCAwLjc5OTQ5MiAxLjIzOUw0LjA1OTQ5IDQuNDk5TDAuNzk5NDkyIDcuNzU5QzAuNTM5NDkyIDguMDE5IDAuNTM5NDkyIDguNDM5IDAuNzk5NDkyIDguNjk5QzEuMDU5NDkgOC45NTkgMS40Nzk0OSA4Ljk1OSAxLjczOTQ5IDguNjk5TDQuOTk5NDkgNS40MzlMOC4yNTk0OSA4LjY5OUM4LjUxOTQ5IDguOTU5IDguOTM5NDkgOC45NTkgOS4xOTk0OSA4LjY5OUM5LjQ1OTQ5IDguNDM5IDkuNDU5NDkgOC4wMTkgOS4xOTk0OSA3Ljc1OUw1LjkzOTQ5IDQuNDk5TDkuMTk5NDkgMS4yMzlDOS40NTI4MyAwLjk4NTY3MSA5LjQ1MjgzIDAuNTU5MDA0IDkuMTk5NDkgMC4zMDU2NzFaIiBmaWxsPSIjNzI3NjdFIi8+Cjwvc3ZnPgo=");
+}
+```
+
+We can change the mask dimensions or color by applying the following rules to the image's class `.str-chat__base-image--load-failed`, that signals the image load has failed:
+
+```css
+:root{
+  --custom-icon-fill-color: #223344;
+  --custom-icon-width-and-height: 4rem 4rem;
+}
+
+.str-chat__base-image--load-failed {
+  mask-size: var(--custom-icon-width-and-height);
+  -webkit-mask-size: var(--custom-icon-width-and-height);
+  background-color: var(--custom-icon-fill-color);
+}
+```
+
+### Custom BaseImage
+
+The default `BaseImage` can be overridden by passing a custom component to `Channel` props:
+
 
 ```tsx
-import { useRef } from 'react';
-import { BaseImage } from 'stream-chat-react';
+import {ComponentProps } from 'react';
+import { Channel } from 'stream-chat-react';
 
-const CustomImageFallback = () => <img src="unsupported-image-format-fallback.jpg" alt="Unsupported Image Format Fallback" />;
-
-const MyUI = () => {
-  const imgRef = useRef<HTMLImageElement | null>(null);
-  const toggleModal = () => {
-      //...
-  }
-  const imageSrc = 'http://link.to/my/image';
-  const style = {
-      // custom styles..
-  }
-  return (
-    <BaseImage
-      alt='My image'
-      className='custom-class'
-      data-testid='custom-test-id'
-      onClick={toggleModal}
-      src={imageSrc}
-      style={style}
-      tabIndex={0}
-      ref={imgRef}
-      ImageFallback={ImageFallback}
-    />
-  );
+const CustomBaseImage = (props: ComponentProps<'img'>) => {
+    // your implementation...
 }
+
+export const MyUI = () => {
+  return (
+    <Channel BaseImage={CustomBaseImage}>
+      {{/* more components */ }}
+    </Channel>
+  );
+};
 ```
 
 ## Props
 
-Besides the `img` component props, the component accepts the following:
+The component accepts the `img` component props.
 
-### ImageFallback
-
-A custom React component to be displayed as a fallback to an image failing to load. The component accepts the `img` props that have originally been passed to `BaseImage` component.
-
-| Type                |
-|---------------------|
-| `React.ComponentProps<'img'>` |

--- a/src/components/Gallery/BaseImage.tsx
+++ b/src/components/Gallery/BaseImage.tsx
@@ -2,35 +2,10 @@ import React, { forwardRef, useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { DownloadButton } from '../Attachment/DownloadButton';
 
-export type ImageFallbackProps = React.ComponentPropsWithoutRef<'img'>;
-
-const DefaultImageFallback = ({ alt, src, title }: ImageFallbackProps) => (
-  <div
-    className='str-chat__image-fallback'
-    data-testid='str-chat__image-fallback'
-    title={title ?? alt}
-  >
-    <svg
-      className='str-chat__image-fallback__icon'
-      fill='none'
-      viewBox='0 0 18 18'
-      xmlns='http://www.w3.org/2000/svg'
-    >
-      <path
-        d='M16 2V16H2V2H16ZM16 0H2C0.9 0 0 0.9 0 2V16C0 17.1 0.9 18 2 18H16C17.1 18 18 17.1 18 16V2C18 0.9 17.1 0 16 0ZM11.14 8.86L8.14 12.73L6 10.14L3 14H15L11.14 8.86Z'
-        fill='#080707'
-      />
-    </svg>
-    <DownloadButton assetUrl={src} />
-  </div>
-);
-
-export type BaseImageProps = React.ComponentPropsWithRef<'img'> & {
-  ImageFallback?: React.ComponentType<ImageFallbackProps>;
-};
+export type BaseImageProps = React.ComponentPropsWithRef<'img'>;
 
 export const BaseImage = forwardRef<HTMLImageElement, BaseImageProps>(function BaseImage(
-  { ImageFallback = DefaultImageFallback, ...props },
+  { ...props },
   ref,
 ) {
   const { className: propsClassName, onError: propsOnError } = props;
@@ -43,20 +18,21 @@ export const BaseImage = forwardRef<HTMLImageElement, BaseImageProps>(function B
     [props.src],
   );
 
-  if (props.src && !error) {
-    return (
+  return (
+    <>
       <img
         data-testid='str-chat__base-image'
         {...props}
-        className={clsx(propsClassName, 'str-chat__base-image')}
+        className={clsx(propsClassName, 'str-chat__base-image', {
+          'str-chat__base-image--load-failed': error,
+        })}
         onError={(e) => {
           setError(true);
           propsOnError?.(e);
         }}
         ref={ref}
       />
-    );
-  }
-
-  return <ImageFallback {...props} />;
+      {error && <DownloadButton assetUrl={props.src} />}
+    </>
+  );
 });

--- a/src/components/Gallery/ModalGallery.tsx
+++ b/src/components/Gallery/ModalGallery.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import ImageGallery from 'react-image-gallery';
+import { useTranslationContext } from '../../context';
 
 import type { Attachment } from 'stream-chat';
 import type { DefaultStreamChatGenerics } from '../../types/types';
@@ -19,6 +20,7 @@ export const ModalGallery = <
   props: ModalGalleryProps<StreamChatGenerics>,
 ) => {
   const { images, index } = props;
+  const { t } = useTranslationContext('ModalGallery');
 
   const formattedArray = useMemo(
     () =>
@@ -26,7 +28,7 @@ export const ModalGallery = <
         const imageSrc = image.image_url || image.thumb_url || '';
         return {
           original: imageSrc,
-          originalAlt: 'User uploaded content',
+          originalAlt: t('User uploaded content'),
           source: imageSrc,
         };
       }),

--- a/src/components/Gallery/__tests__/BaseImage.test.js
+++ b/src/components/Gallery/__tests__/BaseImage.test.js
@@ -10,10 +10,8 @@ const props = {
   src: 'src',
 };
 const t = (val) => val;
-const FALLBACK_TEST_ID = 'str-chat__image-fallback';
 const BASE_IMAGE_TEST_ID = 'str-chat__base-image';
 const getImage = () => screen.queryByTestId(BASE_IMAGE_TEST_ID);
-const getFallback = () => screen.queryByTestId(FALLBACK_TEST_ID);
 
 const renderComponent = (props = {}) =>
   render(
@@ -48,43 +46,48 @@ describe('BaseImage', () => {
       </div>
     `);
   });
-  it('should render an image fallback when missing src', () => {
-    renderComponent();
-    expect(screen.queryByTestId(FALLBACK_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('should forward img props to fallback', () => {
-    const props = { alt: 'alt', title: 'title' };
-    const ImageFallback = (props) => <div>{JSON.stringify(props)}</div>;
-    renderComponent({ ...props, ImageFallback });
-    expect(screen.getByText(JSON.stringify(props))).toBeInTheDocument();
-  });
-
-  it('should apply img title to fallback root div title', () => {
-    const props = { alt: 'alt', title: 'title' };
-    renderComponent(props);
-    expect(screen.queryByTitle(props.title)).toBeInTheDocument();
-  });
-
-  it('should apply img alt to fallback root div title if img title is falsy', () => {
-    const props = { alt: 'alt' };
-    renderComponent({ alt: 'alt' });
-    expect(screen.queryByTitle(props.alt)).toBeInTheDocument();
-  });
 
   it('should render an image fallback on load error', () => {
-    renderComponent(props);
+    const { container } = renderComponent(props);
     const img = getImage();
-    expect(getImage()).toBeInTheDocument();
-    expect(getFallback()).not.toBeInTheDocument();
 
     fireEvent.error(img);
-    expect(img).not.toBeInTheDocument();
-    expect(getFallback()).toBeInTheDocument();
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <img
+          alt="alt"
+          class="str-chat__base-image str-chat__base-image--load-failed"
+          data-testid="str-chat__base-image"
+          src="src"
+        />
+        <a
+          aria-label="Attachment"
+          class="str-chat__message-attachment-file--item-download"
+          download=""
+          href="src"
+          target="_blank"
+        >
+          <svg
+            class="str-chat__message-attachment-download-icon"
+            data-testid="download"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19.35 10.04C18.67 6.59 15.64 4 12 4C9.11 4 6.6 5.64 5.35 8.04C2.34 8.36 0 10.91 0 14C0 17.31 2.69 20 6 20H19C21.76 20 24 17.76 24 15C24 12.36 21.95 10.22 19.35 10.04ZM19 18H6C3.79 18 2 16.21 2 14C2 11.95 3.53 10.24 5.56 10.03L6.63 9.92L7.13 8.97C8.08 7.14 9.94 6 12 6C14.62 6 16.88 7.86 17.39 10.43L17.69 11.93L19.22 12.04C20.78 12.14 22 13.45 22 15C22 16.65 20.65 18 19 18ZM13.45 10H10.55V13H8L12 17L16 13H13.45V10Z"
+              fill="black"
+            />
+          </svg>
+        </a>
+      </div>
+    `);
   });
 
   it('should reset error state on image src change', () => {
-    const { rerender } = renderComponent(props);
+    const { container, rerender } = renderComponent(props);
 
     fireEvent.error(getImage());
 
@@ -93,8 +96,15 @@ describe('BaseImage', () => {
         <BaseImage src={'new-src'} />
       </TranslationProvider>,
     );
-    expect(getImage()).toBeInTheDocument();
-    expect(getFallback()).not.toBeInTheDocument();
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <img
+          class="str-chat__base-image"
+          data-testid="str-chat__base-image"
+          src="new-src"
+        />
+      </div>
+    `);
   });
 
   it('should execute a custom onError callback on load error', () => {
@@ -103,15 +113,5 @@ describe('BaseImage', () => {
 
     fireEvent.error(getImage());
     expect(onError).toHaveBeenCalledTimes(1);
-  });
-  it('should render a custom image fallback on load error', () => {
-    const testId = 'custom-fallback';
-    const ImageFallback = () => <div data-testid={testId}>Custom Fallback</div>;
-    renderComponent({ ...props, ImageFallback });
-
-    fireEvent.error(getImage());
-    expect(screen.queryByTestId(testId)).toBeInTheDocument();
-    expect(getImage()).not.toBeInTheDocument();
-    expect(getFallback()).not.toBeInTheDocument();
   });
 });

--- a/src/components/MessageInput/__tests__/AttachmentPreviewList.test.js
+++ b/src/components/MessageInput/__tests__/AttachmentPreviewList.test.js
@@ -2,13 +2,13 @@
 
 import React, { useEffect } from 'react';
 
-import { act, fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import renderer from 'react-test-renderer';
 import '@testing-library/jest-dom';
 
 import { Chat } from '../../Chat';
 import { Channel } from '../../Channel';
-import { AttachmentPreviewList } from '../AttachmentPreviewList';
+import { AttachmentPreviewList, ImagePreviewItem } from '../AttachmentPreviewList';
 import { ComponentProvider, useChatContext } from '../../../context';
 import { MessageInputContextProvider } from '../../../context/MessageInputContext';
 
@@ -152,5 +152,79 @@ describe('AttachmentPreviewList', () => {
       );
     });
     expect(result.container).toMatchSnapshot();
+  });
+});
+
+describe('ImagePreviewItem', () => {
+  const BASE_IMAGE_TEST_ID = 'str-chat__base-image';
+  const getImage = () => screen.queryByTestId(BASE_IMAGE_TEST_ID);
+  const defaultId = '7VZCBda5mQQk49icgNaUJ';
+  const imageUploads = {
+    [defaultId]: {
+      file: {
+        path:
+          '29c4727a-82ad-4a14-8a49-6a6ba94396b2.300a558c-cb2a-495d-ac5e-b703a24d313f.c7dff19.heic',
+      },
+      id: defaultId,
+      state: 'finished',
+      url: 'https://us-east.stream-io-cdn.com/1145265/images/abc&oh=6120&ow=8160',
+    },
+  };
+  const defaultInputContext = {
+    imageUploads,
+    removeImage: jest.fn(),
+    uploadImage: jest.fn(),
+  };
+  const renderImagePreviewItem = ({ id, ...inputContext } = {}) =>
+    render(
+      <ComponentProvider value={{}}>
+        <MessageInputContextProvider value={{ ...defaultInputContext, ...inputContext }}>
+          <ImagePreviewItem id={id || defaultId} />
+        </MessageInputContextProvider>
+      </ComponentProvider>,
+    );
+
+  it('does not render images not found in the input attachment state', () => {
+    const { container } = renderImagePreviewItem({ id: 'X' });
+    expect(container).toBeEmptyDOMElement();
+  });
+  it('does not render scraped images', () => {
+    const { container } = renderImagePreviewItem({
+      imageUploads: { [defaultId]: { ...imageUploads[defaultId], og_scrape_url: 'og_scrape_url' } },
+    });
+    expect(container).toBeEmpty();
+  });
+  it('renders uploading state', () => {
+    const { container } = renderImagePreviewItem({
+      imageUploads: { [defaultId]: { ...imageUploads[defaultId], state: 'uploading' } },
+    });
+    expect(container).toMatchSnapshot();
+  });
+  it('renders upload finished state', () => {
+    const { container } = renderImagePreviewItem();
+    expect(container).toMatchSnapshot();
+  });
+  it('renders upload failed state', () => {
+    const { container } = renderImagePreviewItem({
+      imageUploads: { [defaultId]: { ...imageUploads[defaultId], state: 'failed' } },
+    });
+    expect(container).toMatchSnapshot();
+  });
+  it('reflects the image load error with str-chat__attachment-preview-image--error class', () => {
+    const { container } = renderImagePreviewItem();
+    fireEvent.error(getImage());
+    expect(container.children[0].className).toMatch('str-chat__attachment-preview-image--error');
+  });
+  it('asks to retry uploading the image', () => {
+    renderImagePreviewItem({
+      imageUploads: { [defaultId]: { ...imageUploads[defaultId], state: 'failed' } },
+    });
+    fireEvent.click(screen.getByTestId('image-preview-item-retry-button'));
+    expect(defaultInputContext.uploadImage).toHaveBeenCalledTimes(1);
+  });
+  it('asks to remove image from input attachment state', () => {
+    renderImagePreviewItem();
+    fireEvent.click(screen.getByTestId('image-preview-item-delete-button'));
+    expect(defaultInputContext.removeImage).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/MessageInput/__tests__/__snapshots__/AttachmentPreviewList.test.js.snap
+++ b/src/components/MessageInput/__tests__/__snapshots__/AttachmentPreviewList.test.js.snap
@@ -714,3 +714,162 @@ exports[`AttachmentPreviewList should render custom BaseImage component 1`] = `
   ,
 </div>
 `;
+
+exports[`ImagePreviewItem renders upload failed state 1`] = `
+<div>
+  <div
+    class="str-chat__attachment-preview-image"
+    data-testid="attachment-preview-image"
+  >
+    <button
+      class="str-chat__attachment-preview-delete"
+      data-testid="image-preview-item-delete-button"
+    >
+      <svg
+        data-testid="close-no-outline"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z"
+          fill="black"
+        />
+      </svg>
+    </button>
+    <button
+      class="str-chat__attachment-preview-error str-chat__attachment-preview-error-image"
+      data-testid="image-preview-item-retry-button"
+    >
+      <svg
+        data-testid="retry"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M17.6449 6.35C16.1949 4.9 14.2049 4 11.9949 4C7.57488 4 4.00488 7.58 4.00488 12C4.00488 16.42 7.57488 20 11.9949 20C15.7249 20 18.8349 17.45 19.7249 14H17.6449C16.8249 16.33 14.6049 18 11.9949 18C8.68488 18 5.99488 15.31 5.99488 12C5.99488 8.69 8.68488 6 11.9949 6C13.6549 6 15.1349 6.69 16.2149 7.78L12.9949 11H19.9949V4L17.6449 6.35Z"
+          fill="black"
+        />
+      </svg>
+    </button>
+    <img
+      class="str-chat__attachment-preview-thumbnail str-chat__base-image"
+      data-testid="str-chat__base-image"
+      src="https://us-east.stream-io-cdn.com/1145265/images/abc&oh=6120&ow=8160"
+    />
+  </div>
+</div>
+`;
+
+exports[`ImagePreviewItem renders upload finished state 1`] = `
+<div>
+  <div
+    class="str-chat__attachment-preview-image"
+    data-testid="attachment-preview-image"
+  >
+    <button
+      class="str-chat__attachment-preview-delete"
+      data-testid="image-preview-item-delete-button"
+    >
+      <svg
+        data-testid="close-no-outline"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z"
+          fill="black"
+        />
+      </svg>
+    </button>
+    <img
+      class="str-chat__attachment-preview-thumbnail str-chat__base-image"
+      data-testid="str-chat__base-image"
+      src="https://us-east.stream-io-cdn.com/1145265/images/abc&oh=6120&ow=8160"
+    />
+  </div>
+</div>
+`;
+
+exports[`ImagePreviewItem renders uploading state 1`] = `
+<div>
+  <div
+    class="str-chat__attachment-preview-image"
+    data-testid="attachment-preview-image"
+  >
+    <button
+      class="str-chat__attachment-preview-delete"
+      data-testid="image-preview-item-delete-button"
+      disabled=""
+    >
+      <svg
+        data-testid="close-no-outline"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z"
+          fill="black"
+        />
+      </svg>
+    </button>
+    <div
+      class="str-chat__attachment-preview-image-loading"
+    >
+      <div
+        class="str-chat__loading-indicator"
+      >
+        <svg
+          data-testid="loading-indicator"
+          height="17"
+          viewBox="0 0 30 30"
+          width="17"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <lineargradient
+              id="randomNanoId-linear-gradient"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stop-color="#FFF"
+                stop-opacity="0"
+              />
+              <stop
+                data-testid="stop-color"
+                offset="100%"
+                stop-opacity="1"
+              />
+            </lineargradient>
+          </defs>
+          <path
+            d="M2.518 23.321l1.664-1.11A12.988 12.988 0 0 0 15 28c7.18 0 13-5.82 13-13S22.18 2 15 2V0c8.284 0 15 6.716 15 15 0 8.284-6.716 15-15 15-5.206 0-9.792-2.652-12.482-6.679z"
+            fill="url(#randomNanoId-linear-gradient)"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+    </div>
+    <img
+      class="str-chat__attachment-preview-thumbnail str-chat__base-image"
+      data-testid="str-chat__base-image"
+      src="https://us-east.stream-io-cdn.com/1145265/images/abc&oh=6120&ow=8160"
+    />
+  </div>
+</div>
+`;

--- a/src/components/MessageInput/index.ts
+++ b/src/components/MessageInput/index.ts
@@ -1,4 +1,4 @@
-export * from './AttachmentPreviewList';
+export { AttachmentPreviewList } from './AttachmentPreviewList';
 export * from './CooldownTimer';
 export * from './DefaultTriggerProvider';
 export * from './EditMessageForm';

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -60,6 +60,7 @@
   "Unmute": "Stummschaltung aufheben",
   "Unpin": "Pin entfernen",
   "Upload type: \"{{ type }}\" is not allowed": "Upload-Typ: \"{{ type }}\" ist nicht erlaubt",
+  "User uploaded content": "Benutzer hochgeladenen Inhalts",
   "Wait until all attachments have uploaded": "Bitte warten, bis alle Anhänge hochgeladen wurden",
   "You have no channels currently": "Du hast momentan noch keinen Channels",
   "You've reached the maximum number of files": "Die maximale Dateianzahl ist erreicht",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -60,6 +60,7 @@
   "Unmute": "Unmute",
   "Unpin": "Unpin",
   "Upload type: \"{{ type }}\" is not allowed": "Upload type: \"{{ type }}\" is not allowed",
+  "User uploaded content": "User uploaded content",
   "Wait until all attachments have uploaded": "Wait until all attachments have uploaded",
   "You have no channels currently": "You have no channels currently",
   "You've reached the maximum number of files": "You've reached the maximum number of files",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -60,6 +60,7 @@
   "Unmute": "Activar sonido",
   "Unpin": "Desprender",
   "Upload type: \"{{ type }}\" is not allowed": "Tipo de carga: \"{{ type }}\" no está permitido",
+  "User uploaded content": "Contenido subido por el usuario",
   "Wait until all attachments have uploaded": "Espere hasta que se hayan cargado todos los archivos adjuntos",
   "You have no channels currently": "Actualmente no tienes canales",
   "You've reached the maximum number of files": "Has alcanzado el número máximo de archivos",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -60,6 +60,7 @@
   "Unmute": "Désactiver muet",
   "Unpin": "Détacher",
   "Upload type: \"{{ type }}\" is not allowed": "Le type de téléchargement: \"{{ type }}\" n'est pas autorisé",
+  "User uploaded content": "Contenu téléchargé par l'utilisateur",
   "Wait until all attachments have uploaded": "Attendez que toutes les pièces jointes soient téléchargées",
   "You have no channels currently": "Vous n'avez actuellement aucun canal",
   "You've reached the maximum number of files": "Vous avez atteint le nombre maximum de fichiers",

--- a/src/i18n/hi.json
+++ b/src/i18n/hi.json
@@ -60,6 +60,7 @@
   "Unmute": "अनम्यूट",
   "Unpin": "अनपिन",
   "Upload type: \"{{ type }}\" is not allowed": "अपलोड प्रकार: \"{{ type }}\" की अनुमति नहीं है",
+  "User uploaded content": "उपयोगकर्ता अपलोड की गई सामग्री",
   "Wait until all attachments have uploaded": "सभी अटैचमेंट अपलोड होने तक प्रतीक्षा करें",
   "You have no channels currently": "आपके पास कोई चैनल नहीं है",
   "You've reached the maximum number of files": "आप अधिकतम फ़ाइलों तक पहुँच गए हैं",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -60,6 +60,7 @@
   "Unmute": "Riattiva le notifiche",
   "Unpin": "Sblocca",
   "Upload type: \"{{ type }}\" is not allowed": "Tipo di caricamento: \"{{ type }}\" non è consentito",
+  "User uploaded content": "Contenuto caricato dall'utente",
   "Wait until all attachments have uploaded": "Attendi il caricamento di tutti gli allegati",
   "You have no channels currently": "Al momento non sono presenti canali",
   "You've reached the maximum number of files": "Hai raggiunto il numero massimo di file",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -60,6 +60,7 @@
   "Unmute": "無音を解除する",
   "Unpin": "ピンを解除する",
   "Upload type: \"{{ type }}\" is not allowed": "アップロードタイプ：\"{{ type }}\"は許可されていません",
+  "User uploaded content": "ユーザーがアップロードしたコンテンツ",
   "Wait until all attachments have uploaded": "すべての添付ファイルがアップロードされるまでお待ちください",
   "You have no channels currently": "現在チャンネルはありません",
   "You've reached the maximum number of files": "ファイルの最大数に達しました",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -60,6 +60,7 @@
   "Unmute": "음소거 해제",
   "Unpin": "핀 해제",
   "Upload type: \"{{ type }}\" is not allowed": "업로드 유형: \"{{ type }}\"은(는) 허용되지 않습니다.",
+  "User uploaded content": "사용자 업로드 콘텐츠",
   "Wait until all attachments have uploaded": "모든 첨부 파일이 업로드될 때까지 기다립니다.",
   "You have no channels currently": "현재 채널이 없습니다.",
   "You've reached the maximum number of files": "최대 파일 수에 도달했습니다.",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -60,6 +60,7 @@
   "Unmute": "Unmute",
   "Unpin": "Losmaken",
   "Upload type: \"{{ type }}\" is not allowed": "Uploadtype: \"{{ type }}\" is niet toegestaan",
+  "User uploaded content": "Gebruikersgeüploade inhoud",
   "Wait until all attachments have uploaded": "Wacht tot alle bijlagen zijn geüpload",
   "You have no channels currently": "Er zijn geen chats beschikbaar",
   "You've reached the maximum number of files": "Je hebt het maximale aantal bestanden bereikt",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -60,6 +60,7 @@
   "Unmute": "Ativar som",
   "Unpin": "Liberar",
   "Upload type: \"{{ type }}\" is not allowed": "Tipo de upload: \"{{ type }}\" não é permitido",
+  "User uploaded content": "Conteúdo enviado pelo usuário",
   "Wait until all attachments have uploaded": "Espere até que todos os anexos tenham sido carregados",
   "You have no channels currently": "Você não tem canais atualmente",
   "You've reached the maximum number of files": "Você atingiu o número máximo de arquivos",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -60,6 +60,7 @@
   "Unmute": "Включить уведомления",
   "Unpin": "Открепить",
   "Upload type: \"{{ type }}\" is not allowed": "Тип загрузки: \"{{ type }}\" не разрешен",
+  "User uploaded content": "Пользователь загрузил контент",
   "Wait until all attachments have uploaded": "Подождите, пока все вложения загрузятся",
   "You have no channels currently": "У вас нет каналов в данный момент",
   "You've reached the maximum number of files": "Вы достигли максимального количества файлов",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -60,6 +60,7 @@
   "Unmute": "Sesini aç",
   "Unpin": "Sabitlemeyi kaldır",
   "Upload type: \"{{ type }}\" is not allowed": "Yükleme türü: \"{{ type }}\" izin verilmez",
+  "User uploaded content": "Kullanıcı tarafından yüklenen içerik",
   "Wait until all attachments have uploaded": "Tüm ekler yüklenene kadar bekleyin",
   "You have no channels currently": "Henüz kanalınız yok",
   "You've reached the maximum number of files": "Maksimum dosya sayısına ulaştınız",


### PR DESCRIPTION
### 🎯 Goal

A follow up to #2183. Just in case prevent any message height changes due to switching between the `<img/>` element and a fallback component in case of image load error. 

