### PR TITLE
fix: ignore new messages from channels a user is not a member in message.new handler for ChannelList

### DIFF
--- a/src/components/ChannelList/hooks/useNotificationRemovedFromChannelListener.ts
+++ b/src/components/ChannelList/hooks/useNotificationRemovedFromChannelListener.ts
@@ -15,7 +15,7 @@ export const useNotificationRemovedFromChannelListener = <
     event: Event<StreamChatGenerics>,
   ) => void,
 ) => {
-  const { client } = useChatContext<StreamChatGenerics>(
+  const { channel, client, setActiveChannel } = useChatContext<StreamChatGenerics>(
     'useNotificationRemovedFromChannelListener',
   );
 
@@ -25,6 +25,7 @@ export const useNotificationRemovedFromChannelListener = <
         customHandler(setChannels, event);
       } else {
         setChannels((channels) => channels.filter((channel) => channel.cid !== event.channel?.cid));
+        // if (channel?.cid === event.channel?.cid) setActiveChannel(); // this may prevent custom setting of active channel in custom event handler
       }
     };
 
@@ -33,5 +34,5 @@ export const useNotificationRemovedFromChannelListener = <
     return () => {
       client.off('notification.removed_from_channel', handleEvent);
     };
-  }, [customHandler]);
+  }, [channel, client, customHandler, setActiveChannel]);
 };


### PR DESCRIPTION
### 🎯 Goal

When a user is removed from a channel with `channel.removeMembers([targetId],{text:"bye"})`:

1. Remove the channel from the channel list - and keep it removed
2. Remove the channel from the active channel - thus prevent user from being able to send messages
3. (Optional) Set a new active channel to `undefined` | ???
