### PR TITLE
fix: disable SuggestionList during text composition

### DIFF
--- a/src/components/AutoCompleteTextarea/Textarea.jsx
+++ b/src/components/AutoCompleteTextarea/Textarea.jsx
@@ -49,6 +49,7 @@ export class ReactTextareaAutocomplete extends React.Component {
       currentTrigger: null,
       data: null,
       dataLoading: false,
+      isComposing: false,
       left: null,
       selectionEnd: 0,
       selectionStart: 0,
@@ -664,37 +665,39 @@ export class ReactTextareaAutocomplete extends React.Component {
       SuggestionList = DefaultSuggestionList,
     } = this.props;
 
+    const { isComposing } = this.state;
+
     const triggerProps = this.getTriggerProps();
 
     if (
-      triggerProps.values &&
-      triggerProps.currentTrigger &&
-      !(disableMentions && triggerProps.currentTrigger === '@')
-    ) {
-      return (
-        <div
-          className={clsx(
-            'rta__autocomplete',
-            'str-chat__suggestion-list-container',
-            dropdownClassName,
-          )}
-          ref={this.setDropdownRef}
-          style={dropdownStyle}
-        >
-          <SuggestionList
-            className={clsx('str-chat__suggestion-list', listClassName)}
-            dropdownScroll={this._dropdownScroll}
-            itemClassName={clsx('str-chat__suggestion-list-item', itemClassName)}
-            itemStyle={itemStyle}
-            onSelect={this._onSelect}
-            SuggestionItem={SuggestionItem}
-            {...triggerProps}
-          />
-        </div>
-      );
-    }
+      isComposing ||
+      !triggerProps.values ||
+      !triggerProps.currentTrigger ||
+      (disableMentions && triggerProps.currentTrigger === '@')
+    )
+      return null;
 
-    return null;
+    return (
+      <div
+        className={clsx(
+          'rta__autocomplete',
+          'str-chat__suggestion-list-container',
+          dropdownClassName,
+        )}
+        ref={this.setDropdownRef}
+        style={dropdownStyle}
+      >
+        <SuggestionList
+          className={clsx('str-chat__suggestion-list', listClassName)}
+          dropdownScroll={this._dropdownScroll}
+          itemClassName={clsx('str-chat__suggestion-list-item', itemClassName)}
+          itemStyle={itemStyle}
+          onSelect={this._onSelect}
+          SuggestionItem={SuggestionItem}
+          {...triggerProps}
+        />
+      </div>
+    );
   }
 
   render() {
@@ -745,6 +748,8 @@ export class ReactTextareaAutocomplete extends React.Component {
             this._onClickAndBlurHandler(e);
             onClick?.(e);
           }}
+          onCompositionEnd={() => this.setState((pv) => ({ ...pv, isComposing: false }))}
+          onCompositionStart={() => this.setState((pv) => ({ ...pv, isComposing: true }))}
           onFocus={(e) => {
             this.props.onFocus?.(e);
             onFocus?.(e);

--- a/src/components/ChatAutoComplete/__tests__/ChatAutocomplete.test.js
+++ b/src/components/ChatAutoComplete/__tests__/ChatAutocomplete.test.js
@@ -218,6 +218,31 @@ describe('ChatAutoComplete', () => {
     expect(userText).toHaveLength(0);
   });
 
+  it('should disable popup list when the input is in "isComposing" state', async () => {
+    const { findAllByText, findByTestId, queryAllByText, typeText } = await renderComponent();
+
+    const messageInput = await findByTestId('message-input');
+
+    act(() => {
+      const cStartEvent = new Event('compositionstart', { bubbles: true });
+      messageInput.dispatchEvent(cStartEvent);
+    });
+
+    const userAutocompleteText = `@${user.name}`;
+    typeText(userAutocompleteText);
+
+    // eslint-disable-next-line jest-dom/prefer-in-document
+    expect(await queryAllByText(user.name)).toHaveLength(0);
+
+    act(() => {
+      const cEndEvent = new Event('compositionend', { bubbles: true });
+      messageInput.dispatchEvent(cEndEvent);
+    });
+
+    // eslint-disable-next-line jest-dom/prefer-in-document
+    expect(await findAllByText(user.name)).toHaveLength(2);
+  });
+
   it('should use the queryMembers API for mentions if a channel has many members', async () => {
     const users = Array(100).fill().map(generateUser);
     const members = users.map((u) => generateMember({ user: u }));


### PR DESCRIPTION
### 🎯 Goal

Disables `SuggestionList` component when text composition (with Korean and Japanese keyboard inputs) is active to prevent text duplication on submission.　

During text composition:
![image](https://github.com/GetStream/stream-chat-react/assets/43254280/a50bf257-7bce-4b7d-ac5b-fb15d1b024ce)

After text composition:
![image](https://github.com/GetStream/stream-chat-react/assets/43254280/da3f2042-d0c9-4670-af10-3b280f6882a8)
