### PR TITLE
fix: mark as read messages sent by current user

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -438,7 +438,7 @@ const ChannelInner = <
         mainChannelUpdated = false;
       }
 
-      if (mainChannelUpdated && event.message?.user?.id !== client.userID) {
+      if (mainChannelUpdated) {
         if (!document.hidden) {
           markReadThrottled();
         } else if (channelConfig?.read_events && !channel.muteStatus().muted) {
@@ -536,6 +536,14 @@ const ChannelInner = <
           ),
           type: 'initStateFromChannel',
         });
+
+        /**
+         * TODO: maybe pass last_read to the countUnread method to get proper value
+         * combined with channel.countUnread adjustment (_countMessageAsUnread)
+         * to allow counting own messages too
+         *
+         * const lastRead = channel.state.read[client.userID as string].last_read;
+         */
         if (channel.countUnread() > 0) markRead();
         // The more complex sync logic is done in Chat
         document.addEventListener('visibilitychange', onVisibilityChange);

--- a/src/components/Channel/__tests__/Channel.test.js
+++ b/src/components/Channel/__tests__/Channel.test.js
@@ -1347,6 +1347,20 @@ describe('Channel', () => {
         await waitFor(() => expect(markReadSpy).toHaveBeenCalledWith());
       });
 
+      it('should mark the channel as read if a new message current user comes in and the user is looking at the page', async () => {
+        const { channel, chatClient } = await initClient();
+        const markReadSpy = jest.spyOn(channel, 'markRead');
+
+        const message = generateMessage({ user: generateUser() });
+        const dispatchMessageEvent = createChannelEventDispatcher({ message }, chatClient, channel);
+
+        renderComponent({ channel, chatClient }, () => {
+          dispatchMessageEvent();
+        });
+
+        await waitFor(() => expect(markReadSpy).toHaveBeenCalledWith());
+      });
+
       it('title of the page should include the unread count if the user is not looking at the page when a new message event happens', async () => {
         const { channel, chatClient } = await initClient();
         const unreadAmount = 1;


### PR DESCRIPTION
### 🎯 Goal

Adjusts Channel behavior to mark as read messages sent by current user as well, this adjustment is made to match the behavior of Angular SDK.