### PR TITLE
Pass groupStyles through VirtualizedMessageList

### DIFF
--- a/src/components/MessageList/VirtualizedMessageListComponents.tsx
+++ b/src/components/MessageList/VirtualizedMessageListComponents.tsx
@@ -108,6 +108,7 @@ export const messageRenderer = <
     lastReceivedMessageId,
     Message: MessageUIComponent,
     messageActions,
+    messageGroupStyles,
     MessageSystem,
     numItemsPrepended,
     ownMessagesReadByOthers,
@@ -153,6 +154,7 @@ export const messageRenderer = <
       endOfGroup={endOfGroup}
       firstOfGroup={firstOfGroup}
       groupedByUser={groupedByUser}
+      groupStyles={[messageGroupStyles[message.id] ?? '']}
       lastReceivedId={lastReceivedMessageId}
       message={message}
       Message={MessageUIComponent}


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

_Describe why we are making this change_

We are trying to switch to `VirtualizedMessageList` and found that our custom `groupStyles` stopped working!

When I dug around, I found that the prop is simply not getting passed through.

### 🛠 Implementation details

_Provide a description of the implementation_

Inside of `messageRender` in `VirtualizedMessageListComponents`, I grab the `messageGroupStyles` object
off of the Virtuoso context, grab the `groupStyles` string that has been set for this message, then
add it as the `groupStyles` prop for the `Messsage` component.

### 🎨 UI Changes

_Add relevant screenshots_

I was having trouble getting this to build locally to get some screenshots =(
It would build fine, but I was getting errors about multiple versions of react when trying to link
the locally built package. I figured that's probably more headache than it's worth so I thought I'd
just get this PR up!
