### PR TITLE
fix: add callback to report fetching active channel errors

### DIFF
--- a/src/components/ChannelList/ChannelList.tsx
+++ b/src/components/ChannelList/ChannelList.tsx
@@ -116,6 +116,7 @@ export type ChannelListProps<
     setChannels: React.Dispatch<React.SetStateAction<Array<Channel<StreamChatGenerics>>>>,
     event: Event<StreamChatGenerics>,
   ) => void;
+  onGetActiveChannelError?: (error: unknown) => void;
   /** An object containing channel query options */
   options?: ChannelOptions;
   /** Custom UI component to handle channel pagination logic, defaults to and accepts same props as: [LoadMorePaginator](https://github.com/GetStream/stream-chat-react/blob/master/src/components/LoadMore/LoadMorePaginator.tsx) */
@@ -215,8 +216,13 @@ const UnMemoizedChannelList = <
       let customActiveChannelObject = channels.find((chan) => chan.id === customActiveChannel);
 
       if (!customActiveChannelObject) {
-        //@ts-expect-error
-        [customActiveChannelObject] = await client.queryChannels({ id: customActiveChannel });
+        try {
+          //@ts-expect-error
+          [customActiveChannelObject] = await client.queryChannels({ id: customActiveChannel });
+        } catch (err) {
+           console.warn(err);
+           onGetActiveChannelError?.(err);
+        }
       }
 
       if (customActiveChannelObject) {


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

_Describe why we are making this change_
When we added opening a channel via react router url to a channel, the user is able to open any channel. 
If the channel exists but the user doesn't have access (is not a member of this channel), there's an error in activeChannelHandler (see screenshot).

### 🛠 Implementation details

_Provide a description of the implementation_
Added try/catch block and callback prop to report to ChannelList's parent component

### 🎨 UI Changes
![Screenshot from 2023-12-21 00-36-10](https://github.com/GetStream/stream-chat-react/assets/27924565/be067ae3-53b1-43aa-beac-ee8f611cb0cf)

