### PR TITLE
fix: hasMore limitations

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -598,6 +598,7 @@ const ChannelInner = <
   // Adds a temporary notification to message list, will be removed after 5 seconds
   const addNotification = makeAddNotifications(setNotifications, notificationTimeouts);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const loadMoreFinished = useCallback(
     debounce(
       (hasMore: boolean, messages: ChannelState<StreamChatGenerics>['messages']) => {
@@ -900,6 +901,7 @@ const ChannelInner = <
     dispatch({ type: 'closeThread' });
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const loadMoreThreadFinished = useCallback(
     debounce(
       (

--- a/src/components/Channel/__tests__/Channel.test.js
+++ b/src/components/Channel/__tests__/Channel.test.js
@@ -322,6 +322,28 @@ describe('Channel', () => {
     });
   });
 
+  // this will only happen if we:
+  // load with channel A
+  // switch to channel B and paginate (loadMore - older)
+  // switch back to channel A (reset hasMore)
+  // switch back to channel B - messages are already cached and there's more than page size amount
+  it('should set hasMore state to true if the initial channel query returns more messages than the default initial page size', async () => {
+    const { channel, chatClient } = await initClient();
+    useMockedApis(chatClient, [
+      queryChannelWithNewMessages(Array.from({ length: 26 }, generateMessage), channel),
+    ]);
+    let hasMore;
+    await act(() => {
+      renderComponent({ channel, chatClient }, ({ hasMore: contextHasMore }) => {
+        hasMore = contextHasMore;
+      });
+    });
+
+    await waitFor(() => {
+      expect(hasMore).toBe(true);
+    });
+  });
+
   it('should set hasMore state to true if the initial channel query returns count of messages equal to the default initial page size', async () => {
     const { channel, chatClient } = await initClient();
     useMockedApis(chatClient, [

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -151,7 +151,6 @@ const VirtualizedMessageListWithContext = <
     defaultItemHeight,
     disableDateSeparator = true,
     groupStyles,
-    hasMore,
     hasMoreNewer,
     head,
     hideDeletedMessages = false,
@@ -333,21 +332,14 @@ const VirtualizedMessageListWithContext = <
   const atBottomStateChange = (isAtBottom: boolean) => {
     atBottom.current = isAtBottom;
     setIsMessageListScrolledToBottom(isAtBottom);
-    if (isAtBottom && newMessagesNotification) {
-      setNewMessagesNotification(false);
+
+    if (isAtBottom) {
+      loadMoreNewer?.(messageLimit);
+      setNewMessagesNotification?.(false);
     }
   };
-
-  const startReached = () => {
-    if (hasMore && loadMore) {
-      loadMore(messageLimit);
-    }
-  };
-
-  const endReached = () => {
-    if (hasMoreNewer && loadMoreNewer) {
-      loadMoreNewer(messageLimit);
-    }
+  const atTopStateChange = (isAtTop: boolean) => {
+    if (isAtTop) loadMore?.(messageLimit);
   };
 
   useEffect(() => {
@@ -368,7 +360,9 @@ const VirtualizedMessageListWithContext = <
         <div className={customClasses?.virtualizedMessageList || 'str-chat__virtual-list'}>
           <Virtuoso<UnknownType, VirtuosoContext<StreamChatGenerics>>
             atBottomStateChange={atBottomStateChange}
-            atBottomThreshold={200}
+            atBottomThreshold={100}
+            atTopStateChange={atTopStateChange}
+            atTopThreshold={100}
             className='str-chat__message-list-scroll'
             components={{
               EmptyPlaceholder,
@@ -399,7 +393,6 @@ const VirtualizedMessageListWithContext = <
               threadList,
               virtuosoRef: virtuoso,
             }}
-            endReached={endReached}
             firstItemIndex={calculateFirstItemIndex(numItemsPrepended)}
             followOutput={followOutput}
             increaseViewportBy={{ bottom: 200, top: 0 }}
@@ -412,7 +405,6 @@ const VirtualizedMessageListWithContext = <
             key={messageSetKey}
             overscan={overscan}
             ref={virtuoso}
-            startReached={startReached}
             style={{ overflowX: 'hidden' }}
             totalCount={processedMessages.length}
             {...overridingVirtuosoProps}

--- a/src/components/MessageList/utils.ts
+++ b/src/components/MessageList/utils.ts
@@ -316,7 +316,7 @@ export const getGroupStyles = <
 //  The MessageList should have configurable the limit for performing the requests.
 //  This parameter would then be used within these functions
 export const hasMoreMessagesProbably = (returnedCountMessages: number, limit: number) =>
-  returnedCountMessages === limit;
+  returnedCountMessages >= limit;
 
 // @deprecated
 export const hasNotMoreMessages = (returnedCountMessages: number, limit: number) =>


### PR DESCRIPTION
### 🎯 Goal

A bug that would prevent users from loading older messages within message lists if they paginated on channel B, switched to channel A and then back to channel B and tried paginating again.

### 🛠 Implementation details

Moved from `startReached` to `atTopStateChange` and from `endReached` to `atBottomStateChange` callbacks for pagination as `startReached` [is distinct](https://github.com/petyosi/react-virtuoso/blob/efdf50b8c4ee18e1c9d2fa4866e47ae9fd64cae1/src/listStateSystem.ts#L386) and called only once per set of data (I assume, not sure why as scrolling back down should ideally reset it) - but if you were to hit the top - and the data load would fail for some reason - scrolling a bit down and back up would not trigger the data load again.
This was one of my ways to try to resolve the original problem before I was able to find reliable reproduction steps but in the end decided to keep it as "futureproofing".
Though I'm worried that some of our integrators migh've hooked into these properties overriding whatever we newly have making their pagination not work.