### PR TITLE
feat: show full list of reactions in a modal

### DIFF
--- a/docusaurus/docs/React/components/contexts/message-context.mdx
+++ b/docusaurus/docs/React/components/contexts/message-context.mdx
@@ -167,6 +167,8 @@ Function that loads all reactions for a message.
 | ------------------------------------- |
 | () => Promise<ReactionResponse[]\> \  |
 
+This function limits the number of loaded reactions to 1200. To customize this behavior, you can pass [a custom `ReactionsList` component](../message-components/reactions.mdx#handlefetchreactions).
+
 ### handleFlag
 
 Function that flags a message.
@@ -347,8 +349,8 @@ An array of users that have read the current message.
 
 Custom function to render message text content.
 
-| Type     | Default                                                                                |
-| -------- | -------------------------------------------------------------------------------------- |
+| Type     | Default                                                                        |
+| -------- | ------------------------------------------------------------------------------ |
 | function | <GHComponentLink text='renderText' path='/Message/renderText/renderText.tsx'/> |
 
 ### setEditingState

--- a/docusaurus/docs/React/components/contexts/message-context.mdx
+++ b/docusaurus/docs/React/components/contexts/message-context.mdx
@@ -161,7 +161,7 @@ Function that edits a message.
 
 ### handleFetchReactions
 
-Function that loads all reactions for a message.
+Function that loads the reactions for a message.
 
 | Type                                  |
 | ------------------------------------- |

--- a/docusaurus/docs/React/components/contexts/message-context.mdx
+++ b/docusaurus/docs/React/components/contexts/message-context.mdx
@@ -159,6 +159,14 @@ Function that edits a message.
 | ----------------------------------------------------------- |
 | (event: React.BaseSyntheticEvent) => Promise<void\> \| void |
 
+### handleFetchReactions
+
+Function that loads all reactions for a message.
+
+| Type                                  |
+| ------------------------------------- |
+| () => Promise<ReactionResponse[]\> \  |
+
 ### handleFlag
 
 Function that flags a message.

--- a/docusaurus/docs/React/components/core-components/message-list.mdx
+++ b/docusaurus/docs/React/components/core-components/message-list.mdx
@@ -295,6 +295,15 @@ deleted [message object](https://getstream.io/chat/docs/javascript/message_forma
 | ---------------------------------- |
 | (message: StreamMessage) => string |
 
+### getFetchReactionsErrorNotification
+
+Function that returns the notification text to be displayed when loading message reactions fails. This function receives the
+current [message object](https://getstream.io/chat/docs/javascript/message_format/?language=javascript) as its argument.
+
+| Type                               |
+| ---------------------------------- |
+| (message: StreamMessage) => string |
+
 ### getFlagMessageErrorNotification
 
 Function that returns the notification text to be displayed when a flag message request fails. This function receives the

--- a/docusaurus/docs/React/components/message-components/message-ui.mdx
+++ b/docusaurus/docs/React/components/message-components/message-ui.mdx
@@ -289,7 +289,7 @@ Function that edits a message (overrides the function stored in `MessageContext`
 
 ### handleFetchReactions
 
-Function that loads all reactions for a message (overrides the function stored in `MessageContext`).
+Function that loads the reactions for a message (overrides the function stored in `MessageContext`).
 
 | Type                                                        | Default                                                                                                  |
 | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |

--- a/docusaurus/docs/React/components/message-components/message-ui.mdx
+++ b/docusaurus/docs/React/components/message-components/message-ui.mdx
@@ -287,6 +287,14 @@ Function that edits a message (overrides the function stored in `MessageContext`
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | (event: React.BaseSyntheticEvent) => Promise<void\> \| void | [MessageContextValue['handleEdit']](../contexts/message-context.mdx#handleedit) |
 
+### handleFetchReactions
+
+Function that loads all reactions for a message (overrides the function stored in `MessageContext`).
+
+| Type                                                        | Default                                                                                                  |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| (event: React.BaseSyntheticEvent) => Promise<void\> \| void | [MessageContextValue['handleFetchReactions']](../contexts/message-context.mdx#handlhandlefetchreactions) |
+
 ### handleFlag
 
 Function that flags a message (overrides the function stored in `MessageContext`).

--- a/docusaurus/docs/React/components/message-components/message-ui.mdx
+++ b/docusaurus/docs/React/components/message-components/message-ui.mdx
@@ -295,6 +295,8 @@ Function that loads all reactions for a message (overrides the function stored i
 | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | (event: React.BaseSyntheticEvent) => Promise<void\> \| void | [MessageContextValue['handleFetchReactions']](../contexts/message-context.mdx#handlhandlefetchreactions) |
 
+This function limits the number of loaded reactions to 1200. To customize this behavior, you can pass [a custom `ReactionsList` component](./reactions.mdx#handlefetchreactions).
+
 ### handleFlag
 
 Function that flags a message (overrides the function stored in `MessageContext`).
@@ -360,6 +362,7 @@ Function that returns whether a message belongs to the current user (overrides t
 | () => boolean |
 
 ### isReactionEnabled (deprecated)
+
 If true, sending reactions is enabled in the currently active channel (overrides the value stored in `MessageContext`).
 
 | Type    | Default |
@@ -466,8 +469,8 @@ An array of users that have read the current message (overrides the value stored
 
 Custom function to render message text content (overrides the function stored in `MessageContext`).
 
-| Type     | Default                                                                                |
-| -------- | -------------------------------------------------------------------------------------- |
+| Type     | Default                                                                        |
+| -------- | ------------------------------------------------------------------------------ |
 | function | <GHComponentLink text='renderText' path='/Message/renderText/renderText.tsx'/> |
 
 ### setEditingState

--- a/docusaurus/docs/React/components/message-components/message.mdx
+++ b/docusaurus/docs/React/components/message-components/message.mdx
@@ -147,6 +147,15 @@ deleted [message object](https://getstream.io/chat/docs/javascript/message_forma
 | ---------------------------------- |
 | (message: StreamMessage) => string |
 
+### getFetchReactionsErrorNotification
+
+Function that returns the notification text to be displayed when loading message reactions fails. This function receives the
+current [message object](https://getstream.io/chat/docs/javascript/message_format/?language=javascript) as its argument.
+
+| Type                               |
+| ---------------------------------- |
+| (message: StreamMessage) => string |
+
 ### getFlagMessageErrorNotification
 
 Function that returns the notification text to be displayed when a flag message request fails. This function receives the
@@ -324,8 +333,8 @@ An array of users that have read the current message.
 
 Custom function to render message text content.
 
-| Type     | Default                                                                                |
-| -------- | -------------------------------------------------------------------------------------- |
+| Type     | Default                                                                        |
+| -------- | ------------------------------------------------------------------------------ |
 | function | <GHComponentLink text='renderText' path='/Message/renderText/renderText.tsx'/> |
 
 ### retrySendMessage

--- a/docusaurus/docs/React/components/message-components/reactions.mdx
+++ b/docusaurus/docs/React/components/message-components/reactions.mdx
@@ -212,6 +212,21 @@ Function that loads all message reactions (overrides the function stored in `Mes
 | -------------------- | --------------------------------------------------------------------------------------------------- |
 | () => Promise<void\> | [MessageContextValue['handleFetchReactions']](../contexts/message-context.mdx#handlefetchreactions) |
 
+The default implementation of `handleFetchReactions`, provided via the [`MessageContext`](../contexts/message-context.mdx#handlefetchreactions), limits the number of loaded reactions to 1200. Use this prop to provide your own loading implementation:
+
+```jsx
+const MyCustomReactionsList = (props) => {
+  const { channel } = useChannelStateContext();
+  const { message } = useMessageContext();
+
+  function fetchReactions() {
+    return channel.getReactions(message.id, { limit: 42 });
+  }
+
+  return <ReactionsList handleFetchReactions={fetchReactions} />;
+};
+```
+
 ### onClick
 
 Custom on click handler for an individual reaction in the list (overrides the function stored in `MessageContext`).

--- a/docusaurus/docs/React/components/message-components/reactions.mdx
+++ b/docusaurus/docs/React/components/message-components/reactions.mdx
@@ -206,7 +206,7 @@ Additional props to be passed to the [`NimbleEmoji`](https://github.com/missive/
 
 ### handleFetchReactions
 
-Function that loads all message reactions (overrides the function stored in `MessageContext`).
+Function that loads the message reactions (overrides the function stored in `MessageContext`).
 
 | Type                 | Default                                                                                             |
 | -------------------- | --------------------------------------------------------------------------------------------------- |
@@ -288,7 +288,7 @@ Additional props to be passed to the [`NimbleEmoji`](https://github.com/missive/
 
 ### handleFetchReactions
 
-Function that loads all message reactions (overrides the function stored in `MessageContext`).
+Function that loads the message reactions (overrides the function stored in `MessageContext`).
 
 | Type                 | Default                                                                                             |
 | -------------------- | --------------------------------------------------------------------------------------------------- |

--- a/docusaurus/docs/React/components/message-components/reactions.mdx
+++ b/docusaurus/docs/React/components/message-components/reactions.mdx
@@ -204,6 +204,14 @@ Additional props to be passed to the [`NimbleEmoji`](https://github.com/missive/
 | ------ |
 | object |
 
+### handleFetchReactions
+
+Function that loads all message reactions (overrides the function stored in `MessageContext`).
+
+| Type                 | Default                                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------------------- |
+| () => Promise<void\> | [MessageContextValue['handleFetchReactions']](../contexts/message-context.mdx#handlefetchreactions) |
+
 ### onClick
 
 Custom on click handler for an individual reaction in the list (overrides the function stored in `MessageContext`).
@@ -262,6 +270,14 @@ Additional props to be passed to the [`NimbleEmoji`](https://github.com/missive/
 | Type   |
 | ------ |
 | object |
+
+### handleFetchReactions
+
+Function that loads all message reactions (overrides the function stored in `MessageContext`).
+
+| Type                 | Default                                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------------------- |
+| () => Promise<void\> | [MessageContextValue['handleFetchReactions']](../contexts/message-context.mdx#handlefetchreactions) |
 
 ### handleReaction
 

--- a/docusaurus/docs/React/hooks/message-hooks.mdx
+++ b/docusaurus/docs/React/hooks/message-hooks.mdx
@@ -179,6 +179,26 @@ const MyCustomMessageComponent = () => {
 };
 ```
 
+### useReactionsFetcher
+
+A [custom hook](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message/hooks/useReactionsFetcher.ts) to handle loading message reactions. Returns an async function that loads and returns message reactions.
+
+```jsx
+const MyCustomMessageComponent = () => {
+  const { message } = useMessageContext();
+  const { addNotification } = useChannelActionContext();
+  const handleFetchReactions = useReactionsFetcher(message, { notify: addNotification });
+  const { data } = useQuery(['message', message.id, 'reactions'], handleFetchReactions);
+
+  return (
+    <div>
+      {message.text}
+      {data && data.map((reaction) => <span key={reaction.type}>reaction.type</span>)}
+    </div>
+  );
+};
+```
+
 ### useRetryHandler
 
 A [custom hook](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message/hooks/useRetryHandler.ts) to handle the retry of sending a message.

--- a/docusaurus/docs/React/hooks/message-hooks.mdx
+++ b/docusaurus/docs/React/hooks/message-hooks.mdx
@@ -184,20 +184,31 @@ const MyCustomMessageComponent = () => {
 A [custom hook](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message/hooks/useReactionsFetcher.ts) to handle loading message reactions. Returns an async function that loads and returns message reactions.
 
 ```jsx
-const MyCustomMessageComponent = () => {
+import { useQuery } from 'react-query';
+
+const MyCustomReactionsList = () => {
   const { message } = useMessageContext();
   const { addNotification } = useChannelActionContext();
   const handleFetchReactions = useReactionsFetcher(message, { notify: addNotification });
+  // This example relies on react-query - but you can use you preferred method
+  // of fetching data instead
   const { data } = useQuery(['message', message.id, 'reactions'], handleFetchReactions);
 
+  if (!data) {
+    return null;
+  }
+
   return (
-    <div>
-      {message.text}
-      {data && data.map((reaction) => <span key={reaction.type}>reaction.type</span>)}
-    </div>
+    <>
+      {data.map((reaction) => (
+        <span key={reaction.type}>reaction.type</span>
+      ))}
+    </>
   );
 };
 ```
+
+This function limits the number of loaded reactions to 1200. To customize this behavior, provide [your own loader function](../message-components/reactions.mdx#handlefetchreactions) instead.
 
 ### useRetryHandler
 

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -11,6 +11,7 @@ import {
   usePinHandler,
   useReactionClick,
   useReactionHandler,
+  useReactionsFetcher,
   useRetryHandler,
   useUserHandler,
   useUserRole,
@@ -38,6 +39,7 @@ type MessageContextPropsToPick =
   | 'handleOpenThread'
   | 'handlePin'
   | 'handleReaction'
+  | 'handleFetchReactions'
   | 'handleRetry'
   | 'isReactionEnabled'
   | 'mutes'
@@ -158,6 +160,7 @@ export const Message = <
     closeReactionSelectorOnClick,
     disableQuotedMessages,
     getDeleteMessageErrorNotification,
+    getFetchReactionsErrorNotification,
     getFlagMessageErrorNotification,
     getFlagMessageSuccessNotification,
     getMuteUserErrorNotification,
@@ -182,6 +185,11 @@ export const Message = <
   const handleReaction = useReactionHandler(message);
   const handleRetry = useRetryHandler(propRetrySendMessage);
   const userRoles = useUserRole(message, onlySenderCanEdit, disableQuotedMessages);
+
+  const handleFetchReactions = useReactionsFetcher(message, {
+    getErrorNotification: getFetchReactionsErrorNotification,
+    notify: addNotification,
+  });
 
   const handleDelete = useDeleteHandler(message, {
     getErrorNotification: getDeleteMessageErrorNotification,
@@ -233,6 +241,7 @@ export const Message = <
       groupStyles={props.groupStyles}
       handleAction={handleAction}
       handleDelete={handleDelete}
+      handleFetchReactions={handleFetchReactions}
       handleFlag={handleFlag}
       handleMute={handleMute}
       handleOpenThread={handleOpenThread}

--- a/src/components/Message/__tests__/MessageSimple.test.js
+++ b/src/components/Message/__tests__/MessageSimple.test.js
@@ -29,6 +29,7 @@ import {
   TranslationProvider,
 } from '../../../context';
 import {
+  countReactions,
   generateChannel,
   generateMessage,
   generateReaction,
@@ -224,9 +225,10 @@ describe('<MessageSimple />', () => {
 
   // FIXME: test relying on deprecated channel config parameter
   it('should render reaction list even though sending reactions is disabled in channel config', async () => {
-    const bobReaction = generateReaction({ user: bob });
+    const reactions = [generateReaction({ user: bob })];
     const message = generateAliceMessage({
-      latest_reactions: [bobReaction],
+      latest_reactions: reactions,
+      reaction_counts: countReactions(reactions),
       text: undefined,
     });
 
@@ -240,9 +242,10 @@ describe('<MessageSimple />', () => {
   });
 
   it('should render reaction list with custom component when one is given', async () => {
-    const bobReaction = generateReaction({ type: 'cool-reaction', user: bob });
+    const reactions = [generateReaction({ type: 'cool-reaction', user: bob })];
     const message = generateAliceMessage({
-      latest_reactions: [bobReaction],
+      latest_reactions: reactions,
+      reaction_counts: countReactions(reactions),
       text: undefined,
     });
     const CustomReactionsList = ({ reactions = [] }) => (

--- a/src/components/Message/__tests__/MessageText.test.js
+++ b/src/components/Message/__tests__/MessageText.test.js
@@ -14,6 +14,7 @@ import {
   TranslationProvider,
 } from '../../../context';
 import {
+  countReactions,
   generateChannel,
   generateMessage,
   generateReaction,
@@ -101,7 +102,6 @@ async function renderMessageText({
 }
 
 const messageTextTestId = 'message-text-inner-wrapper';
-const reactionSelectorTestId = 'reaction-selector';
 
 describe('<MessageText />', () => {
   beforeEach(jest.clearAllMocks);
@@ -230,9 +230,10 @@ describe('<MessageText />', () => {
   });
 
   it('should show reaction list if message has reactions and detailed reactions are not displayed', async () => {
-    const bobReaction = generateReaction({ user: bob });
+    const reactions = [generateReaction({ user: bob })];
     const message = generateAliceMessage({
-      latest_reactions: [bobReaction],
+      latest_reactions: reactions,
+      reaction_counts: countReactions(reactions),
     });
 
     let container;
@@ -248,9 +249,10 @@ describe('<MessageText />', () => {
 
   // FIXME: test relying on deprecated channel config parameter
   it('should show reaction list even though sending reactions is disabled in channelConfig', async () => {
-    const bobReaction = generateReaction({ user: bob });
+    const reactions = [generateReaction({ user: bob })];
     const message = generateAliceMessage({
-      latest_reactions: [bobReaction],
+      latest_reactions: reactions,
+      reaction_counts: countReactions(reactions),
     });
     const { container, queryByTestId } = await renderMessageText({
       channelCapabilitiesOverrides: { 'send-reaction': false },
@@ -258,24 +260,6 @@ describe('<MessageText />', () => {
     });
 
     expect(queryByTestId('reaction-list')).toBeInTheDocument();
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
-  });
-
-  it('should show reaction selector when message has reaction and reaction list is clicked', async () => {
-    const bobReaction = generateReaction({ user: bob });
-    const message = generateAliceMessage({
-      latest_reactions: [bobReaction],
-    });
-    const { container, getByTestId, queryByTestId } = await renderMessageText({
-      customProps: { message },
-    });
-    expect(queryByTestId(reactionSelectorTestId)).not.toBeInTheDocument();
-    await act(() => {
-      fireEvent.click(getByTestId('reaction-list'));
-    });
-
-    expect(getByTestId(reactionSelectorTestId)).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/src/components/Message/__tests__/utils.test.js
+++ b/src/components/Message/__tests__/utils.test.js
@@ -1,5 +1,9 @@
 import { generateMessage, generateReaction, generateUser } from 'mock-builders';
-import { getTestClientWithUser, mockTranslatorFunction } from '../../../mock-builders';
+import {
+  countReactions,
+  getTestClientWithUser,
+  mockTranslatorFunction,
+} from '../../../mock-builders';
 import {
   areMessagePropsEqual,
   areMessageUIPropsEqual,
@@ -236,8 +240,10 @@ describe('Message utils', () => {
       expect(messageHasReactions(message)).toBe(false);
     });
     it('should return true if message has reactions', () => {
+      const reactions = [generateReaction()];
       const message = generateMessage({
-        latest_reactions: [generateReaction()],
+        latest_reactions: reactions,
+        reaction_counts: countReactions(reactions),
       });
       expect(messageHasReactions(message)).toBe(true);
     });

--- a/src/components/Message/hooks/__tests__/useReactionsFetcher.js
+++ b/src/components/Message/hooks/__tests__/useReactionsFetcher.js
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+
+import { ChannelStateProvider } from '../../../../context/ChannelStateContext';
+import { ChatProvider } from '../../../../context/ChatContext';
+import { generateChannel, generateMessage, getTestClient } from '../../../../mock-builders';
+import { useReactionsFetcher } from '../useReactionsFetcher';
+
+async function renderUseReactionsFetcherHook(channel = generateChannel(), notificationOpts) {
+  const client = await getTestClient();
+  const wrapper = ({ children }) => (
+    <ChatProvider value={{ client }}>
+      <ChannelStateProvider value={{ channel }}>{children}</ChannelStateProvider>
+    </ChatProvider>
+  );
+
+  const { result } = renderHook(() => useReactionsFetcher(generateMessage(), notificationOpts), {
+    wrapper,
+  });
+  return result.current;
+}
+
+describe('useReactionsFetcher custom hook', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('should generate a function', async () => {
+    const fetchReactions = await renderUseReactionsFetcherHook();
+    expect(typeof fetchReactions).toBe('function');
+  });
+
+  it('generated function should make a request to fetch reactions', async () => {
+    const getReactionsMock = jest.fn(() => Promise.resolve({ reactions: [] }));
+    const channel = generateChannel({
+      getReactions: getReactionsMock,
+    });
+    const fetchReactions = await renderUseReactionsFetcherHook(channel);
+    await fetchReactions();
+    expect(getReactionsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('generated function should make paged requests to fetch reactions', async () => {
+    const getReactionsMock = jest
+      .fn()
+      .mockImplementationOnce(() => Promise.resolve({ reactions: Array(300) }))
+      .mockImplementationOnce(() => Promise.resolve({ reactions: [] }));
+    const channel = generateChannel({
+      getReactions: getReactionsMock,
+    });
+    const fetchReactions = await renderUseReactionsFetcherHook(channel);
+    await fetchReactions();
+    expect(getReactionsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('generated function should notify about errors', async () => {
+    const getReactionsMock = jest.fn(() => Promise.reject());
+    const channel = generateChannel({
+      getReactions: getReactionsMock,
+    });
+    const getErrorNotificationMock = jest.fn(() => 'Error message');
+    const notifyMock = jest.fn();
+    const fetchReactions = await renderUseReactionsFetcherHook(channel, {
+      getErrorNotification: getErrorNotificationMock,
+      notify: notifyMock,
+    });
+
+    await fetchReactions().catch(() => {});
+
+    expect(getErrorNotificationMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledWith('Error message', 'error');
+  });
+});

--- a/src/components/Message/hooks/index.ts
+++ b/src/components/Message/hooks/index.ts
@@ -10,3 +10,4 @@ export * from './useReactionHandler';
 export * from './useRetryHandler';
 export * from './useUserHandler';
 export * from './useUserRole';
+export * from './useReactionsFetcher';

--- a/src/components/Message/hooks/useReactionsFetcher.ts
+++ b/src/components/Message/hooks/useReactionsFetcher.ts
@@ -1,0 +1,57 @@
+import { StreamMessage, useChannelStateContext, useTranslationContext } from '../../../context';
+import { DefaultStreamChatGenerics } from '../../../types/types';
+import { Channel, ReactionResponse } from 'stream-chat';
+
+export const MAX_MESSAGE_REACTIONS_TO_FETCH = 1200;
+
+type FetchMessageReactionsNotifications<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+> = {
+  getErrorNotification?: (message: StreamMessage<StreamChatGenerics>) => string;
+  notify?: (notificationText: string, type: 'success' | 'error') => void;
+};
+
+export function useReactionsFetcher<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>(
+  message: StreamMessage<StreamChatGenerics>,
+  notifications: FetchMessageReactionsNotifications<StreamChatGenerics>,
+) {
+  const { channel } = useChannelStateContext<StreamChatGenerics>('useReactionFetcher');
+  const { t } = useTranslationContext('useReactionFetcher');
+  const { getErrorNotification, notify } = notifications;
+
+  return () => {
+    try {
+      return fetchMessageReactions(channel, message.id);
+    } catch (e) {
+      const errorMessage = getErrorNotification?.(message);
+      notify?.(errorMessage || t('Error fetching reactions'), 'error');
+      throw e;
+    }
+  };
+}
+
+async function fetchMessageReactions<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>(channel: Channel<StreamChatGenerics>, messageId: string) {
+  const reactions: ReactionResponse<StreamChatGenerics>[] = [];
+  const limit = 300;
+  let offset = 0;
+  const reactionsLimit = MAX_MESSAGE_REACTIONS_TO_FETCH;
+  let lastPageSize = limit;
+
+  while (lastPageSize === limit && reactions.length < reactionsLimit) {
+    const response = await channel.getReactions(messageId, {
+      limit,
+      offset,
+    });
+    lastPageSize = response.reactions.length;
+    if (lastPageSize > 0) {
+      reactions.push(...response.reactions);
+    }
+    offset += lastPageSize;
+  }
+
+  return reactions;
+}

--- a/src/components/Message/hooks/useReactionsFetcher.ts
+++ b/src/components/Message/hooks/useReactionsFetcher.ts
@@ -15,15 +15,15 @@ export function useReactionsFetcher<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 >(
   message: StreamMessage<StreamChatGenerics>,
-  notifications: FetchMessageReactionsNotifications<StreamChatGenerics>,
+  notifications: FetchMessageReactionsNotifications<StreamChatGenerics> = {},
 ) {
   const { channel } = useChannelStateContext<StreamChatGenerics>('useReactionFetcher');
   const { t } = useTranslationContext('useReactionFetcher');
   const { getErrorNotification, notify } = notifications;
 
-  return () => {
+  return async () => {
     try {
-      return fetchMessageReactions(channel, message.id);
+      return await fetchMessageReactions(channel, message.id);
     } catch (e) {
       const errorMessage = getErrorNotification?.(message);
       notify?.(errorMessage || t('Error fetching reactions'), 'error');

--- a/src/components/Message/types.ts
+++ b/src/components/Message/types.ts
@@ -41,6 +41,8 @@ export type MessageProps<
   formatDate?: (date: Date) => string;
   /** Function that returns the notification text to be displayed when a delete message request fails */
   getDeleteMessageErrorNotification?: (message: StreamMessage<StreamChatGenerics>) => string;
+  /** Function that returns the notification text to be displayed when loading message reactions fails */
+  getFetchReactionsErrorNotification?: (message: StreamMessage<StreamChatGenerics>) => string;
   /** Function that returns the notification text to be displayed when a flag message request fails */
   getFlagMessageErrorNotification?: (message: StreamMessage<StreamChatGenerics>) => string;
   /** Function that returns the notification text to be displayed when a flag message request succeeds */

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -305,8 +305,7 @@ export const messageHasReactions = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 >(
   message?: StreamMessage<StreamChatGenerics>,
-) => !!message?.latest_reactions && !!message.latest_reactions.length;
-// tktktk
+) => Object.values(message?.reaction_counts ?? {}).some((count) => count > 0);
 
 export const messageHasAttachments = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -306,6 +306,7 @@ export const messageHasReactions = <
 >(
   message?: StreamMessage<StreamChatGenerics>,
 ) => !!message?.latest_reactions && !!message.latest_reactions.length;
+// tktktk
 
 export const messageHasAttachments = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics

--- a/src/components/Reactions/ReactionsListModal.tsx
+++ b/src/components/Reactions/ReactionsListModal.tsx
@@ -29,9 +29,10 @@ export function ReactionsListModal({
     ({ reactionType }) => reactionType === selectedReactionType,
   );
   const SelectedEmojiComponent = selectedReaction?.EmojiComponent ?? null;
-  const { isLoading: areReactionsLoading, reactions: allReactions } = useFetchReactions(
+  const { isLoading: areReactionsLoading, reactions: allReactions } = useFetchReactions({
     handleFetchReactions,
-  );
+    shouldFetch: modalProps.open,
+  });
   const currentReactions = useMemo(() => {
     if (!selectedReactionType) {
       return [];

--- a/src/components/Reactions/ReactionsListModal.tsx
+++ b/src/components/Reactions/ReactionsListModal.tsx
@@ -45,7 +45,7 @@ export function ReactionsListModal({
 
   return (
     <Modal {...modalProps}>
-      <div className='str-chat__message-reactions-details'>
+      <div className='str-chat__message-reactions-details' data-testid='reactions-list-modal'>
         <div className='str-chat__message-reactions-details-reaction-types'>
           {reactions.map(
             ({ EmojiComponent, reactionCount, reactionType }) =>
@@ -83,11 +83,11 @@ export function ReactionsListModal({
             currentReactions.map(({ user }) => (
               <div className='str-chat__message-reactions-details-reacting-user' key={user?.id}>
                 <Avatar
-                  data-testclass='avatar'
+                  data-testid='avatar'
                   image={user?.image as string | undefined}
                   name={user?.name || user?.id}
                 />
-                <span className='str-chat__user-item--name' data-testclass='reaction-user-username'>
+                <span className='str-chat__user-item--name' data-testid='reaction-user-username'>
                   {user?.name || user?.id}
                 </span>
               </div>

--- a/src/components/Reactions/ReactionsListModal.tsx
+++ b/src/components/Reactions/ReactionsListModal.tsx
@@ -1,0 +1,99 @@
+import React, { useMemo } from 'react';
+import clsx from 'clsx';
+
+import { Modal, ModalProps } from '../Modal';
+import { ReactionSummary } from './types';
+import { useFetchReactions } from './hooks/useFetchReactions';
+import { LoadingIndicator } from '../Loading';
+import { Avatar } from '../Avatar';
+import { MessageContextValue } from '../../context';
+import { DefaultStreamChatGenerics } from '../../types/types';
+
+type ReactionsListModalProps<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+> = ModalProps &
+  Partial<Pick<MessageContextValue<StreamChatGenerics>, 'handleFetchReactions'>> & {
+    reactions: ReactionSummary[];
+    selectedReactionType: string | null;
+    onSelectedReactionTypeChange?: (reactionType: string) => void;
+  };
+
+export function ReactionsListModal({
+  handleFetchReactions,
+  onSelectedReactionTypeChange,
+  reactions,
+  selectedReactionType,
+  ...modalProps
+}: ReactionsListModalProps) {
+  const selectedReaction = reactions.find(
+    ({ reactionType }) => reactionType === selectedReactionType,
+  );
+  const SelectedEmojiComponent = selectedReaction?.EmojiComponent ?? null;
+  const { isLoading: areReactionsLoading, reactions: allReactions } = useFetchReactions(
+    handleFetchReactions,
+  );
+  const currentReactions = useMemo(() => {
+    if (!selectedReactionType) {
+      return [];
+    }
+
+    return allReactions.filter(
+      (reaction) => reaction.type === selectedReactionType && reaction.user,
+    );
+  }, [allReactions, selectedReactionType]);
+
+  return (
+    <Modal {...modalProps}>
+      <div className='str-chat__message-reactions-details'>
+        <div className='str-chat__message-reactions-details-reaction-types'>
+          {reactions.map(
+            ({ EmojiComponent, reactionCount, reactionType }) =>
+              EmojiComponent && (
+                <div
+                  className={clsx('str-chat__message-reactions-details-reaction-type', {
+                    'str-chat__message-reactions-details-reaction-type--selected':
+                      selectedReactionType === reactionType,
+                  })}
+                  data-testid={`reaction-details-selector-${reactionType}`}
+                  key={reactionType}
+                  onClick={() => onSelectedReactionTypeChange?.(reactionType)}
+                >
+                  <span className='emoji str-chat__message-reaction-emoji'>
+                    <EmojiComponent />
+                  </span>
+                  &nbsp;
+                  <span className='str-chat__message-reaction-count'>{reactionCount}</span>
+                </div>
+              ),
+          )}
+        </div>
+        {SelectedEmojiComponent && (
+          <div className='emoji str-chat__message-reaction-emoji str-chat__message-reaction-emoji-big'>
+            <SelectedEmojiComponent />
+          </div>
+        )}
+        <div
+          className='str-chat__message-reactions-details-reacting-users'
+          data-testid='all-reacting-users'
+        >
+          {areReactionsLoading ? (
+            <LoadingIndicator />
+          ) : (
+            currentReactions.map(({ user }) => (
+              <div className='str-chat__message-reactions-details-reacting-user' key={user?.id}>
+                <Avatar
+                  data-testclass='avatar'
+                  image={user?.image as string | undefined}
+                  name={user?.name || user?.id}
+                />
+                <span className='str-chat__user-item--name' data-testclass='reaction-user-username'>
+                  {user?.name || user?.id}
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/Reactions/SimpleReactionsList.tsx
+++ b/src/components/Reactions/SimpleReactionsList.tsx
@@ -111,7 +111,7 @@ const UnMemoizedSimpleReactionsList = <
                     {tooltipVisible && themeVersion === '1' && (
                       <div className='str-chat__simple-reactions-list-tooltip'>
                         <div className='arrow' />
-                        {re}
+                        {tooltipContent}
                       </div>
                     )}
                   </WithTooltip>

--- a/src/components/Reactions/__tests__/ReactionsList.test.js
+++ b/src/components/Reactions/__tests__/ReactionsList.test.js
@@ -53,6 +53,14 @@ describe('ReactionsList', () => {
     expect(results).toHaveNoViolations();
   });
 
+  it('should not break when reaction counts are not defined', async () => {
+    const { container } = renderComponent({
+      reaction_counts: undefined,
+    });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it('should render an emoji for each type of reaction', async () => {
     const reaction_counts = {
       haha: 2,

--- a/src/components/Reactions/__tests__/ReactionsList.test.js
+++ b/src/components/Reactions/__tests__/ReactionsList.test.js
@@ -17,9 +17,6 @@ import { defaultReactionOptions } from '../reactionOptions';
 
 const USER_ID = 'mark';
 
-const generateButtonTitle = (count) =>
-  Array.from({ length: count }, (_, i) => `${USER_ID}-${i}`).join(', ');
-
 const renderComponent = ({ reaction_counts = {}, ...props }) => {
   const reactions = Object.entries(reaction_counts).flatMap(([type, count]) =>
     Array.from({ length: count }, (_, i) =>
@@ -45,7 +42,7 @@ describe('ReactionsList', () => {
   it('should render the total reaction count', async () => {
     const { container, getByText } = renderComponent({
       reaction_counts: {
-        angry: 2,
+        haha: 2,
         love: 5,
       },
     });
@@ -70,11 +67,9 @@ describe('ReactionsList', () => {
     const hahaButton = getByTestId('reactions-list-button-haha');
     const loveButton = getByTestId('reactions-list-button-love');
 
-    expect(hahaButton).toHaveAttribute('title', generateButtonTitle(reaction_counts['haha']));
     expect(hahaButton.lastChild).toHaveTextContent(reaction_counts['haha']);
     expect(hahaButton.firstChild).toHaveTextContent('😂');
 
-    expect(loveButton).toHaveAttribute('title', generateButtonTitle(reaction_counts['love']));
     expect(loveButton.lastChild).toHaveTextContent(reaction_counts['love']);
     expect(loveButton.firstChild).toHaveTextContent('❤️');
 
@@ -99,10 +94,9 @@ describe('ReactionsList', () => {
     const bananaButton = getByTestId('reactions-list-button-banana');
     const cowboyButton = getByTestId('reactions-list-button-cowboy');
 
-    expect(bananaButton).toHaveAttribute('title', generateButtonTitle(reaction_counts['banana']));
     expect(bananaButton.lastChild).toHaveTextContent(reaction_counts['banana']);
     expect(bananaButton.firstChild).toHaveTextContent('🍌');
-    expect(cowboyButton).toHaveAttribute('title', generateButtonTitle(reaction_counts['cowboy']));
+
     expect(cowboyButton.lastChild).toHaveTextContent(reaction_counts['cowboy']);
     expect(cowboyButton.firstChild).toHaveTextContent('🤠');
 

--- a/src/components/Reactions/__tests__/ReactionsListModal.test.js
+++ b/src/components/Reactions/__tests__/ReactionsListModal.test.js
@@ -80,11 +80,47 @@ describe('ReactionsListModal', () => {
     expect(getAllByTestId('reaction-user-username')).toHaveLength(2);
 
     await act(() => {
-      fireEvent.click(getByTestId('reactions-list-button-love'));
+      fireEvent.click(getByTestId('reaction-details-selector-love'));
     });
     expect(getAllByTestId('reaction-user-username')).toHaveLength(5);
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it('should close reactions list modal when close button is clicked', async () => {
+    const reactionCounts = {
+      haha: 2,
+      love: 5,
+    };
+    const { getByTestId, getByTitle, queryByTestId } = renderComponent({
+      reaction_counts: reactionCounts,
+      reactions: generateReactionsFromReactionCounts(reactionCounts),
+    });
+
+    await act(() => {
+      fireEvent.click(getByTestId('reactions-list-button-haha'));
+    });
+    expect(getByTestId('reactions-list-modal')).toBeInTheDocument();
+    await act(() => {
+      fireEvent.click(getByTitle('Close'));
+    });
+    expect(queryByTestId('reactions-list-modal')).not.toBeInTheDocument();
+  });
+
+  it('should not allow opening reactions list modal when the reactions count is too high', async () => {
+    const reactionCounts = {
+      haha: 2000,
+      love: 5000,
+    };
+    const { getByTestId, queryByTestId } = renderComponent({
+      reaction_counts: reactionCounts,
+      reactions: generateReactionsFromReactionCounts(reactionCounts),
+    });
+
+    await act(() => {
+      fireEvent.click(getByTestId('reactions-list-button-haha'));
+    });
+    expect(queryByTestId('reactions-list-modal')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Reactions/__tests__/ReactionsListModal.test.js
+++ b/src/components/Reactions/__tests__/ReactionsListModal.test.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { toHaveNoViolations } from 'jest-axe';
+
+import { axe } from '../../../../axe-helper';
+expect.extend(toHaveNoViolations);
+
+import { ReactionsList } from '../ReactionsList';
+import { MessageProvider } from '../../../context/MessageContext';
+
+import { generateReactions, generateUser } from '../../../mock-builders';
+import { ComponentProvider } from '../../../context';
+import { defaultReactionOptions } from '../reactionOptions';
+
+const generateReactionsFromReactionCounts = (reactionCounts) =>
+  Object.entries(reactionCounts).flatMap(([type, count]) =>
+    generateReactions(count, (i) => ({
+      type,
+      user: generateUser({ id: `mark-${i}`, name: `Mark Number ${i}` }),
+    })),
+  );
+
+const renderComponent = ({ handleFetchReactions, ...props }) =>
+  render(
+    <ComponentProvider value={{ reactionOptions: defaultReactionOptions }}>
+      <MessageProvider value={{}}>
+        <ReactionsList handleFetchReactions={handleFetchReactions} {...props} />,
+      </MessageProvider>
+    </ComponentProvider>,
+  );
+
+describe('ReactionsListModal', () => {
+  beforeEach(() => {
+    // disable warnings (unreachable context)
+    jest.spyOn(console, 'warn').mockImplementation(null);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should show reactions modal when a reaction is clicked', async () => {
+    const reactionCounts = {
+      haha: 2,
+      love: 5,
+    };
+    const { container, getByTestId, queryByTestId } = renderComponent({
+      reaction_counts: reactionCounts,
+      reactions: generateReactionsFromReactionCounts(reactionCounts),
+    });
+
+    expect(queryByTestId('reactions-list-modal')).not.toBeInTheDocument();
+    await act(() => {
+      fireEvent.click(getByTestId('reactions-list-button-haha'));
+    });
+
+    expect(getByTestId('reactions-list-modal')).toBeInTheDocument();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should display a list of reactions in a modal', async () => {
+    const reactionCounts = {
+      haha: 2,
+      love: 5,
+    };
+    const reactions = generateReactionsFromReactionCounts(reactionCounts);
+    const fetchReactions = jest.fn(() => Promise.resolve(reactions));
+
+    const { container, getAllByTestId, getByTestId } = renderComponent({
+      handleFetchReactions: fetchReactions,
+      reaction_counts: reactionCounts,
+      reactions,
+    });
+
+    await act(() => {
+      fireEvent.click(getByTestId('reactions-list-button-haha'));
+    });
+    expect(getAllByTestId('reaction-user-username')).toHaveLength(2);
+
+    await act(() => {
+      fireEvent.click(getByTestId('reactions-list-button-love'));
+    });
+    expect(getAllByTestId('reaction-user-username')).toHaveLength(5);
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/Reactions/hooks/useFetchReactions.ts
+++ b/src/components/Reactions/hooks/useFetchReactions.ts
@@ -3,17 +3,29 @@ import { ReactionResponse } from 'stream-chat';
 import { MessageContextValue, useMessageContext } from '../../../context';
 import { DefaultStreamChatGenerics } from '../../../types/types';
 
+export interface FetchReactionsOptions<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+> {
+  shouldFetch: boolean;
+  handleFetchReactions?: MessageContextValue<StreamChatGenerics>['handleFetchReactions'];
+}
+
 export function useFetchReactions<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
->(propHandleFetchReactions?: MessageContextValue<StreamChatGenerics>['handleFetchReactions']) {
+>(options: FetchReactionsOptions) {
   const {
     handleFetchReactions: contextHandleFetchReactions,
   } = useMessageContext<StreamChatGenerics>('useFetchReactions');
   const [isLoading, setIsLoading] = useState(false);
   const [reactions, setReactions] = useState<ReactionResponse[]>([]);
+  const { handleFetchReactions: propHandleFetchReactions, shouldFetch } = options;
   const handleFetchReactions = propHandleFetchReactions ?? contextHandleFetchReactions;
 
   useEffect(() => {
+    if (!shouldFetch) {
+      return;
+    }
+
     let cancel = false;
 
     (async () => {
@@ -38,7 +50,7 @@ export function useFetchReactions<
     return () => {
       cancel = true;
     };
-  }, [handleFetchReactions]);
+  }, [handleFetchReactions, shouldFetch]);
 
   return { isLoading, reactions };
 }

--- a/src/components/Reactions/hooks/useFetchReactions.ts
+++ b/src/components/Reactions/hooks/useFetchReactions.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { ReactionResponse } from 'stream-chat';
+import { MessageContextValue, useMessageContext } from '../../../context';
+import { DefaultStreamChatGenerics } from '../../../types/types';
+
+export function useFetchReactions<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>(propHandleFetchReactions?: MessageContextValue<StreamChatGenerics>['handleFetchReactions']) {
+  const {
+    handleFetchReactions: contextHandleFetchReactions,
+  } = useMessageContext<StreamChatGenerics>('useFetchReactions');
+  const [isLoading, setIsLoading] = useState(false);
+  const [reactions, setReactions] = useState<ReactionResponse[]>([]);
+  const handleFetchReactions = propHandleFetchReactions ?? contextHandleFetchReactions;
+
+  useEffect(() => {
+    let cancel = false;
+
+    (async () => {
+      try {
+        setIsLoading(true);
+        const reactions = await handleFetchReactions();
+
+        if (!cancel) {
+          setReactions(reactions);
+        }
+      } catch (e) {
+        if (!cancel) {
+          setReactions([]);
+        }
+      } finally {
+        if (!cancel) {
+          setIsLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancel = true;
+    };
+  }, [handleFetchReactions]);
+
+  return { isLoading, reactions };
+}

--- a/src/components/Reactions/types.ts
+++ b/src/components/Reactions/types.ts
@@ -1,0 +1,9 @@
+import { ComponentType } from 'react';
+
+export interface ReactionSummary {
+  EmojiComponent: ComponentType | null;
+  isOwnReaction: boolean;
+  latestReactedUserNames: string[];
+  reactionCount: number;
+  reactionType: string;
+}

--- a/src/context/MessageContext.tsx
+++ b/src/context/MessageContext.tsx
@@ -44,7 +44,7 @@ export type MessageContextValue<
   handleDelete: ReactEventHandler;
   /** Function to edit a message in a Channel */
   handleEdit: ReactEventHandler;
-  /** Function to fetch all message reactions */
+  /** Function to fetch the message reactions */
   handleFetchReactions: () => Promise<Array<ReactionResponse<StreamChatGenerics>>>;
   /** Function to flag a message in a Channel */
   handleFlag: ReactEventHandler;

--- a/src/context/MessageContext.tsx
+++ b/src/context/MessageContext.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, useContext } from 'react';
 
-import type { Mute, UserResponse } from 'stream-chat';
+import type { Mute, ReactionResponse, UserResponse } from 'stream-chat';
 
 import type { ChannelActionContextValue } from './ChannelActionContext';
 import type { StreamMessage } from './ChannelStateContext';
@@ -44,6 +44,8 @@ export type MessageContextValue<
   handleDelete: ReactEventHandler;
   /** Function to edit a message in a Channel */
   handleEdit: ReactEventHandler;
+  /** Function to fetch all message reactions */
+  handleFetchReactions: () => Promise<Array<ReactionResponse<StreamChatGenerics>>>;
   /** Function to flag a message in a Channel */
   handleFlag: ReactEventHandler;
   /** Function to mute a user in a Channel */

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -17,6 +17,7 @@
   "Error adding flag": "Fehler beim Hinzufügen des Flags",
   "Error connecting to chat, refresh the page to try again.": "Verbindungsfehler zum Chat, Aktualisiere die Seite um es erneut zu versuchen.",
   "Error deleting message": "Fehler beim Löschen der Nachricht",
+  "Error fetching reactions": "Fehler beim Laden von Reaktionen",
   "Error muting a user ...": "Fehler beim Stummschalten eines Nutzers.",
   "Error pinning message": "Fehler beim Pinnen der Nachricht",
   "Error removing message pin": "Fehler beim Entfernen der gepinnten Nachricht",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -17,6 +17,7 @@
   "Error adding flag": "Error adding flag",
   "Error connecting to chat, refresh the page to try again.": "Error connecting to chat, refresh the page to try again.",
   "Error deleting message": "Error deleting message",
+  "Error fetching reactions": "Error loading reactions",
   "Error muting a user ...": "Error muting a user ...",
   "Error pinning message": "Error pinning message",
   "Error removing message pin": "Error removing message pin",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -17,6 +17,7 @@
   "Error adding flag": "Error al agregar la bandera",
   "Error connecting to chat, refresh the page to try again.": "Error al conectarse al chat, actualice la página para volver a intentarlo.",
   "Error deleting message": "Error al eliminar el mensaje",
+  "Error fetching reactions": "Error al cargar las reacciones",
   "Error muting a user ...": "Error al silenciar a un usuario ...",
   "Error pinning message": "Mensaje de error al fijar",
   "Error removing message pin": "Error al quitar el pin del mensaje",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -17,6 +17,7 @@
   "Error adding flag": "Erreur lors de l'ajout du drapeau",
   "Error connecting to chat, refresh the page to try again.": "Erreur de connexion au chat, rafraîchissez la page pour réessayer.",
   "Error deleting message": "Erreur lors de la suppression du message",
+  "Error fetching reactions": "Erreur de chargement des réactions",
   "Error muting a user ...": "Erreur de mise en sourdine d'un utilisateur ...",
   "Error pinning message": "Erreur d'épinglage du message",
   "Error removing message pin": "Erreur lors de la suppression du code PIN du message",

--- a/src/i18n/hi.json
+++ b/src/i18n/hi.json
@@ -17,6 +17,7 @@
   "Error adding flag": "ध्वज जोड़ने में त्रुटि",
   "Error connecting to chat, refresh the page to try again.": "चैट से कनेक्ट करने में त्रुटि, पेज को रिफ्रेश करें",
   "Error deleting message": "संदेश हटाने में त्रुटि",
+  "Error fetching reactions": "प्रतिक्रियाएँ लोड करने में त्रुटि",
   "Error muting a user ...": "यूजर को म्यूट करने का प्रयास फेल हुआ",
   "Error pinning message": "संदेश को पिन करने में त्रुटि",
   "Error removing message pin": "संदेश पिन निकालने में त्रुटि",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -17,6 +17,7 @@
   "Error adding flag": "Errore durante l'aggiunta del flag",
   "Error connecting to chat, refresh the page to try again.": "Errore di connessione alla chat, aggiorna la pagina per riprovare",
   "Error deleting message": "Errore durante l'eliminazione del messaggio",
+  "Error fetching reactions": "Errore nel caricamento delle reazioni",
   "Error muting a user ...": "Errore silenziando un utente ...",
   "Error pinning message": "Errore durante il blocco del messaggio",
   "Error removing message pin": "Errore durante la rimozione del PIN del messaggio",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -17,6 +17,7 @@
   "Error adding flag": "フラグを追加のエラーが発生しました",
   "Error connecting to chat, refresh the page to try again.": "チャットへの接続ができませんでした。ページを更新してください。",
   "Error deleting message": "メッセージを削除するエラーが発生しました",
+  "Error fetching reactions": "反応の読み込みエラー",
   "Error muting a user ...": "ユーザーを無音するエラーが発生しました...",
   "Error pinning message": "メッセージをピンのエラーが発生しました",
   "Error removing message pin": "メッセージのピンを削除のエラーが発生しました",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -17,6 +17,7 @@
   "Error adding flag": "플래그를 추가하는 동안 오류가 발생했습니다.",
   "Error connecting to chat, refresh the page to try again.": "채팅에 연결하는 동안 오류가 발생했습니다. 페이지를 새로고침하여 다시 시도하세요.",
   "Error deleting message": "메시지를 삭제하는 중에 오류가 발생했습니다.",
+  "Error fetching reactions": "반응 로딩 오류.",
   "Error muting a user ...": "사용자를 음소거하는 중에 오류가 발생했습니다...",
   "Error pinning message": "메시지를 핀하는 중에 오류가 발생했습니다.",
   "Error removing message pin": "메시지 핀을 제거하는 중에 오류가 발생했습니다.",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -17,6 +17,7 @@
   "Error adding flag": "Fout bij toevoegen van vlag",
   "Error connecting to chat, refresh the page to try again.": "Fout bij het verbinden, ververs de pagina om nogmaals te proberen",
   "Error deleting message": "Fout bij verwijderen van bericht",
+  "Error fetching reactions": "Fout bij het laden van reacties",
   "Error muting a user ...": "Fout bij het muten van de gebruiker",
   "Error pinning message": "Fout bij vastzetten van bericht",
   "Error removing message pin": "Fout bij verwijderen van berichtpin",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -17,6 +17,7 @@
   "Error adding flag": "Erro ao reportar",
   "Error connecting to chat, refresh the page to try again.": "Erro ao conectar ao bate-papo, atualize a página para tentar novamente.",
   "Error deleting message": "Erro ao deletar mensagem",
+  "Error fetching reactions": "Erro ao carregar reacções",
   "Error muting a user ...": "Erro ao silenciar um usuário...",
   "Error pinning message": "Erro ao fixar mensagem",
   "Error removing message pin": "Erro ao remover o PIN da mensagem",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -17,6 +17,7 @@
   "Error adding flag": "Ошибка добавления флага",
   "Error connecting to chat, refresh the page to try again.": "Ошибка подключения к чату, обновите страницу чтобы попробовать снова.",
   "Error deleting message": "Ошибка при удалении сообщения",
+  "Error fetching reactions": "Ошибка при загрузке реакций",
   "Error muting a user ...": "Ошибка отключения уведомлений от пользователя...",
   "Error pinning message": "Сообщение об ошибке при закреплении",
   "Error removing message pin": "Ошибка при удалении булавки сообщения",

--- a/src/mock-builders/generator/reaction.js
+++ b/src/mock-builders/generator/reaction.js
@@ -10,3 +10,11 @@ export const generateReaction = (options = {}) => {
     ...options,
   };
 };
+
+export const countReactions = (reactions = []) => {
+  const reactionCount = {};
+  for (const reaction of reactions) {
+    reactionCount[reaction.type] = (reactionCount[reaction.type] ?? 0) + 1;
+  }
+  return reactionCount;
+};

--- a/src/mock-builders/generator/reaction.js
+++ b/src/mock-builders/generator/reaction.js
@@ -11,6 +11,14 @@ export const generateReaction = (options = {}) => {
   };
 };
 
+export const generateReactions = (count, options = () => ({})) => {
+  const reactions = [];
+  for (let i = 0; i < count; i++) {
+    reactions.push(generateReaction(options(i)));
+  }
+  return reactions;
+};
+
 export const countReactions = (reactions = []) => {
   const reactionCount = {};
   for (const reaction of reactions) {


### PR DESCRIPTION
### 🎯 Goal

We're updating UI for displaying reactions. Instead of showing the latest reactions only, we're adding a separate modal window full the full list of reactions.

Although not a breaking change in terms of API, it's a breaking change in terms of UI and styling.

### 🛠 Implementation details

1. New component `ReactionsListModal` is added (rendered by default `ReactionsList`).
2. New handler added on message context level: `handleFetchReactions`. It's expected to load all reactions for current message (e.g. using our paged endpoint for fetching reactions). As usual, it can be overriden on `Message` or `ReactionsList` level.
3. Instead of showing counts for the latest reactions only, we show counts for all supported reactions in the `ReactionsList`.

### 🎨 UI Changes

![image](https://github.com/GetStream/stream-chat-react/assets/975978/69b93a0b-571f-4823-9f21-ceb744cfb4af)

### To-Do

- [x] Tests for ReactionsListModal
- [x] Add translations