### PR TITLE
feat: allow to pass custom function customQueryChannels to ChannelList to query channels

### DIFF
--- a/docusaurus/docs/React/components/core-components/channel-list.mdx
+++ b/docusaurus/docs/React/components/core-components/channel-list.mdx
@@ -219,6 +219,83 @@ Set a channel (with this ID) to active and force it to move to the top of the li
 | ------ |
 | string |
 
+### customQueryChannels
+
+Custom function that handles the channel pagination.
+
+Takes parameters:
+
+| Parameter         | Description                                                                                                                                                           |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `currentChannels` | The state of loaded `Channel` objects queried thus far. Has to be set with `setChannels` (see below).                                                                 |
+| `queryType`       | A string indicating, whether the channels state has to be reset to the first page ('reload') or newly queried channels should be appended to the `currentChannels`.   |
+| `setChannels`     | Function that allows us to set the channels state reflected in `currentChannels`.                                                                                     |
+| `setHasNextPage`  | Flag indicating whether there are more items to be loaded from the API. Should be infered from the comparison of the query result length and the query options limit. |
+
+The function has to:
+1. build / provide own query filters, sort and options parameters
+2. query and append channels to the current channels state
+3. update the `hasNext` pagination flag after each query with `setChannels` function
+
+An example below implements a custom query function that uses different filters sequentially once a preceding filter is exhausted:
+
+```ts
+import uniqBy from "lodash.uniqby";
+import throttle from 'lodash.throttle';
+import { useRef } from 'react';
+import { ChannelFilters, ChannelOptions, ChannelSort, StreamChat } from 'stream-chat';
+import {
+  CustomQueryChannelParams,
+  useChatContext,
+} from 'stream-chat-react';
+
+export const useCustomQueryChannels = () => {
+    const {client} = useChatContext();
+    const filters1: ChannelFilters = { member_count: {$gt: 10}, members: {$in: [client.user.id]}, type: 'messaging'};
+    const filters2: ChannelFilters = { type: 'messaging', members: { $in: [client.user.id] } };
+    const options: ChannelOptions = { state: true, presence: true, limit: 10 };
+    const sort: ChannelSort = { last_message_at: -1, updated_at: -1 };
+
+    const filtersArray = [filters1, filters2];
+    const appliedFilterIndex = useRef(0);
+
+    const customQueryChannels = throttle(async ({currentChannels, queryType, setChannels, setHasNextPage}: CustomQueryChannelParams) => {
+      const offset = queryType === 'reload' ? 0 : currentChannels.length;
+
+      const newOptions = {
+        limit: options.limit ?? 30,
+        offset,
+        ...options,
+      };
+
+      const filters = filtersArray[appliedFilterIndex.current];
+      const channelQueryResponse = await client.queryChannels(filters, sort || {}, newOptions);
+
+      const newChannels =
+          queryType === 'reload'
+              ? channelQueryResponse
+              : uniqBy([...currentChannels, ...channelQueryResponse], 'cid');
+
+      setChannels(newChannels);
+      const lastPageForCurrentFilter = channelQueryResponse.length < newOptions.limit;
+      const isLastPageForAllFilters = lastPageForCurrentFilter && appliedFilterIndex.current === filtersArray.length - 1;
+      setHasNextPage(!isLastPageForAllFilters);
+      if (lastPageForCurrentFilter) {
+        appliedFilterIndex.current += 1;
+      }
+
+    }, 500, {leading: true, trailing: false});
+
+    return customQueryChannels;
+};
+```
+
+It is recommended to control for duplicate requests by throttling the custom function calls.
+
+| Type                    |
+|-------------------------|
+| `CustomQueryChannelsFn` |
+
 ### EmptyStateIndicator
 
 Custom UI component for rendering an empty list.

--- a/docusaurus/docs/React/components/core-components/channel-list.mdx
+++ b/docusaurus/docs/React/components/core-components/channel-list.mdx
@@ -242,59 +242,79 @@ An example below implements a custom query function that uses different filters 
 ```ts
 import uniqBy from "lodash.uniqby";
 import throttle from 'lodash.throttle';
-import { useRef } from 'react';
-import { ChannelFilters, ChannelOptions, ChannelSort, StreamChat } from 'stream-chat';
+import {useCallback, useRef} from 'react';
+import {ChannelFilters, ChannelOptions, ChannelSort, StreamChat} from 'stream-chat';
 import {
-  CustomQueryChannelParams,
-  useChatContext,
+    CustomQueryChannelParams,
+    useChatContext,
 } from 'stream-chat-react';
 
+const DEFAULT_PAGE_SIZE = 30 as const;
+
 export const useCustomQueryChannels = () => {
-    const {client} = useChatContext();
-    const filters1: ChannelFilters = { member_count: {$gt: 10}, members: {$in: [client.user.id]}, type: 'messaging'};
-    const filters2: ChannelFilters = { type: 'messaging', members: { $in: [client.user.id] } };
-    const options: ChannelOptions = { state: true, presence: true, limit: 10 };
-    const sort: ChannelSort = { last_message_at: -1, updated_at: -1 };
+  const { client } = useChatContext();
+  const filters1: ChannelFilters = {
+    member_count: { $gt: 10 },
+    members: { $in: [client.user?.id || ''] },
+    type: 'messaging',
+  };
+  const filters2: ChannelFilters = { members: { $in: [client.user?.id || ''] }, type: 'messaging' };
+  const options: ChannelOptions = { limit: 10, presence: true, state: true };
+  const sort: ChannelSort = { last_message_at: -1, updated_at: -1 };
 
-    const filtersArray = [filters1, filters2];
-    const appliedFilterIndex = useRef(0);
+  const filtersArray = [filters1, filters2];
+  const appliedFilterIndex = useRef(0);
 
-    const customQueryChannels = throttle(async ({currentChannels, queryType, setChannels, setHasNextPage}: CustomQueryChannelParams) => {
-      const offset = queryType === 'reload' ? 0 : currentChannels.length;
+  const customQueryChannels = useCallback(
+    throttle(
+      async ({
+        currentChannels,
+        queryType,
+        setChannels,
+        setHasNextPage,
+      }: CustomQueryChannelParams) => {
+        const offset = queryType === 'reload' ? 0 : currentChannels.length;
 
-      const newOptions = {
-        limit: options.limit ?? 30,
-        offset,
-        ...options,
-      };
+        const newOptions = {
+          limit: options.limit ?? DEFAULT_PAGE_SIZE,
+          offset,
+          ...options,
+        };
 
-      const filters = filtersArray[appliedFilterIndex.current];
-      const channelQueryResponse = await client.queryChannels(filters, sort || {}, newOptions);
+        const filters = filtersArray[appliedFilterIndex.current];
+        const channelQueryResponse = await client.queryChannels(filters, sort || {}, newOptions);
 
-      const newChannels =
+        const newChannels =
           queryType === 'reload'
-              ? channelQueryResponse
-              : uniqBy([...currentChannels, ...channelQueryResponse], 'cid');
+            ? channelQueryResponse
+            : uniqBy([...currentChannels, ...channelQueryResponse], 'cid');
 
-      setChannels(newChannels);
-      const lastPageForCurrentFilter = channelQueryResponse.length < newOptions.limit;
-      const isLastPageForAllFilters = lastPageForCurrentFilter && appliedFilterIndex.current === filtersArray.length - 1;
-      setHasNextPage(!isLastPageForAllFilters);
-      if (lastPageForCurrentFilter) {
-        appliedFilterIndex.current += 1;
-      }
+        setChannels(newChannels);
 
-    }, 500, {leading: true, trailing: false});
+        const lastPageForCurrentFilter = channelQueryResponse.length < newOptions.limit;
+        const isLastPageForAllFilters =
+          lastPageForCurrentFilter && appliedFilterIndex.current === filtersArray.length - 1;
 
-    return customQueryChannels;
+        setHasNextPage(!isLastPageForAllFilters);
+        if (lastPageForCurrentFilter) {
+          appliedFilterIndex.current += 1;
+        }
+      },
+      500,
+      { leading: true, trailing: false },
+    ),
+    [client, filtersArray],
+  );
+
+  return customQueryChannels;
 };
 ```
 
 It is recommended to control for duplicate requests by throttling the custom function calls.
 
-| Type                    |
-|-------------------------|
-| `CustomQueryChannelsFn` |
+| Type                                                                                              |
+|---------------------------------------------------------------------------------------------------|
+| <GHComponentLink text='CustomQueryChannelsFn' path='/ChannelList/hooks/usePaginatedChannels.ts'/> |
 
 ### EmptyStateIndicator
 

--- a/src/components/ChannelList/ChannelList.tsx
+++ b/src/components/ChannelList/ChannelList.tsx
@@ -13,7 +13,7 @@ import { useMobileNavigation } from './hooks/useMobileNavigation';
 import { useNotificationAddedToChannelListener } from './hooks/useNotificationAddedToChannelListener';
 import { useNotificationMessageNewListener } from './hooks/useNotificationMessageNewListener';
 import { useNotificationRemovedFromChannelListener } from './hooks/useNotificationRemovedFromChannelListener';
-import { usePaginatedChannels } from './hooks/usePaginatedChannels';
+import { CustomQueryChannelsFn, usePaginatedChannels } from './hooks/usePaginatedChannels';
 import { useUserPresenceChangedListener } from './hooks/useUserPresenceChangedListener';
 import { MAX_QUERY_CHANNELS_LIMIT, moveChannelUp } from './utils';
 
@@ -64,6 +64,8 @@ export type ChannelListProps<
   ChannelSearch?: React.ComponentType<ChannelSearchProps<StreamChatGenerics>>;
   /** Set a channel (with this ID) to active and manually move it to the top of the list */
   customActiveChannel?: string;
+  /** Custom function that handles the channel pagination. Has to build query filters, sort and options and query and append channels to the current channels state and update the hasNext pagination flag after each query. */
+  customQueryChannels?: CustomQueryChannelsFn<StreamChatGenerics>;
   /** Custom UI component for rendering an empty list, defaults to and accepts same props as: [EmptyStateIndicator](https://github.com/GetStream/stream-chat-react/blob/master/src/components/EmptyStateIndicator/EmptyStateIndicator.tsx) */
   EmptyStateIndicator?: React.ComponentType<EmptyStateIndicatorProps>;
   /** An object containing channel query filters */
@@ -163,6 +165,7 @@ const UnMemoizedChannelList = <
     channelRenderFilterFn,
     ChannelSearch = DefaultChannelSearch,
     customActiveChannel,
+    customQueryChannels,
     EmptyStateIndicator = DefaultEmptyStateIndicator,
     filters,
     LoadingErrorIndicator = ChatDown,
@@ -274,6 +277,7 @@ const UnMemoizedChannelList = <
     options || DEFAULT_OPTIONS,
     activeChannelHandler,
     recoveryThrottleIntervalMs,
+    customQueryChannels,
   );
 
   const loadedChannels = channelRenderFilterFn ? channelRenderFilterFn(channels) : channels;

--- a/src/components/Chat/hooks/useChannelsQueryState.ts
+++ b/src/components/Chat/hooks/useChannelsQueryState.ts
@@ -9,9 +9,9 @@ type ChannelQueryState =
 
 export interface ChannelsQueryState {
   error: ErrorFromResponse<APIErrorResponse> | null;
-  queryInProgress: ChannelQueryState | null;
+  queryInProgress: ChannelQueryState;
   setError: Dispatch<SetStateAction<ErrorFromResponse<APIErrorResponse> | null>>;
-  setQueryInProgress: Dispatch<SetStateAction<ChannelQueryState | null>>;
+  setQueryInProgress: Dispatch<SetStateAction<ChannelQueryState>>;
 }
 
 export const useChannelsQueryState = (): ChannelsQueryState => {


### PR DESCRIPTION
### 🎯 Goal

Create a new `ChannelList` prop `customQueryChannels` that allows integrators to control the channels pagination queries. The integrators have to generate own `filters`, `sort` and `options` parameters.
