### PR TITLE
fix: avatar alignment

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -80,6 +80,7 @@ export const Avatar = <
           onLoad={() => setLoaded(true)}
           src={image}
           style={{
+            display: 'block',
             flexBasis: `${size}px`,
             height: `${size}px`,
             objectFit: 'cover',

--- a/src/components/Avatar/__tests__/Avatar.test.js
+++ b/src/components/Avatar/__tests__/Avatar.test.js
@@ -61,6 +61,7 @@ describe('Avatar', () => {
           src="random"
           style={
             Object {
+              "display": "block",
               "flexBasis": "32px",
               "height": "32px",
               "objectFit": "cover",

--- a/src/components/ChannelPreview/__tests__/__snapshots__/ChannelPreviewMessenger.test.js.snap
+++ b/src/components/ChannelPreview/__tests__/__snapshots__/ChannelPreviewMessenger.test.js.snap
@@ -40,6 +40,7 @@ exports[`ChannelPreviewMessenger should render correctly 1`] = `
           src="https://randomimage.com/src.jpg"
           style={
             Object {
+              "display": "block",
               "flexBasis": "40px",
               "height": "40px",
               "objectFit": "cover",


### PR DESCRIPTION
### 🎯 Goal

Currently `<img />` in the Avatar component is an inline-block element with line-height equal to the avatar size. Since the image is vertically aligned to the baseline, the actual height occupied by it is a bit more than the avatar size, with a little additional spacing below the baseline.

That doesn't affect the positioning, but can cause unexpected overflows. I encountered this when updating our demos:

https://github.com/GetStream/stream-chat-react/assets/975978/1ab31832-010c-49f6-8a27-13a0f89ad434


### 🛠 Implementation details

Fixing this just by making `<img />` block - no need to deal with vertical alignment that way.

### 🎨 UI Changes

No visible changes.
