### PR TITLE
fix: export DefaultStreamChatGenerics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './components';
 export * from './context';
 export * from './i18n';
+export * from './types';
 export * from './utils';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export { DefaultStreamChatGenerics } from './types';

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -39,16 +39,6 @@ export type DefaultChannelType = UnknownType & {
   subtitle?: string;
 };
 
-export type DefaultStreamChatGenerics = ExtendableGenerics & {
-  attachmentType: DefaultAttachmentType;
-  channelType: DefaultChannelType;
-  commandType: LiteralStringForUnion;
-  eventType: UnknownType;
-  messageType: DefaultMessageType;
-  reactionType: UnknownType;
-  userType: DefaultUserType;
-};
-
 export type DefaultMessageType<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = UnknownType & {
@@ -71,6 +61,16 @@ export type DefaultUserType<
   DefaultUserTypeInternal & {
     mutes?: Array<Mute<StreamChatGenerics>>;
   };
+
+export type DefaultStreamChatGenerics = ExtendableGenerics & {
+  attachmentType: DefaultAttachmentType;
+  channelType: DefaultChannelType;
+  commandType: LiteralStringForUnion;
+  eventType: UnknownType;
+  messageType: DefaultMessageType;
+  reactionType: UnknownType;
+  userType: DefaultUserType;
+};
 
 export type GiphyVersions =
   | 'original'


### PR DESCRIPTION
### 🎯 Goal

All the default components extend from `DefaultStreamChatGenerics` type defined in `stream-chat-react`. This type defines different fields on ChannelType than the generics exported from `stream-chat`. This leads to the situation where custom components extend different default type than the default components.