### PR TITLE
fix: prevent mine attr from spreading on message actions box div

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -164,7 +164,7 @@
         "@typescript-eslint/explicit-module-boundary-types": 0,
         "@typescript-eslint/no-empty-interface": 0,
         "@typescript-eslint/ban-ts-comment": 0,
-        "@typescript-eslint/no-unused-vars": 1,
+        "@typescript-eslint/no-unused-vars": [1, { "ignoreRestSiblings": true }],
         "@typescript-eslint/no-var-requires": 0,
         "react-hooks/exhaustive-deps": 1,
         "react-native/no-inline-styles": 0,

--- a/src/components/MessageActions/MessageActionsBox.tsx
+++ b/src/components/MessageActions/MessageActionsBox.tsx
@@ -46,6 +46,7 @@ const UnMemoizedMessageActionsBox = React.forwardRef(
       handleMute,
       handlePin,
       isUserMuted,
+      mine,
       open = false,
       ...restDivProps
     } = props;


### PR DESCRIPTION
### 🎯 Goal

Prevents excessive spread of props onto the MessageActionsBox div, and fixes https://github.com/GetStream/stream-chat-react/issues/2269.