### PR TITLE
fix: add aria-expanded attribute to emoji picker and reactions selector

### DIFF
--- a/src/components/Emojis/EmojiPicker.tsx
+++ b/src/components/Emojis/EmojiPicker.tsx
@@ -100,6 +100,7 @@ export const EmojiPicker = (props: EmojiPickerProps) => {
         </Tooltip>
       )}
       <button
+        aria-expanded={displayPicker}
         aria-label='Emoji picker'
         className={props.buttonClassName ?? buttonClassName}
         onClick={() => setDisplayPicker((cv) => !cv)}

--- a/src/components/Message/MessageOptions.tsx
+++ b/src/components/Message/MessageOptions.tsx
@@ -52,6 +52,7 @@ const UnMemoizedMessageOptions = <
     initialMessage,
     message,
     onReactionListClick,
+    showDetailedReactions,
     threadList,
   } = useMessageContext<StreamChatGenerics>('MessageOptions');
 
@@ -96,6 +97,7 @@ const UnMemoizedMessageOptions = <
       )}
       {shouldShowReactions && (
         <button
+          aria-expanded={showDetailedReactions}
           aria-label='Open Reaction Selector'
           className={`str-chat__message-${theme}__actions__action str-chat__message-${theme}__actions__action--reactions str-chat__message-reactions-button`}
           data-testid='message-reaction-action'


### PR DESCRIPTION
### 🎯 Goal

This fixes an accessibility issue with the `EmojiPicker` and reactions selector: their respective tigger buttons should have `aria-expanded` attribute, as per the [Menu Button ARIA pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/).

### 🎨 UI Changes

No visible changes.
