### PR TITLE
chore: enable nested-interactive axe rule

### DIFF
--- a/axe-helper.js
+++ b/axe-helper.js
@@ -1,7 +1,4 @@
 /* eslint-disable no-undef */
 const { configureAxe } = require('jest-axe');
 
-module.exports.axe = configureAxe({
-  // FIXME: this is a temporary measure, the SDK needs fixing
-  rules: { 'nested-interactive': { enabled: false } },
-});
+module.exports.axe = configureAxe();


### PR DESCRIPTION
We had `nested-interactive` rule disabled in axe, but that doesn't seems necessary anymore.