### PR TITLE
fix: fix: mark channel read on scroll to bottom of the main message list

### DIFF
--- a/docusaurus/docs/React/components/core-components/message-list.mdx
+++ b/docusaurus/docs/React/components/core-components/message-list.mdx
@@ -459,14 +459,6 @@ Function called when more messages are to be loaded, provide your own function t
 | -------- | ---------------------------------------------------------------------------------------- |
 | function | [ChannelActionContextValue['loadMore']](../contexts/channel-action-context.mdx#loadmore) |
 
-### markReadOnScrolledToBottom
-
-When enabled, the channel will be marked read when a user scrolls to the bottom. Ignored when scrolled to the bottom of a thread message list.
-
-| Type    | Default |
-|---------|---------|
-| boolean | false   |
-
 ### Message
 
 Custom UI component to display an individual message.
@@ -622,6 +614,15 @@ channel, the `MessageNotification` component displays when new messages arrive.
 | Type   | Default |
 | ------ | ------- |
 | number | 200     |
+
+### showUnreadNotificationAlways
+
+The floating notification informing about unread messages will be shown when the `UnreadMessagesSeparator` is not visible. The default is false, that means the notification
+is shown only when viewing unread messages.
+
+| Type    | Default |
+|---------|---------|
+| boolean | false   |
 
 ### threadList
 

--- a/docusaurus/docs/React/components/core-components/virtualized-list.mdx
+++ b/docusaurus/docs/React/components/core-components/virtualized-list.mdx
@@ -174,14 +174,6 @@ Function called when more messages are to be loaded, provide your own function t
 | -------- | ---------------------------------------------------------------------------------------- |
 | function | [ChannelActionContextValue['loadMore']](../contexts/channel-action-context.mdx#loadmore) |
 
-### markReadOnScrolledToBottom
-
-When enabled, the channel will be marked read when a user scrolls to the bottom. Ignored when scrolled to the bottom of a thread message list.
-
-| Type    | Default |
-|---------|---------|
-| boolean | false   |
-
 ### Message
 
 Custom UI component to display an individual message.
@@ -252,6 +244,15 @@ If true, the Giphy preview will render as a separate component above the `Messag
 
 | Type    | Default |
 | ------- | ------- |
+| boolean | false   |
+
+### showUnreadNotificationAlways
+
+The floating notification informing about unread messages will be shown when the `UnreadMessagesSeparator` is not visible. The default is false, that means the notification
+is shown only when viewing unread messages.
+
+| Type    | Default |
+|---------|---------|
 | boolean | false   |
 
 ### stickToBottomScrollBehavior

--- a/docusaurus/docs/React/guides/channel-read-state.mdx
+++ b/docusaurus/docs/React/guides/channel-read-state.mdx
@@ -9,7 +9,9 @@ This guide intends to provide an overview how channel read state is handled by d
 
 ## The model
 
-The React SDK maintains channel read state for UI components inside `Channel` component in a separate variable `channelUnreadUiState`. Channel read state reflecting the back-end state, can be accessed via `channel.state.read` mapping.
+The React SDK maintains channel read state for UI components inside `Channel` component in a separate variable `channelUnreadUiState`. This state is dedicated to show unread count on components `UnreadMessagesSeparator` and `UnreadMessagesNotification` (or other custom components that need its behavior). The `channelUnreadUiState` is special in that when a channel is opened and marked read, the `channelUnreadUiState` does not reflect this initial update. This is in order the user can see, how many unread messages there have been left since the previous session.
+
+Channel read state reflecting the current back-end state can be accessed via `channel.state.read` mapping.
 
 ### Channel UI unread state
 
@@ -25,7 +27,7 @@ The state is maintained by `Channel` component and shared with its children via 
 
 ### Channel read state for all users
 
-The read state is extracted from the channel query response, specifically from each `ChannelResponse` object's `read` attribute This is internally transformed from an array of users' read statuses into and object indexed by user id. The read state is updated upon receiving WS events like `message.read`, `notification.mark_unread`. Each value of the `read` state object has then the following structure:
+The read state is extracted from the channel query response, specifically from each `ChannelResponse` object's `read` attribute. This is internally transformed from an array of users' read statuses into and object indexed by user id. The read state is updated upon receiving WS events like `message.read`, `notification.mark_unread`, `message.new`. Each value of the `read` state object has then the following structure:
 
 | Property                    | Type                    | Description                                                                                                                                                                                                                                  |
 |-----------------------------|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -34,6 +36,10 @@ The read state is extracted from the channel query response, specifically from e
 | **user**                    | `user`                  | Data of a user, whose read state is described in this object. The value is provided with `ChannelResponse` when querying channels or on `notification.mark_unread` event.                                                                    |
 | **first_unread_message_id** | `string` or `undefined` | The ID of the message that was marked unread (`notification.mark_unread` event). The value is available only when a message is marked unread. Therefore, cannot be relied on to place unread messages UI.                                    |
 | **last_read_message_id**    | `string` or `undefined` | The ID of the message preceding the first unread message. The value is provided with `ChannelResponse` when querying channels or on `notification.mark_unread` event.                                                                        |
+
+:::note
+Be aware that only the last 100 newest messages can be marked unread. If older messages are marked unread, an error notification is shown informing about this limitation.
+:::
 
 ### Access the read state
 
@@ -78,7 +84,6 @@ The function accepts a single `options` parameter of the following format:
 | Field                  | Type      | Optional | Description                                                                                                                                                                                                                                                                                                                 |
 |------------------------|-----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `updateChannelUiUnreadState` | `boolean` | yes      | Signal, whether the `channelUnreadUiState` should be updated. The local state update is prevented when the Channel component is mounted. This is in order to keep the UI indicating the original unread state, when the user opens a channel. If the value for `updateChannelUiUnreadState` is not provided, the state is updated. |
-|
 
 :::important
 Please, prefer using the `markRead()` function everywhere in the `Channel` context as this function throttles the API calls thus preventing you from hitting the API limit of mark-read calls.
@@ -91,7 +96,7 @@ The default components included in **marking a channel read**:
 | Component                                                                                                                                     | Description                                                                                                                                                                                    |
 |-----------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [`Channel`](../../components/core-components/channel)                                                                                         | Can be configured to mark active channel read when mounted. This can be done through its prop `markReadOnMount`. By default disabled.                                                          |
-| [`MessageList`](../../components/core-components/message_list), [`VirtualizedMessageList`](../../components/core-components/virtualized_list) | Can be configured to mark channel read when message list is scrolled to the bottom. This can be done through the list's prop `markReadOnScrolledToBottom`. By default disabled.                |
+| [`MessageList`](../../components/core-components/message_list), [`VirtualizedMessageList`](../../components/core-components/virtualized_list) | Marks channel read when message list is scrolled to the bottom.               |
 | [`UnreadMessagesNotification`](../../components/contexts/component_context#unreadmessagesnotification)                                        | Floating notification rendered in the message list. Contains a button, which when clicked, marks the channel read.                                                                             |
 
 The default components included in **marking a channel unread**:
@@ -118,13 +123,16 @@ Message threads do not participate in handling read state of a channel. Thread r
 The channel is marked read in the following scenarios:
 
 1. User enters a channel with unread messages if `Channel` prop `markReadOnMount` is enabled (default behavior).
-2. User clicks the button on the default `UnreadMessagesNotification` component to mark channel read.
+2. User scrolls up and back down to the latest message.
+3. User clicks the button on the default `UnreadMessagesNotification` component to mark channel read.
 
 The channel is marked unread in the following scenarios:
 
 1. User with `read-events` permission selects `Mark as unread` option from the `MessageActionsBox`.
 
-The component `UnreadMessagesSeparator` is shown immediately below the last read message. It can be followed by own message or a message posted by another user. It does not show unread count if among the unread messages are only own messages (own message can be marked unread).
+The component `UnreadMessagesSeparator` is shown immediately below the last read message. It can be followed by own message or a message posted by another user. It does not show unread count if:
+- `showCount` prop is enabled and among the unread messages are only own messages (own message can be marked unread).
+- `showCount` prop is disabled (default)
 
 ## Channel read state handling customization
 
@@ -132,12 +140,9 @@ The component `UnreadMessagesSeparator` is shown immediately below the last read
 
 There is a possibility to configure when a channel is marked read by tweaking these default components' props:
 
-| Component                                                                                                                                     | Prop                                                |
-|-----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
-| [`Channel`](../../components/core-components/channel)                                                                                         | `markReadOnMount` (by default disabled)             |
-| [`MessageList`](../../components/core-components/message_list), [`VirtualizedMessageList`](../../components/core-components/virtualized_list) | `markReadOnScrolledToBottom` (by default disabled)  |
-
-And so instead of marking a channel read on `Channel` component mount, the channel can be marked read when scrolled to the bottom.
+| Component                                             | Prop                                   |
+|-------------------------------------------------------|----------------------------------------|
+| [`Channel`](../../components/core-components/channel) | `markReadOnMount` (by default enabled) |
 
 ### Customization through custom components
 
@@ -163,9 +168,26 @@ const Component = ({children}) => (
 );
 ```
 
+The component can be configured through the following props:
+
+| Prop                | Description                                                                                           | Type      | Default |
+|---------------------|-------------------------------------------------------------------------------------------------------|-----------|---------|
+| `showCount`         | Configuration parameter to determine, whether the unread count is to be shown on the component.       | `boolean` | `false` |
+
+```tsx
+import {
+    UnreadMessagesSeparator as StreamUnreadMessagesSeparator,
+    UnreadMessagesSeparatorProps,
+} from 'stream-chat-react';
+
+const UnreadMessagesSeparator = (props: UnreadMessagesSeparatorProps) => {
+    return <StreamUnreadMessagesSeparator {...props} showCount />
+}
+```
+
 #### Custom `UnreadMessagesNotification` component
 
-Will be rendered only when being scrolled to unread messages in a message list. The default implementation positions the notification as a floating element above the messages in a message list.
+Will be rendered only when `UnreadMessagesSeparator` is not visible in message list. The default implementation positions the notification as a floating element above the messages in a message list. It shows the number of unread messages since the user has scrolled away from the latest message (bottom of the message list).
 
 ```tsx
 import {
@@ -183,9 +205,30 @@ const Component = ({children}) => (
 );
 ```
 
+The component can be configured through the following props:
+
+| Prop                | Description                                                                                           | Type      | Default |
+|---------------------|-------------------------------------------------------------------------------------------------------|-----------|---------|
+| `showCount`         | Configuration parameter to determine, whether the unread count is to be shown on the component.       | `boolean` | `false` |
+| `queryMessageLimit` | Configuration parameter to determine the message page size, when jumping to the first unread message. | `number`  | `100`   |
+
+
+```tsx
+import {
+    UnreadMessagesNotification as StreamUnreadMessagesNotification,
+    UnreadMessagesNotificationProps,
+} from 'stream-chat-react';
+
+const UnreadMessagesNotification = (props: UnreadMessagesNotificationProps) => {
+    return <StreamUnreadMessagesNotification {...props} queryMessageLimit={50} showCount />
+}
+```
+
 #### Custom `MessageNotification` component
 
-The SDK exports [`ScrollToBottomButton`](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageList/ScrollToBottomButton.tsx) that shows the unread count and is rendered only when scrolled away from the bottom of the message list. We can however implement our own message notification component.
+The SDK exports [`ScrollToBottomButton`](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageList/ScrollToBottomButton.tsx) that shows the unread count since the point the user has scrolled away from the newest messages in the list.
+
+We can implement our own message notification component.
 
 ```tsx
 import {
@@ -208,7 +251,7 @@ const Component = ({children}) => (
 
 ### Default SDK component to jump to the first unread message
 
-The SDK provides a component `UnreadMessagesNotification`, that when clicked on the part `X Unread messages`, the message list scrolls to the first unread message. If the first unread message is not loaded in the local channel state, the message is retrieved from the API.
+The SDK provides a component `UnreadMessagesNotification`, that when clicked on the part `Unread messages`, the message list scrolls to the first unread message. If the first unread message is not loaded in the local channel state, the message is retrieved from the API.
 
 
 ### API to jump to the first unread message

--- a/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/src/components/ChannelPreview/ChannelPreview.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import throttle from 'lodash.throttle';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { ChannelPreviewMessenger } from './ChannelPreviewMessenger';
 import { useIsChannelMuted } from './hooks/useIsChannelMuted';
@@ -107,13 +108,17 @@ export const ChannelPreview = <
     };
   }, [channel, client]);
 
-  const refreshUnreadCount = useCallback(() => {
-    if (muted) {
-      setUnread(0);
-    } else {
-      setUnread(channel.countUnread());
-    }
-  }, [channel, muted]);
+  const refreshUnreadCount = useMemo(
+    () =>
+      throttle(() => {
+        if (muted) {
+          setUnread(0);
+        } else {
+          setUnread(channel.countUnread());
+        }
+      }, 400),
+    [channel, muted],
+  );
 
   useEffect(() => {
     refreshUnreadCount();

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -67,12 +67,12 @@ const MessageListWithContext = <
     unsafeHTML = false,
     headerPosition,
     read,
-    markReadOnScrolledToBottom,
     renderMessages = defaultRenderMessages,
     messageLimit = 100,
     loadMore: loadMoreCallback,
     loadMoreNewer: loadMoreNewerCallback,
     hasMoreNewer = false,
+    showUnreadNotificationAlways = true,
     suppressAutoscroll,
     highlightedMessageId,
     jumpToLatestMessage = () => Promise.resolve(),
@@ -111,14 +111,15 @@ const MessageListWithContext = <
 
   const { show: showUnreadMessagesNotification } = useUnreadMessagesNotification({
     isMessageListScrolledToBottom,
+    showAlways: showUnreadNotificationAlways,
     unreadCount: channelUnreadUiState?.unread_messages,
   });
 
   useMarkRead({
     isMessageListScrolledToBottom,
-    markReadOnScrolledToBottom,
     messageListIsThread: threadList,
     unreadCount: channelUnreadUiState?.unread_messages ?? 0,
+    wasMarkedUnread: !!channelUnreadUiState?.first_unread_message_id,
   });
 
   const { messageGroupStyles, messages: enrichedMessages } = useEnrichedMessages({
@@ -326,8 +327,6 @@ export type MessageListProps<
   loadMore?: ChannelActionContextValue['loadMore'] | (() => Promise<void>);
   /** Function called when newer messages are to be loaded, defaults to function stored in [ChannelActionContext](https://getstream.io/chat/docs/sdk/react/contexts/channel_action_context/) */
   loadMoreNewer?: ChannelActionContextValue['loadMoreNewer'] | (() => Promise<void>);
-  /** When enabled, the channel will be marked read when a user scrolls to the bottom. Ignored when scrolled to the bottom of a thread message list. */
-  markReadOnScrolledToBottom?: boolean;
   /** The limit to use when paginating messages */
   messageLimit?: number;
   /** The messages to render in the list, defaults to messages stored in [ChannelStateContext](https://getstream.io/chat/docs/sdk/react/contexts/channel_state_context/) */
@@ -344,6 +343,12 @@ export type MessageListProps<
    * Defaults to 200px
    */
   scrolledUpThreshold?: number;
+  /**
+   * The floating notification informing about unread messages will be shown when the
+   * UnreadMessagesSeparator is not visible. The default is false, that means the notification
+   * is shown only when viewing unread messages.
+   */
+  showUnreadNotificationAlways?: boolean;
   /** If true, indicates the message list is a thread  */
   threadList?: boolean; // todo: refactor needed - message list should have a state in which among others it would be optionally flagged as thread
 };

--- a/src/components/MessageList/ScrollToBottomButton.tsx
+++ b/src/components/MessageList/ScrollToBottomButton.tsx
@@ -1,17 +1,65 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import clsx from 'clsx';
 
 import { ArrowDown } from './icons';
 
+import { useChannelStateContext, useChatContext } from '../../context';
+
+import type { Event } from 'stream-chat';
 import type { MessageNotificationProps } from './MessageNotification';
 
 const UnMemoizedScrollToBottomButton = (
-  props: Pick<
-    MessageNotificationProps,
-    'isMessageListScrolledToBottom' | 'onClick' | 'threadList' | 'unreadCount'
-  >,
+  props: Pick<MessageNotificationProps, 'isMessageListScrolledToBottom' | 'onClick' | 'threadList'>,
 ) => {
-  const { isMessageListScrolledToBottom, onClick, unreadCount = 0 } = props;
+  const { isMessageListScrolledToBottom, onClick, threadList } = props;
+
+  const { channel: activeChannel, client } = useChatContext();
+  const { thread } = useChannelStateContext();
+  const [countUnread, setCountUnread] = useState(activeChannel?.countUnread() || 0);
+  const [replyCount, setReplyCount] = useState(thread?.reply_count || 0);
+  const observedEvent = threadList ? 'message.updated' : 'message.new';
+
+  useEffect(() => {
+    const handleEvent = (event: Event) => {
+      const newMessageInAnotherChannel = event.cid !== activeChannel?.cid;
+      const newMessageIsMine = event.user?.id === client.user?.id;
+
+      const isThreadOpen = !!thread;
+      const newMessageIsReply = !!event.message?.parent_id;
+      const dontIncreaseMainListCounterOnNewReply =
+        isThreadOpen && !threadList && newMessageIsReply;
+
+      if (
+        isMessageListScrolledToBottom ||
+        newMessageInAnotherChannel ||
+        newMessageIsMine ||
+        dontIncreaseMainListCounterOnNewReply
+      ) {
+        return;
+      }
+
+      if (event.type === 'message.new') {
+        // cannot rely on channel.countUnread because active channel is automatically marked read
+        setCountUnread((prev) => prev + 1);
+      } else if (event.message?.id === thread?.id) {
+        const newReplyCount = event.message?.reply_count || 0;
+        setCountUnread(() => newReplyCount - replyCount);
+      }
+    };
+    client.on(observedEvent, handleEvent);
+
+    return () => {
+      client.off(observedEvent, handleEvent);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeChannel, isMessageListScrolledToBottom, observedEvent, replyCount, thread]);
+
+  useEffect(() => {
+    if (isMessageListScrolledToBottom) {
+      setCountUnread(0);
+      setReplyCount(thread?.reply_count || 0);
+    }
+  }, [isMessageListScrolledToBottom, thread]);
 
   if (isMessageListScrolledToBottom) return null;
 
@@ -28,7 +76,7 @@ const UnMemoizedScrollToBottomButton = (
         onClick={onClick}
       >
         <ArrowDown />
-        {unreadCount > 0 && (
+        {countUnread > 0 && (
           <div
             className={clsx(
               'str-chat__message-notification',
@@ -37,7 +85,7 @@ const UnMemoizedScrollToBottomButton = (
             )}
             data-testid={'unread-message-notification-counter'}
           >
-            {unreadCount}
+            {countUnread}
           </div>
         )}
       </button>

--- a/src/components/MessageList/UnreadMessagesNotification.tsx
+++ b/src/components/MessageList/UnreadMessagesNotification.tsx
@@ -3,12 +3,23 @@ import { CloseIcon } from './icons';
 import { useChannelActionContext, useTranslationContext } from '../../context';
 
 export type UnreadMessagesNotificationProps = {
+  /**
+   * Configuration parameter to determine the message page size, when jumping to the first unread message.
+   */
   queryMessageLimit?: number;
+  /**
+   * Configuration parameter to determine, whether the unread count is to be shown on the component. Disabled by default.
+   */
+  showCount?: boolean;
+  /**
+   * The count of unread messages to be displayed if enabled.
+   */
   unreadCount?: number;
 };
 
 export const UnreadMessagesNotification = ({
   queryMessageLimit,
+  showCount,
   unreadCount,
 }: UnreadMessagesNotificationProps) => {
   const { jumpToFirstUnreadMessage, markRead } = useChannelActionContext(
@@ -22,7 +33,9 @@ export const UnreadMessagesNotification = ({
       data-testid='unread-messages-notification'
     >
       <button onClick={() => jumpToFirstUnreadMessage(queryMessageLimit)}>
-        {t<string>('{{count}} unread', { count: unreadCount ?? 0 })}
+        {unreadCount && showCount
+          ? t<string>('{{count}} unread', { count: unreadCount ?? 0 })
+          : t<string>('Unread messages')}
       </button>
       <button onClick={() => markRead()}>
         <CloseIcon />

--- a/src/components/MessageList/UnreadMessagesSeparator.tsx
+++ b/src/components/MessageList/UnreadMessagesSeparator.tsx
@@ -4,14 +4,24 @@ import { useTranslationContext } from '../../context';
 export const UNREAD_MESSAGE_SEPARATOR_CLASS = 'str-chat__unread-messages-separator';
 
 export type UnreadMessagesSeparatorProps = {
+  /**
+   * Configuration parameter to determine, whether the unread count is to be shown on the component. Disabled by default.
+   */
+  showCount?: boolean;
+  /**
+   * The count of unread messages to be displayed if enabled.
+   */
   unreadCount?: number;
 };
 
-export const UnreadMessagesSeparator = ({ unreadCount }: UnreadMessagesSeparatorProps) => {
+export const UnreadMessagesSeparator = ({
+  showCount,
+  unreadCount,
+}: UnreadMessagesSeparatorProps) => {
   const { t } = useTranslationContext('UnreadMessagesSeparator');
   return (
     <div className={UNREAD_MESSAGE_SEPARATOR_CLASS} data-testid='unread-messages-separator'>
-      {unreadCount
+      {unreadCount && showCount
         ? t<string>('unreadMessagesSeparatorText', { count: unreadCount })
         : t<string>('Unread messages')}
     </div>

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -180,7 +180,6 @@ const VirtualizedMessageListWithContext = <
     loadingMore,
     loadMore,
     loadMoreNewer,
-    markReadOnScrolledToBottom,
     Message: MessageUIComponentFromProps,
     messageActions,
     messageLimit = 100,
@@ -194,6 +193,7 @@ const VirtualizedMessageListWithContext = <
     scrollToLatestMessageOnFocus = false,
     separateGiphyPreview = false,
     shouldGroupByUser = false,
+    showUnreadNotificationAlways = true,
     stickToBottomScrollBehavior = 'smooth',
     suppressAutoscroll,
     threadList,
@@ -231,6 +231,7 @@ const VirtualizedMessageListWithContext = <
     toggleShowUnreadMessagesNotification,
   } = useUnreadMessagesNotificationVirtualized({
     lastRead: channelUnreadUiState?.last_read,
+    showAlways: showUnreadNotificationAlways,
     unreadCount: channelUnreadUiState?.unread_messages ?? 0,
   });
 
@@ -312,9 +313,9 @@ const VirtualizedMessageListWithContext = <
 
   useMarkRead({
     isMessageListScrolledToBottom,
-    markReadOnScrolledToBottom,
     messageListIsThread: !!threadList,
     unreadCount: channelUnreadUiState?.unread_messages ?? 0,
+    wasMarkedUnread: !!channelUnreadUiState?.first_unread_message_id,
   });
 
   const scrollToBottom = useCallback(async () => {
@@ -536,8 +537,6 @@ export type VirtualizedMessageListProps<
   loadMore?: ChannelActionContextValue['loadMore'] | (() => Promise<void>);
   /** Function called when new messages are to be loaded, defaults to function stored in [ChannelActionContext](https://getstream.io/chat/docs/sdk/react/contexts/channel_action_context/) */
   loadMoreNewer?: ChannelActionContextValue['loadMore'] | (() => Promise<void>);
-  /** When enabled, the channel will be marked read when a user scrolls to the bottom. Ignored when scrolled to the bottom of a thread message list. */
-  markReadOnScrolledToBottom?: boolean;
   /** Custom UI component to display a message, defaults to and accepts same props as [MessageSimple](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message/MessageSimple.tsx) */
   Message?: React.ComponentType<MessageUIComponentProps<StreamChatGenerics>>;
   /** The limit to use when paginating messages */
@@ -573,6 +572,12 @@ export type VirtualizedMessageListProps<
   separateGiphyPreview?: boolean;
   /** If true, group messages belonging to the same user, otherwise show each message individually */
   shouldGroupByUser?: boolean;
+  /**
+   * The floating notification informing about unread messages will be shown when the
+   * UnreadMessagesSeparator is not visible. The default is false, that means the notification
+   * is shown only when viewing unread messages.
+   */
+  showUnreadNotificationAlways?: boolean;
   /** The scrollTo behavior when new messages appear. Use `"smooth"` for regular chat channels, and `"auto"` (which results in instant scroll to bottom) if you expect high throughput. */
   stickToBottomScrollBehavior?: 'smooth' | 'auto';
   /** stops the list from autoscrolling when new messages are loaded */

--- a/src/components/MessageList/__tests__/ScrollToBottomButton.test.js
+++ b/src/components/MessageList/__tests__/ScrollToBottomButton.test.js
@@ -4,24 +4,52 @@ import '@testing-library/jest-dom';
 
 import { ScrollToBottomButton } from '../ScrollToBottomButton';
 import { ChannelStateProvider, ChatProvider } from '../../../context';
-import { createClientWithChannel } from '../../../mock-builders';
+import {
+  createClientWithChannel,
+  dispatchMessageNewEvent,
+  dispatchMessageUpdatedEvent,
+  generateMessage,
+} from '../../../mock-builders';
 
 const BUTTON_TEST_ID = 'message-notification';
 const NEW_MESSAGE_COUNTER_TEST_ID = 'unread-message-notification-counter';
 
+const mainList = 'the main message list';
+const threadList = 'a thread';
+
 let client;
 let channel;
+let users;
 let containerIsThread;
+let anotherUser;
 let channelStateContext;
 let parentMsg;
 
 const onClick = jest.fn();
 
-describe('ScrollToBottomButton', () => {
+const dispatchMessageEvents = ({ channel, client, newMessage, parentMsg, user }) => {
+  if (containerIsThread) {
+    dispatchMessageUpdatedEvent(
+      client,
+      { ...parentMsg, reply_count: parentMsg.reply_count + 1 },
+      channel,
+      user,
+    );
+  }
+  dispatchMessageNewEvent(client, newMessage, channel);
+};
+
+describe.each([
+  [mainList, threadList],
+  [threadList, mainList],
+])('ScrollToBottomButton in %s', (containerMsgList, otherMsgList) => {
   beforeEach(async () => {
     const result = await createClientWithChannel();
     client = result.client;
     channel = result.channel;
+    users = result.users;
+    containerIsThread = containerMsgList === threadList;
+    anotherUser = Object.values(channel.state.members).find((u) => u.id !== client.user.id);
     parentMsg = { ...Object.values(channel.state.messages)[0], reply_count: 0 };
     channelStateContext = {
       thread: containerIsThread ? parentMsg : null,
@@ -30,7 +58,7 @@ describe('ScrollToBottomButton', () => {
 
   afterEach(jest.clearAllMocks);
 
-  it(`is not rendered if the container is scrolled to the bottom`, () => {
+  it(`is not rendered if ${containerMsgList} scrolled to the bottom`, () => {
     const { container } = render(
       <ChatProvider value={{ channel, client }}>
         <ChannelStateProvider value={channelStateContext}>
@@ -71,8 +99,35 @@ describe('ScrollToBottomButton', () => {
     });
   });
 
-  it('reflects the unread count from props', async () => {
-    const { rerender } = render(
+  it('does not increase the unread count if already scrolled at the bottom', async () => {
+    const newMessage = generateMessage({ user: anotherUser });
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      dispatchMessageEvents({
+        channel,
+        client,
+        newMessage,
+        parentMsg,
+        user: anotherUser,
+      });
+    });
+
+    await waitFor(() => {
+      const counter = screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID);
+      expect(counter).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows the count unread if new message arrives to active channel from another user', async () => {
+    const newMessage = generateMessage({ user: anotherUser });
+    render(
       <ChatProvider value={{ channel, client }}>
         <ChannelStateProvider value={channelStateContext}>
           <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
@@ -80,25 +135,168 @@ describe('ScrollToBottomButton', () => {
       </ChatProvider>,
     );
 
-    expect(screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID)).not.toBeInTheDocument();
-
-    const unreadCount = 2;
-    rerender(
-      <ChatProvider value={{ channel, client }}>
-        <ChannelStateProvider value={channelStateContext}>
-          <ScrollToBottomButton
-            isMessageListScrolledToBottom={false}
-            onClick={onClick}
-            unreadCount={unreadCount}
-          />
-        </ChannelStateProvider>
-      </ChatProvider>,
-    );
+    await act(() => {
+      dispatchMessageEvents({
+        channel,
+        client,
+        newMessage,
+        parentMsg,
+        user: anotherUser,
+      });
+    });
 
     await waitFor(() => {
       const counter = screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID);
       expect(counter).toBeInTheDocument();
-      expect(counter).toHaveTextContent(unreadCount);
+      expect(counter).toHaveTextContent('1');
+    });
+  });
+
+  it('does not show unread count for own arriving messages', async () => {
+    const newMessage = generateMessage({ user: client.user });
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      dispatchMessageEvents({
+        channel,
+        client,
+        newMessage,
+        parentMsg,
+        user: client.user,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID)).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show unread count for messages from others arriving to non-active channel', async () => {
+    const newMessage = generateMessage({ user: anotherUser });
+    const { channel: nonActiveChannel } = await createClientWithChannel({
+      existingClient: client,
+      existingUsers: users,
+    });
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      dispatchMessageEvents({
+        channel: nonActiveChannel,
+        client,
+        newMessage,
+        parentMsg,
+        user: anotherUser,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID)).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show unread count for messages arriving from me to non-active channel', async () => {
+    const newMessage = generateMessage({ user: client.user });
+    const { channel: nonActiveChannel } = await createClientWithChannel({
+      existingClient: client,
+      existingUsers: users,
+    });
+
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      dispatchMessageEvents({
+        channel: nonActiveChannel,
+        client,
+        newMessage,
+        parentMsg,
+        user: client.user,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID)).not.toBeInTheDocument();
+    });
+  });
+
+  it('increases the count unread with each new message arrival', async () => {
+    render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    for (let i = 1; i <= 2; i++) {
+      const newMessage = generateMessage({ user: anotherUser });
+      await act(() => {
+        dispatchMessageEvents({ channel, client, newMessage, parentMsg, user: anotherUser });
+      });
+      const counter = screen.queryByTestId(NEW_MESSAGE_COUNTER_TEST_ID);
+      await waitFor(() => {
+        expect(counter).toHaveTextContent(i.toString());
+      });
+    }
+  });
+
+  it(`does not show the count unread of ${containerMsgList} in ${otherMsgList}`, async () => {
+    const [mainListId, threadListId] = ['main-msg-list', 'thread-msg-list'];
+    const [mainListCounterSelector, threadListCounterSelector] = [
+      `#${mainListId} [data-testid="${NEW_MESSAGE_COUNTER_TEST_ID}"]`,
+      `#${threadListId} [data-testid="${NEW_MESSAGE_COUNTER_TEST_ID}"]`,
+    ];
+
+    const messagePayload = containerIsThread
+      ? { parent_id: parentMsg.id, user: anotherUser }
+      : { user: anotherUser };
+    const newMessage = generateMessage(messagePayload);
+
+    const { container } = render(
+      <ChatProvider value={{ channel, client }}>
+        <ChannelStateProvider value={channelStateContext}>
+          <div id={mainListId}>
+            <ScrollToBottomButton isMessageListScrolledToBottom={false} onClick={onClick} />
+          </div>
+          <div id={threadListId}>
+            <ScrollToBottomButton
+              isMessageListScrolledToBottom={false}
+              onClick={onClick}
+              threadList
+            />
+          </div>
+        </ChannelStateProvider>
+      </ChatProvider>,
+    );
+
+    await act(() => {
+      dispatchMessageEvents({ channel, client, newMessage, parentMsg, user: anotherUser });
+    });
+
+    const [containerMsgListCounterSelector, otherMsgListCounterSelector] = containerIsThread
+      ? [threadListCounterSelector, mainListCounterSelector]
+      : [mainListCounterSelector, threadListCounterSelector];
+
+    await waitFor(() => {
+      expect(container.querySelector(containerMsgListCounterSelector)).toBeInTheDocument();
+      expect(container.querySelector(otherMsgListCounterSelector)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/MessageList/__tests__/VirtualizedMessageListComponents.test.js
+++ b/src/components/MessageList/__tests__/VirtualizedMessageListComponents.test.js
@@ -363,7 +363,7 @@ describe('VirtualizedMessageComponents', () => {
                   class="str-chat__unread-messages-separator"
                   data-testid="unread-messages-separator"
                 >
-                  unreadMessagesSeparatorText
+                  Unread messages
                 </div>
               </div>
             </div>

--- a/src/components/MessageList/hooks/__tests__/useMarkRead.test.js
+++ b/src/components/MessageList/hooks/__tests__/useMarkRead.test.js
@@ -1,14 +1,29 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useMarkRead } from '../useMarkRead';
-import { ChannelActionProvider } from '../../../../context';
+import { ChannelActionProvider, ChannelStateProvider, ChatProvider } from '../../../../context';
+import {
+  dispatchMessageNewEvent,
+  generateChannel,
+  generateMessage,
+  generateUser,
+  initClientWithChannels,
+} from '../../../../mock-builders';
+import { act } from 'react-dom/test-utils';
 
 const visibilityChangeScenario = 'visibilitychange event';
 const markRead = jest.fn();
+const setChannelUnreadUiState = jest.fn();
 
-const render = ({ params }) => {
+const render = ({ channel, client, params }) => {
   const wrapper = ({ children }) => (
-    <ChannelActionProvider value={{ markRead }}>{children}</ChannelActionProvider>
+    <ChatProvider value={{ client }}>
+      <ChannelStateProvider value={{ channel }}>
+        <ChannelActionProvider value={{ markRead, setChannelUnreadUiState }}>
+          {children}
+        </ChannelActionProvider>
+      </ChannelStateProvider>
+    </ChatProvider>
   );
   const { result } = renderHook(() => useMarkRead(params), { wrapper });
   return result.current;
@@ -20,13 +35,21 @@ describe('useMarkRead', () => {
     markReadOnScrolledToBottom: true,
     messageListIsThread: false,
     unreadCount: 1,
+    wasMarkedUnread: false,
   };
 
   beforeEach(jest.clearAllMocks);
 
-  describe.each([[visibilityChangeScenario], ['render']])('on %s', (scenario) => {
-    it('should not mark channel read from thread message list', () => {
+  describe.each([[visibilityChangeScenario], ['render'], ['message.new']])('on %s', (scenario) => {
+    it('should not mark channel read from thread message list', async () => {
+      const {
+        channels: [channel],
+        client,
+      } = await initClientWithChannels();
+
       render({
+        channel,
+        client,
         params: {
           ...shouldMarkReadParams,
           messageListIsThread: true,
@@ -34,59 +57,388 @@ describe('useMarkRead', () => {
       });
       if (scenario === visibilityChangeScenario) {
         document.dispatchEvent(new Event('visibilitychange'));
+      } else if (scenario === 'message.new') {
+        await act(() => {
+          dispatchMessageNewEvent(client, generateMessage(), channel);
+        });
+        expect(setChannelUnreadUiState).not.toHaveBeenCalled();
       }
-      expect(markRead).toHaveBeenCalledTimes(0);
+      expect(markRead).not.toHaveBeenCalled();
     });
 
-    it('should not mark channel read from message list not scrolled to the bottom', () => {
-      render({
+    it('should not mark channel read from message list not scrolled to the bottom', async () => {
+      const {
+        channels: [channel],
+        client,
+      } = await initClientWithChannels();
+
+      await render({
+        channel,
+        client,
         params: {
           ...shouldMarkReadParams,
           isMessageListScrolledToBottom: false,
         },
       });
+
       if (scenario === visibilityChangeScenario) {
         document.dispatchEvent(new Event('visibilitychange'));
+      } else if (scenario === 'message.new') {
+        let channelUnreadUiStateCb;
+        setChannelUnreadUiState.mockImplementationOnce((cb) => (channelUnreadUiStateCb = cb));
+        await act(() => {
+          dispatchMessageNewEvent(client, generateMessage(), channel);
+        });
+        expect(setChannelUnreadUiState).toHaveBeenCalledTimes(1);
+        const channelUnreadUiState = channelUnreadUiStateCb();
+        expect(channelUnreadUiState.unread_messages).toBe(1);
       }
-      expect(markRead).toHaveBeenCalledTimes(0);
+      expect(markRead).not.toHaveBeenCalled();
     });
 
-    it('should not mark channel read when markReadOnScrolledToBottom is disabled', () => {
-      render({
-        params: {
-          ...shouldMarkReadParams,
-          markReadOnScrolledToBottom: false,
-        },
-      });
-      if (scenario === visibilityChangeScenario) {
-        document.dispatchEvent(new Event('visibilitychange'));
-      }
-      expect(markRead).toHaveBeenCalledTimes(0);
-    });
+    it('should not mark channel read from message list in channel with 0 unread messages', async () => {
+      const {
+        channels: [channel],
+        client,
+      } = await initClientWithChannels();
 
-    it('should not mark channel read from message list in channel with 0 unread messages', () => {
-      render({
+      const countUnread = jest.spyOn(channel, 'countUnread').mockReturnValueOnce(0);
+
+      await render({
+        channel,
+        client,
         params: {
           ...shouldMarkReadParams,
           unreadCount: 0,
         },
       });
+
       if (scenario === visibilityChangeScenario) {
         document.dispatchEvent(new Event('visibilitychange'));
+      } else if (scenario === 'message.new') {
+        await act(() => {
+          dispatchMessageNewEvent(client, generateMessage(), channel);
+        });
+        expect(setChannelUnreadUiState).not.toHaveBeenCalled();
       }
-      expect(markRead).toHaveBeenCalledTimes(0);
+
+      expect(markRead).not.toHaveBeenCalled();
+      countUnread.mockRestore();
     });
 
-    it('should mark channel read from non-thread message list scrolled to the bottom not previously marked unread', () => {
-      render({
+    it('should not mark channel read from non-thread message list scrolled to the bottom previously marked unread', async () => {
+      const {
+        channels: [channel],
+        client,
+      } = await initClientWithChannels();
+
+      await render({
+        channel,
+        client,
+        params: {
+          shouldMarkReadParams,
+          wasMarkedUnread: true,
+        },
+      });
+      if (scenario === visibilityChangeScenario) {
+        document.dispatchEvent(new Event('visibilitychange'));
+      } else if (scenario === 'message.new') {
+        let channelUnreadUiStateCb;
+        setChannelUnreadUiState.mockImplementationOnce((cb) => (channelUnreadUiStateCb = cb));
+        await act(() => {
+          dispatchMessageNewEvent(client, generateMessage(), channel);
+        });
+        expect(setChannelUnreadUiState).toHaveBeenCalledTimes(1);
+        const channelUnreadUiState = channelUnreadUiStateCb();
+        expect(channelUnreadUiState.unread_messages).toBe(1);
+      }
+
+      expect(markRead).not.toHaveBeenCalled();
+    });
+
+    it('should mark channel read from non-thread message list scrolled to the bottom not previously marked unread', async () => {
+      const {
+        channels: [channel],
+        client,
+      } = await initClientWithChannels();
+
+      await render({
+        channel,
+        client,
         params: shouldMarkReadParams,
       });
       if (scenario === visibilityChangeScenario) {
         document.dispatchEvent(new Event('visibilitychange'));
         expect(markRead).toHaveBeenCalledTimes(2);
+      } else if (scenario === 'message.new') {
+        await act(() => {
+          dispatchMessageNewEvent(client, generateMessage(), channel);
+        });
+        expect(markRead).toHaveBeenCalledTimes(2);
+        expect(setChannelUnreadUiState).not.toHaveBeenCalled();
       } else {
         expect(markRead).toHaveBeenCalledTimes(1);
       }
+    });
+  });
+
+  describe('on message.new', () => {
+    it('should not mark channel read for messages incoming to other channels', async () => {
+      const {
+        channels: [activeChannel, otherChannel],
+        client,
+      } = await initClientWithChannels({ channelsData: [generateChannel(), generateChannel()] });
+
+      await render({
+        channel: activeChannel,
+        client,
+        params: {
+          ...shouldMarkReadParams,
+          unreadCount: 0,
+        },
+      });
+
+      await act(() => {
+        dispatchMessageNewEvent(client, generateMessage(), otherChannel);
+      });
+
+      expect(markRead).not.toHaveBeenCalled();
+      expect(setChannelUnreadUiState).not.toHaveBeenCalled();
+    });
+
+    it('should not mark channel read for own messages', async () => {
+      const user = generateUser();
+      const {
+        channels: [channel],
+        client,
+      } = await initClientWithChannels({
+        customUser: user,
+      });
+
+      await render({
+        channel,
+        client,
+        params: {
+          ...shouldMarkReadParams,
+          unreadCount: 0,
+        },
+      });
+
+      await act(() => {
+        dispatchMessageNewEvent(client, generateMessage({ user }), channel);
+      });
+
+      expect(markRead).not.toHaveBeenCalled();
+      expect(setChannelUnreadUiState).not.toHaveBeenCalled();
+    });
+
+    it('should not mark channel read for thread messages', async () => {
+      const {
+        channels: [channel],
+        client,
+      } = await initClientWithChannels();
+
+      await render({
+        channel,
+        client,
+        params: {
+          ...shouldMarkReadParams,
+          unreadCount: 0,
+        },
+      });
+
+      await act(() => {
+        dispatchMessageNewEvent(client, generateMessage({ parent_id: 'X' }), channel);
+      });
+
+      expect(markRead).not.toHaveBeenCalled();
+      expect(setChannelUnreadUiState).not.toHaveBeenCalled();
+    });
+
+    it('should mark channel read for thread messages with event.show_in_channel enabled', async () => {
+      const {
+        channels: [channel],
+        client,
+      } = await initClientWithChannels();
+
+      await render({
+        channel,
+        client,
+        params: {
+          ...shouldMarkReadParams,
+          unreadCount: 0,
+        },
+      });
+
+      await act(() => {
+        dispatchMessageNewEvent(
+          client,
+          generateMessage({ parent_id: 'X', show_in_channel: true }),
+          channel,
+        );
+      });
+
+      expect(markRead).toHaveBeenCalledTimes(1);
+      expect(setChannelUnreadUiState).not.toHaveBeenCalled();
+    });
+
+    it('should mark channel read for not-own messages when scrolled to bottom in main message list', async () => {
+      const {
+        channels: [channel],
+        client,
+      } = await initClientWithChannels();
+
+      await render({
+        channel,
+        client,
+        params: {
+          ...shouldMarkReadParams,
+          unreadCount: 0,
+        },
+      });
+
+      await act(() => {
+        dispatchMessageNewEvent(client, generateMessage(), channel);
+      });
+
+      expect(markRead).toHaveBeenCalledTimes(1);
+      expect(setChannelUnreadUiState).not.toHaveBeenCalled();
+    });
+
+    describe('update unread UI state unread_messages', () => {
+      it('should be performed when message list is not scrolled to bottom', async () => {
+        let channelUnreadUiStateCb;
+        setChannelUnreadUiState.mockImplementationOnce((cb) => (channelUnreadUiStateCb = cb));
+        const {
+          channels: [channel],
+          client,
+        } = await initClientWithChannels();
+
+        await render({
+          channel,
+          client,
+          params: {
+            ...shouldMarkReadParams,
+            isMessageListScrolledToBottom: false,
+          },
+        });
+
+        await act(() => {
+          dispatchMessageNewEvent(client, generateMessage(), channel);
+        });
+
+        expect(setChannelUnreadUiState).toHaveBeenCalledTimes(1);
+        const channelUnreadUiState = channelUnreadUiStateCb();
+        expect(channelUnreadUiState.unread_messages).toBe(1);
+      });
+
+      it('should be performed when channel was marked unread and is scrolled to the bottom', async () => {
+        let channelUnreadUiStateCb;
+        setChannelUnreadUiState.mockImplementationOnce((cb) => (channelUnreadUiStateCb = cb));
+        const {
+          channels: [channel],
+          client,
+        } = await initClientWithChannels();
+
+        await render({
+          channel,
+          client,
+          params: {
+            ...shouldMarkReadParams,
+            wasMarkedUnread: true,
+          },
+        });
+
+        await act(() => {
+          dispatchMessageNewEvent(client, generateMessage(), channel);
+        });
+
+        expect(setChannelUnreadUiState).toHaveBeenCalledTimes(1);
+        const channelUnreadUiState = channelUnreadUiStateCb();
+        expect(channelUnreadUiState.unread_messages).toBe(1);
+      });
+    });
+
+    describe('update unread UI state last_read', () => {
+      it('should be performed when message list is not scrolled to bottom', async () => {
+        let channelUnreadUiStateCb;
+        setChannelUnreadUiState.mockImplementationOnce((cb) => (channelUnreadUiStateCb = cb));
+        const channelsData = [
+          generateChannel({ messages: Array.from({ length: 2 }, generateMessage) }),
+        ];
+        const {
+          channels: [channel],
+          client,
+        } = await initClientWithChannels({
+          channelsData,
+        });
+
+        await render({
+          channel,
+          client,
+          params: {
+            ...shouldMarkReadParams,
+            isMessageListScrolledToBottom: false,
+          },
+        });
+
+        await act(() => {
+          dispatchMessageNewEvent(client, generateMessage(), channel);
+        });
+
+        const prevLastRead = 'X';
+        let channelUnreadUiState = channelUnreadUiStateCb({ last_read: prevLastRead });
+        expect(channelUnreadUiState.last_read).toBe(prevLastRead);
+        channelUnreadUiState = channelUnreadUiStateCb({ unread_messages: 0 });
+        expect(channelUnreadUiState.last_read.getTime()).toBe(
+          channelsData[0].messages[1].created_at.getTime(),
+        );
+        channelUnreadUiState = channelUnreadUiStateCb();
+        expect(channelUnreadUiState.last_read.getTime()).toBe(
+          channelsData[0].messages[1].created_at.getTime(),
+        );
+        channelUnreadUiState = channelUnreadUiStateCb({ unread_messages: 1 });
+        expect(channelUnreadUiState.last_read.getTime()).toBe(0);
+      });
+
+      it('should be performed when channel was marked unread and is scrolled to the bottom', async () => {
+        let channelUnreadUiStateCb;
+        setChannelUnreadUiState.mockImplementation((cb) => (channelUnreadUiStateCb = cb));
+        const channelsData = [generateChannel({ messages: [generateMessage()] })];
+        const {
+          channels: [channel],
+          client,
+        } = await initClientWithChannels({
+          channelsData,
+        });
+
+        await render({
+          channel,
+          client,
+          params: {
+            ...shouldMarkReadParams,
+            wasMarkedUnread: true,
+          },
+        });
+
+        await act(async () => {
+          await dispatchMessageNewEvent(client, generateMessage(), channel);
+        });
+
+        const prevLastRead = 'X';
+        let channelUnreadUiState = channelUnreadUiStateCb({ last_read: prevLastRead });
+        expect(channelUnreadUiState.last_read).toBe(prevLastRead);
+        channelUnreadUiState = channelUnreadUiStateCb({ unread_messages: 0 });
+        expect(channelUnreadUiState.last_read.getTime()).toBe(
+          channelsData[0].messages[0].created_at.getTime(),
+        );
+        channelUnreadUiState = channelUnreadUiStateCb();
+        expect(channelUnreadUiState.last_read.getTime()).toBe(
+          channelsData[0].messages[0].created_at.getTime(),
+        );
+        channelUnreadUiState = channelUnreadUiStateCb({ unread_messages: 1 });
+        expect(channelUnreadUiState.last_read.getTime()).toBe(0);
+      });
     });
   });
 });

--- a/src/components/MessageList/hooks/__tests__/useUnreadMessagesNotificationVirtualized.test.js
+++ b/src/components/MessageList/hooks/__tests__/useUnreadMessagesNotificationVirtualized.test.js
@@ -21,27 +21,13 @@ describe('useUnreadMessagesNotificationVirtualized', () => {
   });
 
   describe('toggle function', () => {
-    it('should prevent show state change when there no messages to render', async () => {
+    it('should prevent show state change when there are no messages to render', async () => {
       const { rerender, result } = render({ unreadCount: 0 });
       await act(() => {
         result.current.toggleShowUnreadMessagesNotification([]);
       });
       rerender({ lastRead: new Date('1970-1-1'), unreadCount: 1 });
       expect(result.current.show).toBe(false);
-    });
-    it('should show notification if there are unread messages and first rendered message was created later than last read', async () => {
-      const now = new Date();
-      const lastRead = new Date(now - 1000);
-      const firstRenderedMsgCreated = new Date(now - 500);
-      const messages = [
-        generateMessage({ created_at: firstRenderedMsgCreated }),
-        generateMessage({ created_at: now }),
-      ];
-      const { result } = render({ lastRead, unreadCount: 1 });
-      await act(() => {
-        result.current.toggleShowUnreadMessagesNotification(messages);
-      });
-      expect(result.current.show).toBe(true);
     });
 
     it('should not show notification if unread count is 0', async () => {
@@ -52,40 +38,103 @@ describe('useUnreadMessagesNotificationVirtualized', () => {
         generateMessage({ created_at: firstRenderedMsgCreated }),
         generateMessage({ created_at: now }),
       ];
-      const { result } = render({ lastRead, unreadCount: 0 });
+      const { result } = render({ lastRead, showAlways: false, unreadCount: 0 });
       await act(() => {
         result.current.toggleShowUnreadMessagesNotification(messages);
       });
       expect(result.current.show).toBe(false);
     });
 
-    it('should not show notification if the first rendered message was created earlier than last read', async () => {
-      const now = new Date();
-      const lastRead = new Date(now - 1000);
-      const firstRenderedMsgCreated = new Date(now - 1001);
-      const messages = [
-        generateMessage({ created_at: firstRenderedMsgCreated }),
-        generateMessage({ created_at: now }),
-      ];
-      const { result } = render({ lastRead, unreadCount: 1 });
-      await act(() => {
-        result.current.toggleShowUnreadMessagesNotification(messages);
-      });
-      expect(result.current.show).toBe(false);
-    });
+    it.each([[true], [false]])(
+      'should show notification if there are unread messages and first rendered message was created later than last read when showUnreadNotificationAlways is %s',
+      async (showUnreadNotificationAlways) => {
+        const now = new Date();
+        const lastRead = new Date(now - 1000);
+        const firstRenderedMsgCreated = new Date(now - 500);
+        const messages = [
+          generateMessage({ created_at: firstRenderedMsgCreated }),
+          generateMessage({ created_at: now }),
+        ];
+        const { result } = render({
+          lastRead,
+          showAlways: showUnreadNotificationAlways,
+          unreadCount: 1,
+        });
+        await act(() => {
+          result.current.toggleShowUnreadMessagesNotification(messages);
+        });
+        expect(result.current.show).toBe(true);
+      },
+    );
 
-    it('should not show notification if the first rendered message was created equal to last read', async () => {
-      const now = new Date();
-      const lastRead = new Date(now - 1000);
-      const messages = [
-        generateMessage({ created_at: lastRead }),
-        generateMessage({ created_at: now }),
-      ];
-      const { result } = render({ lastRead, unreadCount: 1 });
-      await act(() => {
-        result.current.toggleShowUnreadMessagesNotification(messages);
-      });
-      expect(result.current.show).toBe(false);
-    });
+    it.each([
+      ['should', true],
+      ['should not', false],
+    ])(
+      '%s show notification if the last rendered message was created earlier than last read when showUnreadNotificationAlways is %s',
+      async (_, showUnreadNotificationAlways) => {
+        const now = new Date();
+        const firstRenderedMsgCreated = new Date(now - 1002);
+        const lastRenderedMsgCreated = new Date(now - 1001);
+        const lastRead = new Date(now - 1000);
+        const messages = [
+          generateMessage({ created_at: firstRenderedMsgCreated }),
+          generateMessage({ created_at: lastRenderedMsgCreated }),
+        ];
+        const { result } = render({
+          lastRead,
+          showAlways: showUnreadNotificationAlways,
+          unreadCount: 1,
+        });
+        await act(() => {
+          result.current.toggleShowUnreadMessagesNotification(messages);
+        });
+        expect(result.current.show).toBe(showUnreadNotificationAlways);
+      },
+    );
+
+    it.each([[true], [false]])(
+      'should not show notification if the first rendered message was created earlier than last read when showUnreadNotificationAlways is %s',
+      async (showUnreadNotificationAlways) => {
+        const now = new Date();
+        const firstRenderedMsgCreated = new Date(now - 1002);
+        const lastRead = new Date(now - 1001);
+        const messages = [
+          generateMessage({ created_at: firstRenderedMsgCreated }),
+          generateMessage({ created_at: lastRead }),
+        ];
+        const { result } = render({
+          lastRead,
+          showAlways: showUnreadNotificationAlways,
+          unreadCount: 1,
+        });
+        await act(() => {
+          result.current.toggleShowUnreadMessagesNotification(messages);
+        });
+        expect(result.current.show).toBe(false);
+      },
+    );
+
+    it.each([[true], [false]])(
+      'should not show notification if the last rendered message was created earlier than last read when showUnreadNotificationAlways is %s',
+      async (showUnreadNotificationAlways) => {
+        const now = new Date();
+        const lastRead = new Date(now - 1001);
+        const lastRenderedMsgCreated = new Date(now - 1000);
+        const messages = [
+          generateMessage({ created_at: lastRead }),
+          generateMessage({ created_at: lastRenderedMsgCreated }),
+        ];
+        const { result } = render({
+          lastRead,
+          showAlways: showUnreadNotificationAlways,
+          unreadCount: 1,
+        });
+        await act(() => {
+          result.current.toggleShowUnreadMessagesNotification(messages);
+        });
+        expect(result.current.show).toBe(false);
+      },
+    );
   });
 });

--- a/src/components/MessageList/hooks/useMarkRead.ts
+++ b/src/components/MessageList/hooks/useMarkRead.ts
@@ -1,11 +1,18 @@
-import { useEffect } from 'react';
-import { useChannelActionContext } from '../../../context';
+import { useEffect, useRef } from 'react';
+import {
+  StreamMessage,
+  useChannelActionContext,
+  useChannelStateContext,
+  useChatContext,
+} from '../../../context';
+import { Event, MessageResponse } from 'stream-chat';
+import { DefaultStreamChatGenerics } from '../../../types';
 
 type UseMarkReadParams = {
   isMessageListScrolledToBottom: boolean;
   messageListIsThread: boolean;
   unreadCount: number;
-  markReadOnScrolledToBottom?: boolean;
+  wasMarkedUnread?: boolean;
 };
 
 /**
@@ -18,37 +25,100 @@ type UseMarkReadParams = {
  * @param unreadCount
  * @param wasChannelMarkedUnread
  */
-export const useMarkRead = ({
+export const useMarkRead = <
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>({
   isMessageListScrolledToBottom,
-  markReadOnScrolledToBottom,
   messageListIsThread,
   unreadCount,
+  wasMarkedUnread,
 }: UseMarkReadParams) => {
-  const { markRead } = useChannelActionContext('useMarkRead');
+  const { client } = useChatContext<StreamChatGenerics>('useMarkRead');
+  const { markRead, setChannelUnreadUiState } = useChannelActionContext('useMarkRead');
+  const { channel } = useChannelStateContext('useMarkRead');
+  const previousRenderMessageListScrolledToBottom = useRef(isMessageListScrolledToBottom);
 
   useEffect(() => {
-    const shouldMarkRead =
+    const shouldMarkRead = (unreadMessages: number) =>
+      !document.hidden &&
+      !wasMarkedUnread &&
       !messageListIsThread &&
       isMessageListScrolledToBottom &&
-      markReadOnScrolledToBottom &&
-      unreadCount > 0;
+      unreadMessages > 0;
 
     const onVisibilityChange = () => {
-      if (!document.hidden && shouldMarkRead) markRead();
+      if (shouldMarkRead(unreadCount)) markRead();
     };
 
+    const handleMessageNew = (event: Event<StreamChatGenerics>) => {
+      const newMessageToCurrentChannel = event.cid === channel.cid;
+      const isOwnMessage = event.user?.id && event.user.id === client.user?.id;
+      const mainChannelUpdated = !event.message?.parent_id || event.message?.show_in_channel;
+      if (isOwnMessage) return;
+      if (!isMessageListScrolledToBottom || wasMarkedUnread) {
+        setChannelUnreadUiState((prev) => {
+          const previousUnreadCount = prev?.unread_messages ?? 0;
+          const previousLastMessage = getPreviousLastMessage<StreamChatGenerics>(
+            channel.state.messages,
+            event.message,
+          );
+          return {
+            ...(prev || {}),
+            last_read:
+              prev?.last_read ??
+              (previousUnreadCount === 0 && previousLastMessage?.created_at
+                ? new Date(previousLastMessage.created_at)
+                : new Date(0)), // not having information about the last read message means the whole channel is unread,
+            unread_messages: previousUnreadCount + 1,
+          };
+        });
+      } else if (
+        newMessageToCurrentChannel &&
+        mainChannelUpdated &&
+        !isOwnMessage &&
+        shouldMarkRead(channel.countUnread())
+      ) {
+        markRead();
+      }
+    };
+
+    client.on('message.new', handleMessageNew);
     document.addEventListener('visibilitychange', onVisibilityChange);
 
-    if (shouldMarkRead) markRead();
+    const hasScrolledToBottom =
+      previousRenderMessageListScrolledToBottom.current !== isMessageListScrolledToBottom &&
+      isMessageListScrolledToBottom;
+    if (shouldMarkRead(hasScrolledToBottom ? channel.countUnread() : unreadCount)) markRead();
+    previousRenderMessageListScrolledToBottom.current = isMessageListScrolledToBottom;
 
     return () => {
+      client.off('message.new', handleMessageNew);
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
   }, [
+    channel,
+    client,
     isMessageListScrolledToBottom,
     markRead,
     messageListIsThread,
+    setChannelUnreadUiState,
     unreadCount,
-    markReadOnScrolledToBottom,
+    wasMarkedUnread,
   ]);
 };
+
+function getPreviousLastMessage<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>(messages: StreamMessage<StreamChatGenerics>[], newMessage?: MessageResponse<StreamChatGenerics>) {
+  if (!newMessage) return;
+  let previousLastMessage;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg?.id) break;
+    if (msg.id !== newMessage.id) {
+      previousLastMessage = msg;
+      break;
+    }
+  }
+  return previousLastMessage;
+}

--- a/src/context/ChannelActionContext.tsx
+++ b/src/context/ChannelActionContext.tsx
@@ -17,6 +17,7 @@ import type { ChannelStateReducerAction } from '../components/Channel/channelSta
 import type { CustomMentionHandler } from '../components/Message/hooks/useMentionsHandler';
 
 import type {
+  ChannelUnreadUiState,
   DefaultStreamChatGenerics,
   SendMessageOptions,
   UnknownType,
@@ -87,6 +88,7 @@ export type ChannelActionContextValue<
     customMessageData?: Partial<Message<StreamChatGenerics>>,
     options?: SendMessageOptions,
   ) => Promise<void>;
+  setChannelUnreadUiState: React.Dispatch<React.SetStateAction<ChannelUnreadUiState | undefined>>;
   setQuotedMessage: React.Dispatch<
     React.SetStateAction<StreamMessage<StreamChatGenerics> | undefined>
   >;


### PR DESCRIPTION
### 🎯 Goal

1. Mark channel read when:
  a. `Channel` component is mounted and prop `markReadOnMount` is enabled (default)
  b. Scrolled to the bottom of the main message list or returned back to the bottom of the main message list
  c. Document visibility changed (switch to tab with the chat app) with the main message list scrolled to the bottom
  d. New message (not a thread reply) arrives from another user to the active channel and the message list is scrolled to the bottom

2. Increase the unread count for `UnreadMessagesSeparator`, `UnreadMessagesNotification` when:
  a. user marks channel as unread
  b. a new not own message arrives to a non-active channel
  c. a new not own message arrives to the active channel while being scrolled away from the latest messages
  d. a new not own message arrives to the active channel on an app running on inactive tab while being scrolled to the latest messages
  e. a new not own message arrives to the active channel scrolled to the bottom that was previously marked unread

If an unread channel is opened, it is marked read, but the `UnreadMessagesSeparator`, `UnreadMessagesNotification` are kept mounted with the original unread count (e.g. 5). Then if new messages arrive the unread count is increased from the original unread count (5 + 1 => 6 Unread messages)

3. Increase the unread count in `ScrollToBottomButton` only if the user has scrolled away from the latest messages. The count should take into consideration only newly arrived events `message.new` and not the initial unread count before scrolling up.

4. Throttle unread count updates in `ChannelPreview` to prevent blinking in channels with high message frequencies

5. Make it optional to display unread counts on `UnreadMessagesSeparator`, `UnreadMessagesNotification` by adding new prop `showCount` to them

6. Allow to configure, when `UnreadMessagesNotification` will be displayed through `MessageList` / `VirtualizedMessageList` props `showUnreadNotificationAlways`. By default the notification is visible only when viewing unread messages.

7. Unmount `UnreadMessagesSeparator`, `UnreadMessagesNotification` ever time a message list is scrolled to the bottom and marked read