### PR TITLE
chore: add verbatim type specifier to export from statements

### DIFF
--- a/src/components/Message/renderText/index.ts
+++ b/src/components/Message/renderText/index.ts
@@ -1,4 +1,4 @@
-export { MentionProps } from './componentRenderers';
+export type { MentionProps } from './componentRenderers';
 export { escapeRegExp, matchMarkdownLinks, messageCodeBlocks } from './regex';
 export * from './rehypePlugins';
 export * from './remarkPlugins';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,4 +32,5 @@ export * from './TypingIndicator';
 export * from './UserItem';
 export * from './Window';
 
-export { UploadButton, UploadButtonProps } from './ReactFileUtilities';
+export { UploadButton } from './ReactFileUtilities';
+export type { UploadButtonProps } from './ReactFileUtilities';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,1 @@
-export { DefaultStreamChatGenerics, ChannelUnreadUiState } from './types';
+export type { DefaultStreamChatGenerics, ChannelUnreadUiState } from './types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
     "declaration": true,
     "declarationDir": "./dist",
     "declarationMap": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "isolatedModules": true
   },
   "include": ["./src/**/*"],
   "exclude": ["./src/stories", "./src/mock-builders", "./src/**/__tests__/*"]


### PR DESCRIPTION
### 🎯 Goal

If we want the codebase to be compilable by tools like Vite, that use esbuild under the hood to process files one-by-one, we should follow the rules for isolated typescript modules.

Previously we were breaking the isolated modules rule by doing re-exports like this one:

```ts
export { DefaultStreamChatGenerics, ChannelUnreadUiState } from './types';
```

Where both `DefaultStreamChatGenerics` and `ChannelUnreadUiState` are types. When processing a single file, the compiler doesn't know if these are types or not, and leaves the export statement as is, when really it should be removed.

Fixing this by using verbatim module syntax:

```ts
export type { DefaultStreamChatGenerics, ChannelUnreadUiState } from './types';
```

After fixing all issues, `isolatedModules` was enabled in tsconfig.

A good side-effect of this change is that Ladle (which uses Vite internally) now works again, which is crucial for e2e tests :)