### PR TITLE
fix: await word replace before submitting message

### DIFF
--- a/src/components/AutoCompleteTextarea/Textarea.jsx
+++ b/src/components/AutoCompleteTextarea/Textarea.jsx
@@ -113,14 +113,14 @@ export class ReactTextareaAutocomplete extends React.Component {
     if (event.key === 'Escape') return this._closeAutocomplete();
   };
 
-  _onEnter = (event) => {
+  _onEnter = async (event) => {
     if (!this.textareaRef) return;
 
     const trigger = this.state.currentTrigger;
 
     if (!trigger || !this.state.data) {
       // trigger a submit
-      this._replaceWord();
+      await this._replaceWord();
       if (this.textareaRef) {
         this.textareaRef.selectionEnd = 0;
       }

--- a/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -826,7 +826,7 @@ function axeNoViolations(container) {
           }),
         );
 
-        act(() => fireEvent.keyDown(input, { key: 'Enter' }));
+        await act(() => fireEvent.keyDown(input, { key: 'Enter' }));
 
         expect(submitHandler).toHaveBeenCalledWith(
           expect.objectContaining({


### PR DESCRIPTION
### 🎯 Goal

Fixes a race condition with emoji auto-replacement when submitting a message.

### 🛠 Implementation details

`_replaceWord` is an async method, we should await it before submitting.

### 🎨 UI Changes

Before:

https://github.com/GetStream/stream-chat-react/assets/975978/d989b491-d301-43c0-9386-ffc41f00f4ee

After:

https://github.com/GetStream/stream-chat-react/assets/975978/3fcf49bf-84e2-46cc-92f4-9eafd2f1c2b0

### To-Do

- [ ] Bump SDK in website demo