### PR TITLE
feat: allow EmojiPicker to be closed on emoji click

### DIFF
--- a/src/components/Emojis/EmojiPicker.tsx
+++ b/src/components/Emojis/EmojiPicker.tsx
@@ -19,7 +19,7 @@ export type EmojiPickerProps = {
   buttonClassName?: string;
   pickerContainerClassName?: string;
   wrapperClassName?: string;
-  closeOnEmojiClick?: boolean;
+  closeOnEmojiSelect?: boolean;
   /**
    * Untyped [properties](https://github.com/missive/emoji-mart/tree/v5.5.2#options--props) to be
    * passed to the [emoji-mart `Picker`](https://github.com/missive/emoji-mart/tree/v5.5.2#-picker) component
@@ -90,7 +90,7 @@ export const EmojiPicker = (props: EmojiPickerProps) => {
             onEmojiSelect={(e: { native: string }) => {
               insertText(e.native);
               textareaRef.current?.focus();
-              if (props.closeOnEmojiClick) {
+              if (props.closeOnEmojiSelect) {
                 setDisplayPicker(false);
               }
             }}

--- a/src/components/Emojis/EmojiPicker.tsx
+++ b/src/components/Emojis/EmojiPicker.tsx
@@ -19,6 +19,7 @@ export type EmojiPickerProps = {
   buttonClassName?: string;
   pickerContainerClassName?: string;
   wrapperClassName?: string;
+  closeOnEmojiClick?: boolean;
   /**
    * Untyped [properties](https://github.com/missive/emoji-mart/tree/v5.5.2#options--props) to be
    * passed to the [emoji-mart `Picker`](https://github.com/missive/emoji-mart/tree/v5.5.2#-picker) component
@@ -89,6 +90,9 @@ export const EmojiPicker = (props: EmojiPickerProps) => {
             onEmojiSelect={(e: { native: string }) => {
               insertText(e.native);
               textareaRef.current?.focus();
+              if (props.closeOnEmojiClick) {
+                setDisplayPicker(false);
+              }
             }}
             {...props.pickerProps}
           />


### PR DESCRIPTION
# Submit a pull request

### 🎯 Goal

- Some chat applications that uses the EmojiPicker needs the emoji picker to be closed once an emoji is selected
- The component EmojiPicker allows multiple props available but it doesn't allow to configure this behaviour

### 🛠 Implementation details

- New boolean property `closeOnEmojiSelect` on `EmojiPicker.tsx`
- When the event `onEmojiSelect` is received from `@emoji-mart/react`, the property is checked, unmounting the picker container