### PR TITLE
fix: add missing PinIndicator placeholder

### DIFF
--- a/src/components/Message/MessageSimple.tsx
+++ b/src/components/Message/MessageSimple.tsx
@@ -85,6 +85,7 @@ const MessageSimpleWithContext = <
     MessageTimestamp = DefaultMessageTimestamp,
     ReactionSelector = DefaultReactionSelector,
     ReactionsList = DefaultReactionList,
+    PinIndicator,
   } = useComponentContext<StreamChatGenerics>('MessageSimple');
   const { themeVersion } = useChatContext('MessageSimple');
 
@@ -132,9 +133,9 @@ const MessageSimpleWithContext = <
       : 'str-chat__message--other',
     message.text ? 'str-chat__message--has-text' : 'has-no-text',
     {
-      'pinned-message': message.pinned,
       'str-chat__message--has-attachment': hasAttachment,
       'str-chat__message--highlighted': highlighted,
+      'str-chat__message--pinned pinned-message': message.pinned,
       'str-chat__message--with-reactions str-chat__message-with-thread-link': canShowReactions,
       'str-chat__message-send-can-be-retried':
         message?.status === 'failed' && message?.errorStatusCode !== 403,
@@ -167,6 +168,7 @@ const MessageSimpleWithContext = <
       )}
       {
         <div className={rootClassName} key={message.id}>
+          {PinIndicator && <PinIndicator />}
           {themeVersion === '1' && <MessageStatus />}
           {message.user && (
             <Avatar


### PR DESCRIPTION
### 🎯 Goal

This PR adds missing `PinIndicator` placeholder and `str-chat__message--pinned` class name to a `MessageSimple` component.