### PR TITLE
fix: file size formatting

### DIFF
--- a/src/components/Attachment/__tests__/VoiceRecording.test.js
+++ b/src/components/Attachment/__tests__/VoiceRecording.test.js
@@ -59,7 +59,7 @@ describe('VoiceRecordingPlayer', () => {
 
   it('should fallback to file size, if duration is not available', () => {
     const { getByTestId } = renderComponent({
-      attachment: { ...attachment, duration: undefined, file_size: 60000 },
+      attachment: { ...attachment, duration: undefined, file_size: 60 * 1024 },
     });
     expect(getByTestId('file-size-indicator')).toHaveTextContent('60 kB');
   });
@@ -149,7 +149,7 @@ describe('QuotedVoiceRecording', () => {
   });
   it('should fallback to file size, if duration is not available', () => {
     const { queryByTestId } = renderComponent({
-      attachment: { ...attachment, duration: undefined, file_size: 60000 },
+      attachment: { ...attachment, duration: undefined, file_size: 60 * 1024 },
       isQuoted: true,
     });
     expect(queryByTestId('file-size-indicator')).toHaveTextContent('60 kB');

--- a/src/components/Attachment/__tests__/__snapshots__/File.test.js.snap
+++ b/src/components/Attachment/__tests__/__snapshots__/File.test.js.snap
@@ -32,7 +32,7 @@ exports[`File should render File component in V1 1`] = `
       className="str-chat__message-attachment-file--item-size"
       data-testid="file-size-indicator"
     >
-      1.34 kB
+      1.31 kB
     </span>
   </div>
 </div>
@@ -113,7 +113,7 @@ exports[`File should render File component in V2 1`] = `
       className="str-chat__message-attachment-file--item-size"
       data-testid="file-size-indicator"
     >
-      1.34 kB
+      1.31 kB
     </span>
   </div>
 </div>

--- a/src/components/MessageInput/hooks/utils.ts
+++ b/src/components/MessageInput/hooks/utils.ts
@@ -212,5 +212,7 @@ export function prettifyFileSize(bytes: number, precision = 3) {
   const units = ['B', 'kB', 'MB', 'GB'];
   const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
   const mantissa = bytes / 1024 ** exponent;
-  return `${mantissa.toPrecision(precision)} ${units[exponent]}`;
+  const formattedMantissa =
+    precision === 0 ? Math.round(mantissa).toString() : mantissa.toPrecision(precision);
+  return `${formattedMantissa} ${units[exponent]}`;
 }


### PR DESCRIPTION
Quick fix for some stuff that got broken after removing `pretty-bytes` in #2301:
1. Sizes are now 1024-based (as opposed for 1000-based) to align with backend.
2. Add support for zero-precision,