### PR TITLE
fix: make setChannels prop optional for ChannelSearch

### DIFF
--- a/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -85,7 +85,7 @@ export type ChannelSearchControllerParams<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = ChannelSearchParams<StreamChatGenerics> & {
   /** Set the array of channels displayed in the ChannelList */
-  setChannels: React.Dispatch<React.SetStateAction<Array<Channel<StreamChatGenerics>>>>;
+  setChannels?: React.Dispatch<React.SetStateAction<Array<Channel<StreamChatGenerics>>>>;
 };
 
 export const useChannelSearch = <
@@ -204,7 +204,7 @@ export const useChannelSearch = <
         setActiveChannel(newChannel);
         selectedChannel = newChannel;
       }
-      setChannels((channels) => uniqBy([selectedChannel, ...channels], 'cid'));
+      setChannels?.((channels) => uniqBy([selectedChannel, ...channels], 'cid'));
       if (clearSearchOnClickOutside) {
         exitSearch();
       }


### PR DESCRIPTION
### 🎯 Goal

`setChannels` is used by the `ChannelSearch` component to update the channel list state to include the selected search result. When rendered by the `ChannelList`, it actually passes its own `setChannels` setter there.

But this behavior should be optional, because it's totally valid to use search outside of the `ChannelList`.