### PR TITLE
fix: search results list props

### DIFF
--- a/src/components/ChannelSearch/SearchResults.tsx
+++ b/src/components/ChannelSearch/SearchResults.tsx
@@ -44,9 +44,8 @@ const DefaultSearchResultsHeader = <
 
 export type SearchResultsListProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
-> = Pick<
-  SearchResultsProps<StreamChatGenerics>,
-  'results' | 'SearchResultItem' | 'selectResult'
+> = Required<
+  Pick<SearchResultsProps<StreamChatGenerics>, 'results' | 'SearchResultItem' | 'selectResult'>
 > & {
   focusedUser?: number;
 };
@@ -161,7 +160,7 @@ const ResultsContainer = ({
 export type SearchResultsController<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = {
-  results: Array<ChannelOrUserResponse<StreamChatGenerics>> | [];
+  results: Array<ChannelOrUserResponse<StreamChatGenerics>>;
   searching: boolean;
   selectResult: (result: ChannelOrUserResponse<StreamChatGenerics>) => Promise<void> | void;
 };

--- a/src/components/ChannelSearch/SearchResults.tsx
+++ b/src/components/ChannelSearch/SearchResults.tsx
@@ -55,7 +55,7 @@ const DefaultSearchResultsList = <
 >(
   props: SearchResultsListProps<StreamChatGenerics>,
 ) => {
-  const { focusedUser, results, SearchResultItem = DefaultSearchResultItem, selectResult } = props;
+  const { focusedUser, results, SearchResultItem, selectResult } = props;
 
   return (
     <>


### PR DESCRIPTION
Small fixups for search results list props:

1. `SearchResultItem` is not an optional prop is practice (it's defaulted in the parent component). Having it optional makes it hard to override `SearchResultsList`. (Technically a breaking change, but let's consider it a fix instead.)
2. `| []` is not required 😅 

## Migration

The only place realistically that may require updates is the custom `SearchResultsList` component.

Before:

```tsx
const CustomSearchResultsList = (props: SearchResultsListProps) => {
  const { results, SearchResultItem = DefaultSearchResultItem } = props;
  return /* ... */
};

<ChannelSearch SearchResultsList={CustomSearchResultsList} />
```

After:

```tsx
const CustomSearchResultsList = (props: SearchResultsListProps) => {
                              // 👇 
  const { results, SearchResultItem } = props;
  return /* ... */
};
```

The change is not strictly required, but may cause linter errors otherwise.