### PR TITLE
fix(EmojiPicker): check whether clicked target is child of shadow root node

### DIFF
--- a/src/components/Emojis/EmojiPicker.tsx
+++ b/src/components/Emojis/EmojiPicker.tsx
@@ -14,6 +14,8 @@ import {
 import { EmojiIconLarge, EmojiPickerIcon } from '../MessageInput/icons';
 import { Tooltip } from '../Tooltip';
 
+const isShadowRoot = (node: Node): node is ShadowRoot => !!(node as ShadowRoot).host;
+
 export type EmojiPickerProps = {
   ButtonIconComponent?: React.ComponentType;
   buttonClassName?: string;
@@ -67,7 +69,14 @@ export const EmojiPicker = (props: EmojiPickerProps) => {
     const handlePointerDown = (e: PointerEvent) => {
       const target = e.target as HTMLElement;
 
-      if (popperElement.contains(target) || referenceElement.contains(target)) return;
+      const rootNode = target.getRootNode();
+
+      if (
+        popperElement.contains(isShadowRoot(rootNode) ? rootNode.host : target) ||
+        referenceElement.contains(target)
+      ) {
+        return;
+      }
 
       setDisplayPicker(false);
     };


### PR DESCRIPTION
### 🎯 Goal

[@tanstack/react-query-devtools]() introduces a side effect which causes pointer event handlers to return children of shadow root nodes as targets. As these targets are not children of hosting elements the `element.contains` method returns `false` and in turn closes the `EmojiPicker`.

### 🛠 Implementation details

Adds `isShadowRoot` check and reaches for `host` node if it is.