### PR TITLE
feat: support reaction groups

### DIFF
--- a/docusaurus/docs/React/components/message-components/reactions.mdx
+++ b/docusaurus/docs/React/components/message-components/reactions.mdx
@@ -102,13 +102,13 @@ An array of own reaction objects to display in the list (overrides `message.own_
 | ----- |
 | array |
 
-### reaction_counts
+### reaction_groups
 
-An object that keeps track of the count of each type of reaction on a message (overrides `message.reaction_counts` from `MessageContext`).
+An object that keeps track of the reactions on a message (overrides `message.reaction_groups` from `MessageContext`).
 
-| Type                            |
-| ------------------------------- |
-| { [key: reactionType]: number } |
+| Type                                           |
+| ---------------------------------------------- |
+| { [key: reactionType]: ReactionGroupResponse } |
 
 ### reactionOptions
 
@@ -167,13 +167,13 @@ An array of the own reaction objects to distinguish own reactions visually (over
 | ----- |
 | array |
 
-### reaction_counts
+### reaction_groups
 
-An object that keeps track of the count of each type of reaction on a message (overrides `message.reaction_counts` from `MessageContext`).
+An object that keeps track of the reactions on a message (overrides `message.reaction_groups` from `MessageContext`).
 
-| Type                            |
-| ------------------------------- |
-| { [key: reactionType]: number } |
+| Type                                           |
+| ---------------------------------------------- |
+| { [key: reactionType]: ReactionGroupResponse } |
 
 ### reactionOptions
 
@@ -241,13 +241,13 @@ An array of the own reaction objects to distinguish own reactions visually (over
 | ----- |
 | array |
 
-### reaction_counts
+### reaction_groups
 
-An object that keeps track of the count of each type of reaction on a message (overrides `message.reaction_counts` from `MessageContext`).
+An object that keeps track of the reactions on a message (overrides `message.reaction_groups` from `MessageContext`).
 
-| Type                            |
-| ------------------------------- |
-| { [key: reactionType]: number } |
+| Type                                           |
+| ---------------------------------------------- |
+| { [key: reactionType]: ReactionGroupResponse } |
 
 ### reactionOptions
 

--- a/examples/typescript/yarn.lock
+++ b/examples/typescript/yarn.lock
@@ -1389,6 +1389,11 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz#923ca57e173c6b232bbbb07347b1be982f03e783"
   integrity sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==
 
+"@breezystack/lamejs@^1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@breezystack/lamejs/-/lamejs-1.2.7.tgz#c4779f7f0b6b685da675ebbaaff85e52187a51ad"
+  integrity sha512-6wc7ck65ctA75Hq7FYHTtTvGnYs6msgdxiSUICQ+A01nVOWg6rqouZB8IdyteRlfpYYiFovkf67dIeOgWIUzTA==
+
 "@csstools/normalize.css@*":
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-12.1.1.tgz#f0ad221b7280f3fc814689786fd9ee092776ef8f"
@@ -1917,56 +1922,56 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
-"@react-aria/focus@^3.16.1":
-  version "3.16.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.16.1.tgz#557a451cbe901153d23045ce27851b05709db24a"
-  integrity sha512-3ZEYc+hWqDQX7fA54ZOTkED8OGXs9+K9fYmjD1IdjZJAJS/2/AJ95PgIQ29zBkl9D9TAi4Nb3tJ/3+H/02UzoA==
+"@react-aria/focus@^3":
+  version "3.16.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.16.2.tgz#2285bc19e091233b4d52399c506ac8fa60345b44"
+  integrity sha512-Rqo9ummmgotESfypzFjI3uh58yMpL+E+lJBbQuXkBM0u0cU2YYzu0uOrFrq3zcHk997udZvq1pGK/R+2xk9B7g==
   dependencies:
-    "@react-aria/interactions" "^3.21.0"
-    "@react-aria/utils" "^3.23.1"
-    "@react-types/shared" "^3.22.0"
+    "@react-aria/interactions" "^3.21.1"
+    "@react-aria/utils" "^3.23.2"
+    "@react-types/shared" "^3.22.1"
     "@swc/helpers" "^0.5.0"
     clsx "^2.0.0"
 
-"@react-aria/interactions@^3.21.0":
-  version "3.21.0"
-  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.21.0.tgz#c04f4eb59ae70b723d7be8d5f8eb4e2802087a49"
-  integrity sha512-sPuzEl4Xq/BR5gbYr2R/sDzwlX9NdJ02i8Ew2rEy2hLMlf1jAeUAdTg/G+K9baWJ8acV9fZv6h/mdV3dXGLPSg==
+"@react-aria/interactions@^3.21.1":
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.21.1.tgz#d8d9b0cf628d0bf4bb4e9d7eac485cfb9ed9cb97"
+  integrity sha512-AlHf5SOzsShkHfV8GLLk3v9lEmYqYHURKcXWue0JdYbmquMRkUsf/+Tjl1+zHVAQ8lKqRnPYbTmc4AcZbqxltw==
   dependencies:
-    "@react-aria/ssr" "^3.9.1"
-    "@react-aria/utils" "^3.23.1"
-    "@react-types/shared" "^3.22.0"
+    "@react-aria/ssr" "^3.9.2"
+    "@react-aria/utils" "^3.23.2"
+    "@react-types/shared" "^3.22.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/ssr@^3.9.1":
+"@react-aria/ssr@^3.9.2":
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.9.2.tgz#01b756965cd6e32b95217f968f513eb3bd6ee44b"
+  integrity sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@react-aria/utils@^3.23.2":
+  version "3.23.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.23.2.tgz#23fd55b165a799ecf72c1c66508574f67de20162"
+  integrity sha512-yznR9jJ0GG+YJvTMZxijQwVp+ahP66DY0apZf7X+dllyN+ByEDW+yaL1ewYPIpugxVzH5P8jhnBXsIyHKN411g==
+  dependencies:
+    "@react-aria/ssr" "^3.9.2"
+    "@react-stately/utils" "^3.9.1"
+    "@react-types/shared" "^3.22.1"
+    "@swc/helpers" "^0.5.0"
+    clsx "^2.0.0"
+
+"@react-stately/utils@^3.9.1":
   version "3.9.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.9.1.tgz#a1252fd5ef87eada810dd9dd6751a5e21359d1d2"
-  integrity sha512-NqzkLFP8ZVI4GSorS0AYljC13QW2sc8bDqJOkBvkAt3M8gbcAXJWVRGtZBCRscki9RZF+rNlnPdg0G0jYkhJcg==
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.9.1.tgz#5ce94ca4f88fc991263c7b3fa4690b09e2153484"
+  integrity sha512-yzw75GE0iUWiyps02BOAPTrybcsMIxEJlzXqtvllAb01O9uX5n0i3X+u2eCpj2UoDF4zS08Ps0jPgWxg8xEYtA==
   dependencies:
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/utils@^3.23.1":
-  version "3.23.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.23.1.tgz#a082a5ffb97a7b9c03d522dcedfc251af8473e44"
-  integrity sha512-iXibf9ojqdoygbvy/++v5cKLKgjc/5ZmKV8/9u/2Hkpha1cf5Td/Z+Vl42B6giUBAsuDio5kuZYfYC7Uk+t8ag==
-  dependencies:
-    "@react-aria/ssr" "^3.9.1"
-    "@react-stately/utils" "^3.9.0"
-    "@react-types/shared" "^3.22.0"
-    "@swc/helpers" "^0.5.0"
-    clsx "^2.0.0"
-
-"@react-stately/utils@^3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.9.0.tgz#9cb2c8eea5dd1b58256ecb436b963c01526bae37"
-  integrity sha512-yPKFY1F88HxuZ15BG2qwAYxtpE4HnIU0Ofi4CuBE0xC6I8mwo4OQjDzi+DZjxQngM9D6AeTTD6F1V8gkozA0Gw==
-  dependencies:
-    "@swc/helpers" "^0.5.0"
-
-"@react-types/shared@^3.22.0":
-  version "3.22.0"
-  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.22.0.tgz#70f85aad46cd225f7fcb29f1c2b5213163605074"
-  integrity sha512-yVOekZWbtSmmiThGEIARbBpnmUIuePFlLyctjvCbgJgGhz8JnEJOipLQ/a4anaWfzAgzSceQP8j/K+VOOePleA==
+"@react-types/shared@^3.22.1":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.22.1.tgz#4e5de032fcb0b7bca50f6a9f8e133fd882821930"
+  integrity sha512-PCpa+Vo6BKnRMuOEzy5zAZ3/H5tnQg1e80khMhK2xys0j6ZqzkgQC+fHMNZ7VDFNLqqNMj/o0eVeSBDh2POjkw==
 
 "@rgrove/parse-xml@^3.0.0":
   version "3.0.0"
@@ -5426,6 +5431,11 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+fix-webm-duration@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/fix-webm-duration/-/fix-webm-duration-1.0.5.tgz#da4558a92196a677302bfc54780b494dd5336a96"
+  integrity sha512-b6oula3OfSknx0aWoLsxvp4DVIYbwsf+UAkr6EDAK3iuMYk/OSNKzmeSI61GXK0MmFTEuzle19BPvTxMIKjkZg==
+
 flat-cache@^3.0.4:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.2.0.tgz#2c0c2d5040c99b1632771a9d105725c0115363ee"
@@ -7443,6 +7453,11 @@ lodash.deburr@^4.1.0:
   resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
   integrity sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=
 
+lodash.defaultsdeep@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz#512e9bd721d272d94e3d3a63653fa17516741ca6"
+  integrity sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -7482,6 +7497,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.once@^4.0.0:
   version "4.1.1"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "emoji-mart": "^5.4.0",
     "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
     "react-dom": "^18.0.0 || ^17.0.0 || ^16.8.0",
-    "stream-chat": "^8.29.0"
+    "stream-chat": "^8.30.0"
   },
   "peerDependenciesMeta": {
     "emoji-mart": {
@@ -226,7 +226,7 @@
     "rollup-plugin-url": "^3.0.1",
     "rollup-plugin-visualizer": "^4.2.0",
     "semantic-release": "^19.0.5",
-    "stream-chat": "^8.29.0",
+    "stream-chat": "^8.30.0",
     "style-loader": "^2.0.0",
     "ts-jest": "^28.0.8",
     "typescript": "^4.7.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "emoji-mart": "^5.4.0",
     "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
     "react-dom": "^18.0.0 || ^17.0.0 || ^16.8.0",
-    "stream-chat": "^8.21.0"
+    "stream-chat": "^8.29.0"
   },
   "peerDependenciesMeta": {
     "emoji-mart": {
@@ -226,7 +226,7 @@
     "rollup-plugin-url": "^3.0.1",
     "rollup-plugin-visualizer": "^4.2.0",
     "semantic-release": "^19.0.5",
-    "stream-chat": "^8.25.1",
+    "stream-chat": "^8.29.0",
     "style-loader": "^2.0.0",
     "ts-jest": "^28.0.8",
     "typescript": "^4.7.4",

--- a/src/components/Message/__tests__/MessageSimple.test.js
+++ b/src/components/Message/__tests__/MessageSimple.test.js
@@ -35,6 +35,7 @@ import {
   generateReaction,
   generateUser,
   getTestClientWithUser,
+  groupReactions,
 } from '../../../mock-builders';
 import { MessageBouncePrompt } from '../../MessageBounce';
 
@@ -236,6 +237,7 @@ describe('<MessageSimple />', () => {
     const message = generateAliceMessage({
       latest_reactions: reactions,
       reaction_counts: countReactions(reactions),
+      reaction_groups: groupReactions(reactions),
       text: undefined,
     });
 
@@ -253,6 +255,7 @@ describe('<MessageSimple />', () => {
     const message = generateAliceMessage({
       latest_reactions: reactions,
       reaction_counts: countReactions(reactions),
+      reaction_groups: groupReactions(reactions),
       text: undefined,
     });
     const CustomReactionsList = ({ reactions = [] }) => (

--- a/src/components/Message/__tests__/MessageText.test.js
+++ b/src/components/Message/__tests__/MessageText.test.js
@@ -20,6 +20,7 @@ import {
   generateReaction,
   generateUser,
   getTestClientWithUser,
+  groupReactions,
 } from '../../../mock-builders';
 
 import { Attachment } from '../../Attachment';
@@ -234,6 +235,7 @@ describe('<MessageText />', () => {
     const message = generateAliceMessage({
       latest_reactions: reactions,
       reaction_counts: countReactions(reactions),
+      reaction_groups: groupReactions(reactions),
     });
 
     let container;
@@ -253,6 +255,7 @@ describe('<MessageText />', () => {
     const message = generateAliceMessage({
       latest_reactions: reactions,
       reaction_counts: countReactions(reactions),
+      reaction_groups: groupReactions(reactions),
     });
     const { container, queryByTestId } = await renderMessageText({
       channelCapabilitiesOverrides: { 'send-reaction': false },

--- a/src/components/Message/__tests__/utils.test.js
+++ b/src/components/Message/__tests__/utils.test.js
@@ -2,6 +2,7 @@ import { generateMessage, generateReaction, generateUser } from 'mock-builders';
 import {
   countReactions,
   getTestClientWithUser,
+  groupReactions,
   mockTranslatorFunction,
 } from '../../../mock-builders';
 import {
@@ -247,6 +248,7 @@ describe('Message utils', () => {
       const message = generateMessage({
         latest_reactions: reactions,
         reaction_counts: countReactions(reactions),
+        reaction_groups: groupReactions(reactions),
       });
       expect(messageHasReactions(message)).toBe(true);
     });

--- a/src/components/Message/hooks/useReactionHandler.ts
+++ b/src/components/Message/hooks/useReactionHandler.ts
@@ -31,17 +31,28 @@ export const useReactionHandler = <
       reaction: ReactionResponse<StreamChatGenerics>,
       message: StreamMessage<StreamChatGenerics>,
     ): StreamMessage<StreamChatGenerics> => {
-      const newReactionCounts = message?.reaction_counts || {};
+      const newReactionGroups = message?.reaction_groups || {};
       const reactionType = reaction.type;
-      const hasReaction = !!newReactionCounts[reactionType];
+      const hasReaction = !!newReactionGroups[reactionType];
 
       if (add) {
-        newReactionCounts[reactionType] = hasReaction ? newReactionCounts[reactionType] + 1 : 1;
+        const timestamp = new Date().toISOString();
+        newReactionGroups[reactionType] = hasReaction
+          ? { ...newReactionGroups[reactionType], count: newReactionGroups[reactionType].count + 1 }
+          : {
+              count: 1,
+              first_reaction_at: timestamp,
+              last_reaction_at: timestamp,
+              sum_scores: 1,
+            };
       } else {
-        if (hasReaction && newReactionCounts[reactionType] > 1) {
-          newReactionCounts[reactionType]--;
+        if (hasReaction && newReactionGroups[reactionType].count > 1) {
+          newReactionGroups[reactionType] = {
+            ...newReactionGroups[reactionType],
+            count: newReactionGroups[reactionType].count - 1,
+          };
         } else {
-          delete newReactionCounts[reactionType];
+          delete newReactionGroups[reactionType];
         }
       }
 
@@ -59,8 +70,7 @@ export const useReactionHandler = <
         ...message,
         latest_reactions: newReactions || message.latest_reactions,
         own_reactions: newOwnReactions,
-        reaction_counts: newReactionCounts,
-        reaction_scores: newReactionCounts,
+        reaction_groups: newReactionGroups,
       } as StreamMessage<StreamChatGenerics>;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/Message/hooks/useReactionsFetcher.ts
+++ b/src/components/Message/hooks/useReactionsFetcher.ts
@@ -1,4 +1,4 @@
-import { ReactionResponse, StreamChat } from 'stream-chat';
+import { Reaction, ReactionResponse, StreamChat } from 'stream-chat';
 import { StreamMessage, useChatContext, useTranslationContext } from '../../../context';
 import { DefaultStreamChatGenerics } from '../../../types/types';
 
@@ -34,9 +34,13 @@ export function useReactionsFetcher<
 
 async function queryMessageReactions<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
->(client: StreamChat<StreamChatGenerics>, messageId: string, reactionType?: string) {
+>(
+  client: StreamChat<StreamChatGenerics>,
+  messageId: string,
+  reactionType?: Reaction<StreamChatGenerics>['type'],
+) {
   const reactions: ReactionResponse<StreamChatGenerics>[] = [];
-  const limit = 300;
+  const limit = 25;
   let hasNext = true;
   let next: string | undefined;
 

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -326,7 +326,7 @@ export const messageHasReactions = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 >(
   message?: StreamMessage<StreamChatGenerics>,
-) => Object.values(message?.reaction_counts ?? {}).some((count) => count > 0);
+) => Object.values(message?.reaction_groups ?? {}).some(({ count }) => count > 0);
 
 export const messageHasAttachments = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics

--- a/src/components/MessageList/utils.ts
+++ b/src/components/MessageList/utils.ts
@@ -281,7 +281,7 @@ export const getGroupStyles = <
     message.user?.id !== previousMessage.user?.id ||
     previousMessage.type === 'error' ||
     previousMessage.deleted_at ||
-    (message.reaction_counts && Object.keys(message.reaction_counts).length > 0) ||
+    (message.reaction_groups && Object.keys(message.reaction_groups).length > 0) ||
     isMessageEdited(previousMessage);
 
   const isBottomMessage =
@@ -293,7 +293,7 @@ export const getGroupStyles = <
     message.user?.id !== nextMessage.user?.id ||
     nextMessage.type === 'error' ||
     nextMessage.deleted_at ||
-    (nextMessage.reaction_counts && Object.keys(nextMessage.reaction_counts).length > 0) ||
+    (nextMessage.reaction_groups && Object.keys(nextMessage.reaction_groups).length > 0) ||
     isMessageEdited(message);
 
   if (!isTopMessage && !isBottomMessage) {

--- a/src/components/Reactions/ReactionSelector.tsx
+++ b/src/components/Reactions/ReactionSelector.tsx
@@ -8,7 +8,7 @@ import { AvatarProps, Avatar as DefaultAvatar } from '../Avatar';
 import { useComponentContext } from '../../context/ComponentContext';
 import { useMessageContext } from '../../context/MessageContext';
 
-import type { ReactionResponse } from 'stream-chat';
+import type { ReactionGroupResponse, ReactionResponse } from 'stream-chat';
 
 import type { DefaultStreamChatGenerics } from '../../types/types';
 import type { ReactionOptions } from './reactionOptions';
@@ -26,8 +26,13 @@ export type ReactionSelectorProps<
   latest_reactions?: ReactionResponse<StreamChatGenerics>[];
   /** An array of the own reaction objects to distinguish own reactions visually */
   own_reactions?: ReactionResponse<StreamChatGenerics>[];
-  /** An object that keeps track of the count of each type of reaction on a message */
+  /**
+   * An object that keeps track of the count of each type of reaction on a message
+   * @deprecated This override value is no longer taken into account. Use `reaction_groups` to override reaction counts instead.
+   * */
   reaction_counts?: Record<string, number>;
+  /** An object containing summary for each reaction type on a message */
+  reaction_groups?: Record<string, ReactionGroupResponse>;
   /** A list of the currently supported reactions on a message */
   reactionOptions?: ReactionOptions;
   /** If true, adds a CSS class that reverses the horizontal positioning of the selector */
@@ -45,7 +50,7 @@ const UnMemoizedReactionSelector = React.forwardRef(
       handleReaction: propHandleReaction,
       latest_reactions: propLatestReactions,
       own_reactions: propOwnReactions,
-      reaction_counts: propReactionCounts,
+      reaction_groups: propReactionGroups,
       reactionOptions: propReactionOptions,
       reverse = false,
     } = props;
@@ -65,7 +70,7 @@ const UnMemoizedReactionSelector = React.forwardRef(
     const handleReaction = propHandleReaction || contextHandleReaction;
     const latestReactions = propLatestReactions || message?.latest_reactions || [];
     const ownReactions = propOwnReactions || message?.own_reactions || [];
-    const reactionCounts = propReactionCounts || message?.reaction_counts || {};
+    const reactionGroups = propReactionGroups || message?.reaction_groups || {};
 
     const [tooltipReactionType, setTooltipReactionType] = useState<string | null>(null);
     const [tooltipPositions, setTooltipPositions] = useState<{
@@ -157,7 +162,7 @@ const UnMemoizedReactionSelector = React.forwardRef(
         <ul className='str-chat__message-reactions-list str-chat__message-reactions-options'>
           {reactionOptions.map(({ Component, name: reactionName, type: reactionType }) => {
             const latestUser = getLatestUserForReactionType(reactionType);
-            const count = reactionCounts && reactionCounts[reactionType];
+            const count = reactionGroups[reactionType]?.count ?? 0;
             return (
               <li key={reactionType}>
                 <button

--- a/src/components/Reactions/ReactionsList.tsx
+++ b/src/components/Reactions/ReactionsList.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import clsx from 'clsx';
 
-import type { ReactionResponse } from 'stream-chat';
+import type { ReactionGroupResponse, ReactionResponse } from 'stream-chat';
 
 import { useProcessReactions } from './hooks/useProcessReactions';
 
@@ -20,8 +20,13 @@ export type ReactionsListProps<
   onClick?: ReactEventHandler;
   /** An array of the own reaction objects to distinguish own reactions visually */
   own_reactions?: ReactionResponse<StreamChatGenerics>[];
-  /** An object that keeps track of the count of each type of reaction on a message */
+  /**
+   * An object that keeps track of the count of each type of reaction on a message
+   * @deprecated This override value is no longer taken into account. Use `reaction_groups` to override reaction counts instead.
+   * */
   reaction_counts?: Record<string, number>;
+  /** An object containing summary for each reaction type on a message */
+  reaction_groups?: Record<string, ReactionGroupResponse>;
   /** A list of the currently supported reactions on a message */
   reactionOptions?: ReactionOptions;
   /** An array of the reaction objects to display in the list */

--- a/src/components/Reactions/SimpleReactionsList.tsx
+++ b/src/components/Reactions/SimpleReactionsList.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren, useState } from 'react';
 import clsx from 'clsx';
 
-import type { ReactionResponse } from 'stream-chat';
+import type { ReactionGroupResponse, ReactionResponse } from 'stream-chat';
 
 import { useChatContext } from '../../context/ChatContext';
 import { MessageContextValue, useMessageContext } from '../../context/MessageContext';
@@ -51,8 +51,13 @@ export type SimpleReactionsListProps<
 > = Partial<Pick<MessageContextValue, 'handleFetchReactions' | 'handleReaction'>> & {
   /** An array of the own reaction objects to distinguish own reactions visually */
   own_reactions?: ReactionResponse<StreamChatGenerics>[];
-  /** An object that keeps track of the count of each type of reaction on a message */
-  reaction_counts?: { [key: string]: number };
+  /**
+   * An object that keeps track of the count of each type of reaction on a message
+   * @deprecated This override value is no longer taken into account. Use `reaction_groups` to override reaction counts instead.
+   * */
+  reaction_counts?: Record<string, number>;
+  /** An object containing summary for each reaction type on a message */
+  reaction_groups?: Record<string, ReactionGroupResponse>;
   /** A list of the currently supported reactions on a message */
   reactionOptions?: ReactionOptions;
   /** An array of the reaction objects to display in the list */

--- a/src/components/Reactions/__tests__/ReactionSelector.test.js
+++ b/src/components/Reactions/__tests__/ReactionSelector.test.js
@@ -92,7 +92,7 @@ describe('ReactionSelector', () => {
     const aliceReaction = generateReaction({ type: 'love', user: alice });
     const { container } = renderComponent({
       latest_reactions: [aliceReaction],
-      reaction_counts: { love: 1 },
+      reaction_groups: { love: { count: 1 } },
     });
 
     expect(AvatarMock).toHaveBeenCalledWith(
@@ -110,9 +110,9 @@ describe('ReactionSelector', () => {
     const love = 1;
     const haha = 2;
     const { container, getByText } = renderComponent({
-      reaction_counts: {
-        haha,
-        love,
+      reaction_groups: {
+        haha: { count: haha },
+        love: { count: love },
       },
     });
 
@@ -132,7 +132,7 @@ describe('ReactionSelector', () => {
     const bobReaction = generateReaction({ type: 'love', user: bob });
     const { container, findByText, getByTestId } = renderComponent({
       latest_reactions: [aliceReaction, bobReaction],
-      reaction_counts: { love: 2 },
+      reaction_groups: { love: { count: 2 } },
     });
 
     expect(AvatarMock).toHaveBeenCalledWith(

--- a/src/components/Reactions/__tests__/ReactionsListModal.test.js
+++ b/src/components/Reactions/__tests__/ReactionsListModal.test.js
@@ -13,8 +13,8 @@ import { generateReactions, generateUser } from '../../../mock-builders';
 import { ComponentProvider } from '../../../context';
 import { defaultReactionOptions } from '../reactionOptions';
 
-const generateReactionsFromReactionCounts = (reactionCounts) =>
-  Object.entries(reactionCounts).flatMap(([type, count]) =>
+const generateReactionsFromReactionGroups = (reactionGroups) =>
+  Object.entries(reactionGroups).flatMap(([type, { count }]) =>
     generateReactions(count, (i) => ({
       type,
       user: generateUser({ id: `mark-${i}`, name: `Mark Number ${i}` }),
@@ -41,13 +41,13 @@ describe('ReactionsListModal', () => {
   });
 
   it('should show reactions modal when a reaction is clicked', async () => {
-    const reactionCounts = {
-      haha: 2,
-      love: 5,
+    const reactionGroups = {
+      haha: { count: 2 },
+      love: { count: 5 },
     };
     const { container, getByTestId, queryByTestId } = renderComponent({
-      reaction_counts: reactionCounts,
-      reactions: generateReactionsFromReactionCounts(reactionCounts),
+      reaction_groups: reactionGroups,
+      reactions: generateReactionsFromReactionGroups(reactionGroups),
     });
 
     expect(queryByTestId('reactions-list-modal')).not.toBeInTheDocument();
@@ -61,16 +61,16 @@ describe('ReactionsListModal', () => {
   });
 
   it('should display a list of reactions in a modal', async () => {
-    const reactionCounts = {
-      haha: 2,
-      love: 5,
+    const reactionGroups = {
+      haha: { count: 2 },
+      love: { count: 5 },
     };
-    const reactions = generateReactionsFromReactionCounts(reactionCounts);
+    const reactions = generateReactionsFromReactionGroups(reactionGroups);
     const fetchReactions = jest.fn(() => Promise.resolve(reactions));
 
     const { container, getAllByTestId, getByTestId } = renderComponent({
       handleFetchReactions: fetchReactions,
-      reaction_counts: reactionCounts,
+      reaction_groups: reactionGroups,
       reactions,
     });
 
@@ -89,13 +89,13 @@ describe('ReactionsListModal', () => {
   });
 
   it('should close reactions list modal when close button is clicked', async () => {
-    const reactionCounts = {
-      haha: 2,
-      love: 5,
+    const reactionGroups = {
+      haha: { count: 2 },
+      love: { count: 5 },
     };
     const { getByTestId, getByTitle, queryByTestId } = renderComponent({
-      reaction_counts: reactionCounts,
-      reactions: generateReactionsFromReactionCounts(reactionCounts),
+      reaction_groups: reactionGroups,
+      reactions: generateReactionsFromReactionGroups(reactionGroups),
     });
 
     await act(() => {
@@ -109,13 +109,13 @@ describe('ReactionsListModal', () => {
   });
 
   it('should not allow opening reactions list modal when the reactions count is too high', async () => {
-    const reactionCounts = {
-      haha: 2000,
-      love: 5000,
+    const reactionGroups = {
+      haha: { count: 2000 },
+      love: { count: 5000 },
     };
     const { getByTestId, queryByTestId } = renderComponent({
-      reaction_counts: reactionCounts,
-      reactions: generateReactionsFromReactionCounts(reactionCounts),
+      reaction_groups: reactionGroups,
+      reactions: generateReactionsFromReactionGroups(reactionGroups),
     });
 
     await act(() => {
@@ -125,14 +125,14 @@ describe('ReactionsListModal', () => {
   });
 
   it('should order reactions alphabetically by default', async () => {
-    const reactionCounts = {
-      haha: 2,
-      like: 8,
-      love: 5,
+    const reactionGroups = {
+      haha: { count: 2 },
+      like: { count: 8 },
+      love: { count: 5 },
     };
     const { getByTestId } = renderComponent({
-      reaction_counts: reactionCounts,
-      reactions: generateReactionsFromReactionCounts(reactionCounts),
+      reaction_groups: reactionGroups,
+      reactions: generateReactionsFromReactionGroups(reactionGroups),
     });
 
     await act(() => {
@@ -153,14 +153,14 @@ describe('ReactionsListModal', () => {
   });
 
   it('should use custom reactions comparator if provided', async () => {
-    const reactionCounts = {
-      haha: 2,
-      like: 8,
-      love: 5,
+    const reactionGroups = {
+      haha: { count: 2 },
+      like: { count: 8 },
+      love: { count: 5 },
     };
     const { getByTestId } = renderComponent({
-      reaction_counts: reactionCounts,
-      reactions: generateReactionsFromReactionCounts(reactionCounts),
+      reaction_groups: reactionGroups,
+      reactions: generateReactionsFromReactionGroups(reactionGroups),
       sortReactions: (a, b) => b.reactionCount - a.reactionCount,
     });
 
@@ -182,14 +182,14 @@ describe('ReactionsListModal', () => {
   });
 
   it('should order reacted users alphabetically by default', async () => {
-    const reactionCounts = {
-      haha: 3,
+    const reactionGroups = {
+      haha: { count: 3 },
     };
-    const reactions = generateReactionsFromReactionCounts(reactionCounts).reverse();
+    const reactions = generateReactionsFromReactionGroups(reactionGroups).reverse();
     const fetchReactions = jest.fn(() => Promise.resolve(reactions));
     const { getByTestId, getByText } = renderComponent({
       handleFetchReactions: fetchReactions,
-      reaction_counts: reactionCounts,
+      reaction_groups: reactionGroups,
       reactions,
     });
 
@@ -207,14 +207,14 @@ describe('ReactionsListModal', () => {
   });
 
   it('should use custom reaction details comparator if provided', async () => {
-    const reactionCounts = {
-      haha: 3,
+    const reactionGroups = {
+      haha: { count: 3 },
     };
-    const reactions = generateReactionsFromReactionCounts(reactionCounts).reverse();
+    const reactions = generateReactionsFromReactionGroups(reactionGroups).reverse();
     const fetchReactions = jest.fn(() => Promise.resolve(reactions));
     const { getByTestId, getByText } = renderComponent({
       handleFetchReactions: fetchReactions,
-      reaction_counts: reactionCounts,
+      reaction_groups: reactionGroups,
       reactions,
       sortReactionDetails: (a, b) => -a.user.name.localeCompare(b.user.name),
     });

--- a/src/components/Reactions/__tests__/SimpleReactionsList.test.js
+++ b/src/components/Reactions/__tests__/SimpleReactionsList.test.js
@@ -18,8 +18,8 @@ import { ComponentProvider } from '../../../context';
 const handleReactionMock = jest.fn();
 // const loveEmojiTestId = 'emoji-love';
 
-const renderComponent = ({ reaction_counts = {}, themeVersion = '1', ...props }) => {
-  const reactions = Object.entries(reaction_counts).flatMap(([type, count]) =>
+const renderComponent = ({ reaction_groups = {}, themeVersion = '1', ...props }) => {
+  const reactions = Object.entries(reaction_groups).flatMap(([type, { count }]) =>
     Array(count)
       .fill()
       .map((_, i) => generateReaction({ type, user: { id: `${USER_ID}-${i}` } })),
@@ -32,7 +32,7 @@ const renderComponent = ({ reaction_counts = {}, themeVersion = '1', ...props })
           <MessageProvider value={{}}>
             <SimpleReactionsList
               handleReaction={handleReactionMock}
-              reaction_counts={reaction_counts}
+              reaction_groups={reaction_groups}
               reactions={reactions}
               {...props}
             />
@@ -61,9 +61,9 @@ describe.each(['1', '2'])('SimpleReactionsList v%s', (themeVersion) => {
 
   it('should render the total reaction count', async () => {
     const { container, getByText } = renderComponent({
-      reaction_counts: {
-        haha: 2,
-        love: 5,
+      reaction_groups: {
+        haha: { count: 2 },
+        love: { count: 5 },
       },
       themeVersion,
     });
@@ -75,15 +75,15 @@ describe.each(['1', '2'])('SimpleReactionsList v%s', (themeVersion) => {
   });
 
   it('should render an emoji for each type of reaction', async () => {
-    const reaction_counts = {
-      haha: 2,
-      love: 5,
+    const reaction_groups = {
+      haha: { count: 2 },
+      love: { count: 5 },
     };
     // force to render default fallbacks
     jest.spyOn(utils, 'getImageDimensions').mockRejectedValue('Error');
     jest.spyOn(console, 'error').mockImplementation(null);
 
-    const { container } = renderComponent({ reaction_counts, themeVersion });
+    const { container } = renderComponent({ reaction_groups, themeVersion });
 
     expect(container).toMatchSnapshot();
     const results = await axe(container);
@@ -91,13 +91,13 @@ describe.each(['1', '2'])('SimpleReactionsList v%s', (themeVersion) => {
   });
 
   it('should handle custom reaction options', async () => {
-    const reaction_counts = {
-      banana: 1,
-      cowboy: 2,
+    const reaction_groups = {
+      banana: { count: 1 },
+      cowboy: { count: 2 },
     };
 
     const { container } = renderComponent({
-      reaction_counts,
+      reaction_groups,
       reactionOptions: [
         { emoji: '🍌', id: 'banana' },
         { emoji: '🤠', id: 'cowboy' },
@@ -111,11 +111,11 @@ describe.each(['1', '2'])('SimpleReactionsList v%s', (themeVersion) => {
   });
 
   it('should call handleReaction callback if a reaction emoji is clicked', async () => {
-    const reaction_counts = {
-      love: 1,
+    const reaction_groups = {
+      love: { count: 1 },
     };
 
-    const { container, getByText } = renderComponent({ reaction_counts, themeVersion });
+    const { container, getByText } = renderComponent({ reaction_groups, themeVersion });
 
     fireEvent.click(getByText('❤️'));
 
@@ -125,12 +125,12 @@ describe.each(['1', '2'])('SimpleReactionsList v%s', (themeVersion) => {
   });
 
   it('should render a tooltip with all users that reacted a certain way if the emoji is hovered', async () => {
-    const reaction_counts = {
-      love: 3,
+    const reaction_groups = {
+      love: { count: 3 },
     };
 
     const { container, getByText, queryByText, reactions } = renderComponent({
-      reaction_counts,
+      reaction_groups,
       themeVersion,
     });
 

--- a/src/components/Reactions/hooks/useProcessReactions.tsx
+++ b/src/components/Reactions/hooks/useProcessReactions.tsx
@@ -48,7 +48,7 @@ export const useProcessReactions = <
   const sortReactions = propSortReactions ?? contextSortReactions ?? defaultReactionsSort;
   const latestReactions = propReactions || message.latest_reactions;
   const ownReactions = propOwnReactions || message?.own_reactions;
-  const reactionGroups = propReactionGroups || message.reaction_groups;
+  const reactionGroups = propReactionGroups || message?.reaction_groups;
 
   const isOwnReaction = useCallback(
     (reactionType: string) =>

--- a/src/components/Reactions/types.ts
+++ b/src/components/Reactions/types.ts
@@ -3,10 +3,13 @@ import type { ReactionResponse } from 'stream-chat';
 
 export interface ReactionSummary {
   EmojiComponent: ComponentType | null;
+  firstReactionAt: Date | null;
   isOwnReaction: boolean;
+  lastReactionAt: Date | null;
   latestReactedUserNames: string[];
   reactionCount: number;
   reactionType: string;
+  unlistedReactedUserCount: number;
 }
 
 export type ReactionsComparator = (a: ReactionSummary, b: ReactionSummary) => number;

--- a/src/context/MessageContext.tsx
+++ b/src/context/MessageContext.tsx
@@ -46,7 +46,9 @@ export type MessageContextValue<
   /** Function to edit a message in a Channel */
   handleEdit: ReactEventHandler;
   /** Function to fetch the message reactions */
-  handleFetchReactions: () => Promise<Array<ReactionResponse<StreamChatGenerics>>>;
+  handleFetchReactions: (
+    reactionType?: string,
+  ) => Promise<Array<ReactionResponse<StreamChatGenerics>>>;
   /** Function to flag a message in a Channel */
   handleFlag: ReactEventHandler;
   /** Function to mark message and the messages that follow it as unread in a Channel */

--- a/src/context/MessageContext.tsx
+++ b/src/context/MessageContext.tsx
@@ -46,9 +46,7 @@ export type MessageContextValue<
   /** Function to edit a message in a Channel */
   handleEdit: ReactEventHandler;
   /** Function to fetch the message reactions */
-  handleFetchReactions: (
-    reactionType?: string,
-  ) => Promise<Array<ReactionResponse<StreamChatGenerics>>>;
+  handleFetchReactions: () => Promise<Array<ReactionResponse<StreamChatGenerics>>>;
   /** Function to flag a message in a Channel */
   handleFlag: ReactEventHandler;
   /** Function to mark message and the messages that follow it as unread in a Channel */

--- a/src/mock-builders/generator/reaction.js
+++ b/src/mock-builders/generator/reaction.js
@@ -26,3 +26,17 @@ export const countReactions = (reactions = []) => {
   }
   return reactionCount;
 };
+
+export const groupReactions = (reactions = []) => {
+  const timestamp = new Date().toISOString();
+  const reactionGroups = {};
+  for (const reaction of reactions) {
+    reactionGroups[reaction.type] ??= {
+      count: 0,
+      first_reaction_at: timestamp,
+      last_reaction_at: timestamp,
+    };
+    reactionGroups[reaction.type].count++;
+  }
+  return reactionGroups;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -13322,10 +13322,10 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-chat@^8.29.0:
-  version "8.29.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.29.0.tgz#e166c50b38b503bd618c349c34d5fcbb33aab743"
-  integrity sha512-Dzwey5Hg4xX4W3Kl3o2OBn+tyxV4BecnKNTMBjccLAHOjXGhawAAtpwTw5ljRRldAdzjJ2t2ORtHjwKluZ5VyA==
+stream-chat@^8.30.0:
+  version "8.30.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.30.0.tgz#47cd05adee04ff7f7b170cac55698474e2819eb4"
+  integrity sha512-UNdCC9P9wM9DBn6hgVby1rSQuAwTovRpoZL5PdvUS3AEIpXCU4tj2zlwCbz2GFA/M9spDfyQsT/c+vbbr7eCAg==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13322,10 +13322,10 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-chat@^8.25.1:
-  version "8.25.1"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.25.1.tgz#5898098cb25e81ac537dd6adbbd9742b8a508fbf"
-  integrity sha512-9U4aVbLmRrRumxMGq4Fr/Y6vR30JSTxC9BkU3uGf3q+QZam3t4XA6TzsTJdJ6c34+QBSXL/k1hlsyA/InxKOLQ==
+stream-chat@^8.29.0:
+  version "8.29.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.29.0.tgz#e166c50b38b503bd618c349c34d5fcbb33aab743"
+  integrity sha512-Dzwey5Hg4xX4W3Kl3o2OBn+tyxV4BecnKNTMBjccLAHOjXGhawAAtpwTw5ljRRldAdzjJ2t2ORtHjwKluZ5VyA==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"


### PR DESCRIPTION
### 🎯 Goal

Adds support for a new `reaction_groups` property on message, that contains more in-depth summary of message reactions than the soon-to-be-deprecated `reaction_counts`.

### 🛠 Implementation details

The new property allows to implement a Slack-like sorting order for reactions (sorted by first reaction timestamp) which is now the default.

### To-Do:

- [x] Bump LLC