### PR TITLE
feat: allow to review message processing before rendering in message lists

### DIFF
--- a/docusaurus/docs/React/components/core-components/message-list.mdx
+++ b/docusaurus/docs/React/components/core-components/message-list.mdx
@@ -453,6 +453,68 @@ only `readBy` data for a user's most recently sent message is returned.
 | ------- | ------- |
 | boolean | false   |
 
+### reviewProcessedMessage
+
+Allows to review changes introduced to messages array on per message basis (for example date separator injection before a message). The array returned from the function is appended to the array of messages that are later rendered into React elements in the `MessageList`.
+
+The function expects a single parameter, which is an object containing the following attributes:
+
+- `changes` - array of messages representing the changes applied around a given processed message
+- `context` - configuration params and information forwarded from `processMessages`
+- `index` - index of the processed message in the original messages array
+- `messages` - array of messages retrieved from the back-end
+- `processedMessages` - newly built array of messages to be later rendered
+
+The `context` has the following parameters:
+
+- `userId` - the connected user ID;
+- `enableDateSeparator` - flag determining whether the date separators will be injected Enable date separator
+- `hideDeletedMessages` - flag determining whether deleted messages would be filtered out during the processing
+- `hideNewMessageSeparator` - disables date separator display for unread incoming messages
+- `lastRead`: Date when the channel has been last read. Sets the threshold after everything is considered unread
+
+The example below demonstrates how the custom logic can decide, whether deleted messages should be rendered on a given date. In this example, the deleted messages neither the date separator would be rendered if all the messages on a given date are deleted.
+
+```js
+const getMsgDate = (msg) =>
+  (msg && msg.created_at && isDate(msg.created_at) && msg.created_at.toDateString()) || '';
+
+const dateSeparatorFilter = (msg) => msg.customType !== 'message.date';
+
+const msgIsDeleted = (msg) => msg.type === 'deleted';
+
+const reviewProcessedMessage = ({ changes, context, index, messages, processedMessages }) => {
+  if (!context.enableDateSeparator) return changes;
+
+  const changesWithoutSeparator = changes.filter(dateSeparatorFilter);
+  const dateSeparatorInjected = changesWithoutSeparator.length !== changes.length;
+  const previousProcessedMessage = processedMessages[processedMessages.length - 1];
+  const processedMessage = messages[index];
+  const processedMessageDate = getMsgDate(processedMessage);
+
+  if (dateSeparatorInjected) {
+    if (!processedMessageDate) return changes;
+    const followingMessages = messages.slice(index + 1);
+    let allFollowingMessagesOnDateDeleted = false;
+
+    for (const followingMsg of followingMessages) {
+      const followingMsgDate = getMsgDate(followingMsg);
+      if (followingMsgDate !== processedMessageDate) break;
+      allFollowingMessagesOnDateDeleted = followingMsg.type === 'deleted';
+    }
+
+    return allFollowingMessagesOnDateDeleted ? [] : changes;
+  } else if (
+    msgIsDeleted(processedMessage) &&
+    getMsgDate(previousProcessedMessage) !== getMsgDate(processedMessage)
+  ) {
+    return [];
+  } else {
+    return changes;
+  }
+};
+```
+
 ### scrolledUpThreshold
 
 The pixel threshold to determine whether the user is scrolled up in the list. When scrolled up in the active

--- a/docusaurus/docs/React/components/core-components/virtualized-list.mdx
+++ b/docusaurus/docs/React/components/core-components/virtualized-list.mdx
@@ -217,6 +217,66 @@ Keep track of read receipts for each message sent by the user. When disabled, on
 | ------- | ------- |
 | boolean | false   |
 
+### reviewProcessedMessage
+
+Allows to review changes introduced to messages array on per message basis (for example date separator injection before a message). The array returned from the function is appended to the array of messages that are later rendered into React elements in the `VirtualizedMessageList`.
+
+The function expects a single parameter, which is an object containing the following attributes:
+
+- `changes` - array of messages representing the changes applied around a given processed message
+- `context` - configuration params and information forwarded from `processMessages`
+- `index` - index of the processed message in the original messages array
+- `messages` - array of messages retrieved from the back-end
+- `processedMessages` - newly built array of messages to be later rendered
+
+The `context` has the following parameters:
+
+- `userId` - the connected user ID;
+- `enableDateSeparator` - flag determining whether the date separators will be injected Enable date separator
+- `hideDeletedMessages` - flag determining whether deleted messages would be filtered out during the processing
+- `hideNewMessageSeparator` - disables date separator display for unread incoming messages
+- `lastRead`: Date when the channel has been last read. Sets the threshold after everything is considered unread
+
+The example below demonstrates how the custom logic can decide, whether deleted messages should be rendered on a given date. In this example, the deleted messages neither the date separator would be rendered if all the messages on a given date are deleted.
+
+```js
+const getMsgDate = (msg) =>
+  (msg && msg.created_at && isDate(msg.created_at) && msg.created_at.toDateString()) || '';
+
+const dateSeparatorFilter = (msg) => msg.customType !== 'message.date';
+
+const msgIsDeleted = (msg) => msg.type === 'deleted';
+
+const reviewProcessedMessage = ({ changes, index, messages, processedMessages }) => {
+  const changesWithoutSeparator = changes.filter(dateSeparatorFilter);
+  const dateSeparatorInjected = changesWithoutSeparator.length !== changes.length;
+  const previousProcessedMessage = processedMessages[processedMessages.length - 1];
+  const processedMessage = messages[index];
+  const processedMessageDate = getMsgDate(processedMessage);
+
+  if (dateSeparatorInjected) {
+    if (!processedMessageDate) return changes;
+    const followingMessages = messages.slice(index + 1);
+    let allFollowingMessagesOnDateDeleted = false;
+
+    for (const followingMsg of followingMessages) {
+      const followingMsgDate = getMsgDate(followingMsg);
+      if (followingMsgDate !== processedMessageDate) break;
+      allFollowingMessagesOnDateDeleted = followingMsg.type === 'deleted';
+    }
+
+    return allFollowingMessagesOnDateDeleted ? [] : changes;
+  } else if (
+    msgIsDeleted(processedMessage) &&
+    getMsgDate(previousProcessedMessage) !== getMsgDate(processedMessage)
+  ) {
+    return [];
+  } else {
+    return changes;
+  }
+};
+```
+
 ### scrollSeekPlaceHolder
 
 Custom data passed to the list that determines when message placeholders should be shown during fast scrolling.

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -30,9 +30,9 @@ import { defaultPinPermissions, MESSAGE_ACTIONS } from '../Message/utils';
 import { TypingIndicator as DefaultTypingIndicator } from '../TypingIndicator';
 import { MessageListMainPanel } from './MessageListMainPanel';
 
-import type { GroupStyle } from './utils';
 import { defaultRenderMessages, MessageRenderer } from './renderMessages';
 
+import type { GroupStyle, ProcessMessagesParams } from './utils';
 import type { MessageProps } from '../Message/types';
 
 import type { StreamMessage } from '../../context/ChannelStateContext';
@@ -75,6 +75,7 @@ const MessageListWithContext = <
     headerPosition,
     read,
     renderMessages = defaultRenderMessages,
+    reviewProcessedMessage,
     messageLimit = DEFAULT_NEXT_CHANNEL_PAGE_SIZE,
     loadMore: loadMoreCallback,
     loadMoreNewer: loadMoreNewerCallback,
@@ -136,6 +137,7 @@ const MessageListWithContext = <
     hideNewMessageSeparator,
     messages,
     noGroupByUser,
+    reviewProcessedMessage,
   });
 
   const elements = useMessageListElements({
@@ -344,6 +346,11 @@ export type MessageListProps<
   renderMessages?: MessageRenderer<StreamChatGenerics>;
   /** If true, `readBy` data supplied to the `Message` components will include all user read states per sent message */
   returnAllReadData?: boolean;
+  /**
+   * Allows to review changes introduced to messages array on per message basis (e.g. date separator injection before a message).
+   * The array returned from the function is appended to the array of messages that are later rendered into React elements in the `MessageList`.
+   */
+  reviewProcessedMessage?: ProcessMessagesParams<StreamChatGenerics>['reviewProcessedMessage'];
   /**
    * The pixel threshold under which the message list is considered to be so near to the bottom,
    * so that if a new message is delivered, the list will be scrolled to the absolute bottom.

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -24,7 +24,13 @@ import { useMarkRead } from './hooks/useMarkRead';
 import { MessageNotification as DefaultMessageNotification } from './MessageNotification';
 import { MessageListNotifications as DefaultMessageListNotifications } from './MessageListNotifications';
 import { MessageListMainPanel } from './MessageListMainPanel';
-import { getGroupStyles, getLastReceived, GroupStyle, processMessages } from './utils';
+import {
+  getGroupStyles,
+  getLastReceived,
+  GroupStyle,
+  processMessages,
+  ProcessMessagesParams,
+} from './utils';
 import { MessageProps, MessageSimple, MessageUIComponentProps } from '../Message';
 import { UnreadMessagesNotification as DefaultUnreadMessagesNotification } from './UnreadMessagesNotification';
 import {
@@ -193,6 +199,7 @@ const VirtualizedMessageListWithContext = <
     overscan = 0,
     read,
     returnAllReadData = false,
+    reviewProcessedMessage,
     scrollSeekPlaceHolder,
     scrollToLatestMessageOnFocus = false,
     separateGiphyPreview = false,
@@ -259,12 +266,13 @@ const VirtualizedMessageListWithContext = <
       return messages;
     }
 
-    return processMessages({
+    return processMessages<StreamChatGenerics>({
       enableDateSeparator: !disableDateSeparator,
       hideDeletedMessages,
       hideNewMessageSeparator,
       lastRead,
       messages,
+      reviewProcessedMessage,
       setGiphyPreviewMessage,
       userId: client.userID || '',
     });
@@ -563,6 +571,11 @@ export type VirtualizedMessageListProps<
   overscan?: number;
   /** Keep track of read receipts for each message sent by the user. When disabled, only the last own message delivery / read status is rendered. */
   returnAllReadData?: boolean;
+  /**
+   * Allows to review changes introduced to messages array on per message basis (e.g. date separator injected before a message).
+   * The array returned from the function is appended to the array of messages that are later rendered into React elements in the `VirtualizedMessageList`.
+   */
+  reviewProcessedMessage?: ProcessMessagesParams<StreamChatGenerics>['reviewProcessedMessage'];
   /**
    * @deprecated Pass additionalVirtuosoProps.scrollSeekConfiguration and specify the placeholder in additionalVirtuosoProps.components.ScrollSeekPlaceholder instead.  Will be removed with next major release - `v11.0.0`.
    * Performance improvement by showing placeholders if user scrolls fast through list.

--- a/src/components/MessageList/__tests__/MessageList.test.js
+++ b/src/components/MessageList/__tests__/MessageList.test.js
@@ -316,6 +316,25 @@ describe('MessageList', () => {
     });
   });
 
+  it('forwards and executes reviewProcessedMessage function for each message', async () => {
+    const msgCount = 3;
+    const messages = Array.from({ length: msgCount }, generateMessage);
+    const reviewProcessedMessage = jest.fn();
+
+    await act(() => {
+      renderComponent({
+        channelProps: { channel },
+        chatClient,
+        msgListProps: { messages, reviewProcessedMessage },
+      });
+    });
+
+    expect(reviewProcessedMessage.mock.calls[0][0].changes[0].id).toMatchSnapshot('message.date');
+    expect(reviewProcessedMessage.mock.calls[0][0].changes[1].id).toBe(messages[0].id);
+    expect(reviewProcessedMessage.mock.calls[1][0].changes[0].id).toBe(messages[1].id);
+    expect(reviewProcessedMessage.mock.calls[2][0].changes[0].id).toBe(messages[2].id);
+  });
+
   describe('unread messages', () => {
     const messages = Array.from({ length: 5 }, generateMessage);
     const unread_messages = 2;

--- a/src/components/MessageList/__tests__/MessageList.test.js
+++ b/src/components/MessageList/__tests__/MessageList.test.js
@@ -329,7 +329,7 @@ describe('MessageList', () => {
       });
     });
 
-    expect(reviewProcessedMessage.mock.calls[0][0].changes[0].id).toMatchSnapshot('message.date');
+    expect(reviewProcessedMessage.mock.calls[0][0].changes[0].id).toMatch('message.date');
     expect(reviewProcessedMessage.mock.calls[0][0].changes[1].id).toBe(messages[0].id);
     expect(reviewProcessedMessage.mock.calls[1][0].changes[0].id).toBe(messages[1].id);
     expect(reviewProcessedMessage.mock.calls[2][0].changes[0].id).toBe(messages[2].id);

--- a/src/components/MessageList/__tests__/utils.test.js
+++ b/src/components/MessageList/__tests__/utils.test.js
@@ -404,4 +404,20 @@ describe('processMessages', () => {
     const customMsgIDs = customMessages.map((m) => m.id);
     expect(customMessages).toHaveLength(new Set(customMsgIDs).size);
   });
+
+  it('executes reviewProcessedMessage function for each message', () => {
+    const msgCount = 5;
+    const messages = Array.from({ length: msgCount }, generateMessage);
+    const reviewProcessedMessage = jest.fn();
+    processMessages({
+      messages,
+      reviewProcessedMessage,
+      userId: myUserId,
+    });
+
+    expect(reviewProcessedMessage).toHaveBeenCalledTimes(msgCount);
+    messages.forEach((msg, i) => {
+      expect(reviewProcessedMessage.mock.calls[i][0].changes[0].id).toBe(msg.id);
+    });
+  });
 });

--- a/src/components/MessageList/hooks/MessageList/useEnrichedMessages.ts
+++ b/src/components/MessageList/hooks/MessageList/useEnrichedMessages.ts
@@ -1,6 +1,12 @@
 import { useMemo } from 'react';
 
-import { getGroupStyles, GroupStyle, insertIntro, processMessages } from '../../utils';
+import {
+  getGroupStyles,
+  GroupStyle,
+  insertIntro,
+  processMessages,
+  ProcessMessagesParams,
+} from '../../utils';
 
 import { useChatContext } from '../../../../context/ChatContext';
 import { useComponentContext } from '../../../../context/ComponentContext';
@@ -27,6 +33,7 @@ export const useEnrichedMessages = <
     noGroupByUser: boolean,
   ) => GroupStyle;
   headerPosition?: number;
+  reviewProcessedMessage?: ProcessMessagesParams<StreamChatGenerics>['reviewProcessedMessage'];
 }) => {
   const {
     channel,
@@ -37,6 +44,7 @@ export const useEnrichedMessages = <
     hideNewMessageSeparator,
     messages,
     noGroupByUser,
+    reviewProcessedMessage,
   } = args;
 
   const { client } = useChatContext<StreamChatGenerics>('useEnrichedMessages');
@@ -49,12 +57,13 @@ export const useEnrichedMessages = <
   let messagesWithDates =
     !enableDateSeparator && !hideDeletedMessages && hideNewMessageSeparator
       ? messages
-      : processMessages({
+      : processMessages<StreamChatGenerics>({
           enableDateSeparator,
           hideDeletedMessages,
           hideNewMessageSeparator,
           lastRead,
           messages,
+          reviewProcessedMessage,
           userId: client.userID || '',
         });
 

--- a/src/components/MessageList/utils.ts
+++ b/src/components/MessageList/utils.ts
@@ -10,10 +10,8 @@ import type { DefaultStreamChatGenerics } from '../../types/types';
 import type { StreamMessage } from '../../context/ChannelStateContext';
 import { isMessageEdited } from '../Message/utils';
 
-type ProcessMessagesParams<
-  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
-> = {
-  messages: StreamMessage<StreamChatGenerics>[];
+type ProcessMessagesContext = {
+  /** the connected user ID */
   userId: string;
   /** Enable date separator */
   enableDateSeparator?: boolean;
@@ -21,8 +19,26 @@ type ProcessMessagesParams<
   hideDeletedMessages?: boolean;
   /** Disable date separator display for unread incoming messages */
   hideNewMessageSeparator?: boolean;
-  /** Sets the treshold after everything is considered unread */
+  /** Sets the threshold after everything is considered unread */
   lastRead?: Date | null;
+};
+
+export type ProcessMessagesParams<
+  StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+> = ProcessMessagesContext & {
+  messages: StreamMessage<StreamChatGenerics>[];
+  reviewProcessedMessage?: (params: {
+    /** array of messages representing the changes applied around a given processed message */
+    changes: StreamMessage<StreamChatGenerics>[];
+    /** configuration params and information forwarded from `processMessages` */
+    context: ProcessMessagesContext;
+    /** index of the processed message in the original messages array */
+    index: number;
+    /** array of messages retrieved from the back-end */
+    messages: StreamMessage<StreamChatGenerics>[];
+    /** newly built array of messages to be later rendered */
+    processedMessages: StreamMessage<StreamChatGenerics>[];
+  }) => StreamMessage<StreamChatGenerics>[];
   /** Signals whether to separate giphy preview as well as used to set the giphy preview state */
   setGiphyPreviewMessage?: React.Dispatch<
     React.SetStateAction<StreamMessage<StreamChatGenerics> | undefined>
@@ -50,15 +66,14 @@ export const processMessages = <
 >(
   params: ProcessMessagesParams<StreamChatGenerics>,
 ) => {
+  const { messages, reviewProcessedMessage, setGiphyPreviewMessage, ...context } = params;
   const {
     enableDateSeparator,
     hideDeletedMessages,
     hideNewMessageSeparator,
     lastRead,
-    messages,
-    setGiphyPreviewMessage,
     userId,
-  } = params;
+  } = context;
 
   let unread = false;
   let ephemeralMessagePresent = false;
@@ -78,6 +93,7 @@ export const processMessages = <
       continue;
     }
 
+    const changes: StreamMessage<StreamChatGenerics>[] = [];
     const messageDate =
       (message.created_at && isDate(message.created_at) && message.created_at.toDateString()) || '';
     const previousMessage = messages[i - 1];
@@ -92,7 +108,7 @@ export const processMessages = <
 
       // do not show date separator for current user's messages
       if (enableDateSeparator && unread && message.user?.id !== userId) {
-        newMessages.push({
+        changes.push({
           customType: CUSTOM_MESSAGE_TYPE.date,
           date: message.created_at,
           id: makeDateMessageId(message.created_at),
@@ -109,11 +125,11 @@ export const processMessages = <
         (hideDeletedMessages &&
           previousMessage?.type === 'deleted' &&
           lastDateSeparator !== messageDate)) &&
-      newMessages?.[newMessages.length - 1]?.customType !== CUSTOM_MESSAGE_TYPE.date // do not show two date separators in a row)
+      changes[changes.length - 1]?.customType !== CUSTOM_MESSAGE_TYPE.date // do not show two date separators in a row)
     ) {
       lastDateSeparator = messageDate;
 
-      newMessages.push(
+      changes.push(
         {
           customType: CUSTOM_MESSAGE_TYPE.date,
           date: message.created_at,
@@ -122,8 +138,18 @@ export const processMessages = <
         message,
       );
     } else {
-      newMessages.push(message);
+      changes.push(message);
     }
+
+    newMessages.push(
+      ...(reviewProcessedMessage?.({
+        changes,
+        context,
+        index: i,
+        messages,
+        processedMessages: newMessages,
+      }) || changes),
+    );
   }
 
   // clean up the giphy preview component state after a Cancel action
@@ -333,6 +359,7 @@ type DateSeparatorMessage = {
 
 export function isDateSeparatorMessage<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+  // @ts-ignore
 >(message: StreamMessage<StreamChatGenerics>): message is DateSeparatorMessage {
   return message.customType === CUSTOM_MESSAGE_TYPE.date && !!message.date && isDate(message.date);
 }


### PR DESCRIPTION
### 🎯 Goal

Allow integrators to influence the "processing" of messages before they are rendered. The adjustment is possible for each message retrieved from the back-end by passing `reviewProcessedMessage` prop to `MessageList` resp. `VirtualizedMessageList`