### PR TITLE
fix: message input not preventing default on enter on React 16

### DIFF
--- a/src/components/AutoCompleteTextarea/Textarea.jsx
+++ b/src/components/AutoCompleteTextarea/Textarea.jsx
@@ -119,6 +119,8 @@ export class ReactTextareaAutocomplete extends React.Component {
     const trigger = this.state.currentTrigger;
 
     if (!trigger || !this.state.data) {
+      // https://legacy.reactjs.org/docs/legacy-event-pooling.html
+      event.persist();
       // trigger a submit
       await this._replaceWord();
       if (this.textareaRef) {


### PR DESCRIPTION
React 16 had a wacky thing called [event pooling](https://legacy.reactjs.org/docs/legacy-event-pooling.html). Basically you couldn't use event objects outside of the microtask in which the event handler was triggered, unless you explicitly called `event.persist()`.

When we made key down handler on message input async in https://github.com/GetStream/stream-chat-react/pull/2332, we broke this rule. So `preventDefault()` in [submit handler](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageInput/hooks/useSubmitHandler.ts#L119) became a no-op.

React still provides the `perist()` method on synthetic events, even in newer versions, so we just use it to fix the issue.