### PR TITLE
fix: prevent showing link previews in AttachmentPreviewList

### DIFF
--- a/src/components/MessageInput/AttachmentPreviewList/AttachmentPreviewList.tsx
+++ b/src/components/MessageInput/AttachmentPreviewList/AttachmentPreviewList.tsx
@@ -23,6 +23,7 @@ import {
   isLocalImageAttachment,
   isLocalMediaAttachment,
   isLocalVoiceRecordingAttachment,
+  isScrapedContent,
 } from '../../Attachment';
 import { useMessageInputContext } from '../../../context';
 
@@ -66,6 +67,7 @@ export const AttachmentPreviewList = <
         data-testid='attachment-list-scroll-container'
       >
         {attachments.map((attachment) => {
+          if (isScrapedContent(attachment)) return null;
           if (isLocalVoiceRecordingAttachment(attachment)) {
             return (
               <VoiceRecordingPreview

--- a/src/components/MessageInput/MessageInputFlat.tsx
+++ b/src/components/MessageInput/MessageInputFlat.tsx
@@ -279,9 +279,11 @@ const MessageInputV2 = <
           </div>
           <div className='str-chat__message-textarea-container'>
             {displayQuotedMessage && <QuotedMessagePreview quotedMessage={quotedMessage} />}
-            {isUploadEnabled && !!(numberOfUploads || attachments.length) && (
-              <AttachmentPreviewList />
-            )}
+            {isUploadEnabled &&
+              !!(
+                numberOfUploads ||
+                (attachments.length && attachments.length !== linkPreviews.size)
+              ) && <AttachmentPreviewList />}
 
             <div className='str-chat__message-textarea-with-emoji-picker'>
               <ChatAutoComplete />

--- a/src/components/MessageInput/__tests__/MessageInput.test.js
+++ b/src/components/MessageInput/__tests__/MessageInput.test.js
@@ -562,6 +562,17 @@ function axeNoViolations(container) {
         });
       });
 
+      // todo: adjust tests once merged PR: feat: remove legacy style components #2394
+      it.todo('should show attachment previews if at least 1 file uploaded');
+      it.todo('should show attachment previews if at least one non-scraped attachments available');
+      it.todo('should not show scraped content in attachment previews');
+      it.todo(
+        'should not show attachment previews if no files uploaded and no attachments available',
+      );
+      it.todo(
+        'should not show attachment previews if no files uploaded and attachments available are only link previews',
+      );
+
       // TODO: Check if pasting plaintext is not prevented -> tricky because recreating exact event is hard
       // TODO: Remove image/file -> difficult because there is no easy selector and components are in react-file-utils
     });


### PR DESCRIPTION
## Goal

Prevent showing link previews in AttachmentPreviewList:

<img width="546" alt="image" src="https://github.com/GetStream/stream-chat-react/assets/32706194/4d3c4b25-99e7-4a09-8f8a-9f1d87992536">


### 🛠 Implementation details

Link previews are not filtered out of `attachments` array in `MessageInput` state. Therefore:

- if there are only link previews in `attachments` and no uploads, do not show `AttachmentPreviewList`
- if there is a mix of link previews and other attachments in `attachments`, show `AttachmentPreviewList` without attachments representing link previews. The link previews are rendered with another component.

### Out of scope

Tests to cover these requirements are just drafted in todo as the whole `MessageInput.test.js` tests only v1 components. These tests will be added to #2394 (added with commit https://github.com/GetStream/stream-chat-react/pull/2394/commits/ef5e46bbb0f7075bb236171ccd5f27bb05c1fd35)
