### PR TITLE
fix: keep line breaks in message text that contains multiple markdown elements

### DIFF
--- a/src/components/Message/renderText/__tests__/__snapshots__/renderText.test.js.snap
+++ b/src/components/Message/renderText/__tests__/__snapshots__/renderText.test.js.snap
@@ -214,6 +214,30 @@ Array [
 ]
 `;
 
+exports[`keepLineBreaksPlugin present keeps line between lines with strong text 1`] = `
+Array [
+  <p>
+    This is 
+    <strong>
+      the first
+    </strong>
+     line
+  </p>,
+  "
+",
+  <br />,
+  "
+",
+  "
+",
+  "
+",
+  <p>
+    This is the second line
+  </p>,
+]
+`;
+
 exports[`keepLineBreaksPlugin present keeps line breaks around a blockquote 1`] = `
 Array [
   <p>

--- a/src/components/Message/renderText/__tests__/renderText.test.js
+++ b/src/components/Message/renderText/__tests__/renderText.test.js
@@ -277,6 +277,7 @@ describe('keepLineBreaksPlugin', () => {
   const blockquoteText = `a${lineBreaks}>b${lineBreaks}c`;
   const withStrikeThroughText = `a${lineBreaks}${strikeThroughText}${lineBreaks}b`;
   const tableText = `a${lineBreaks}| a | b  |  c |  d  |\n| - | :- | -: | :-: |\n| a | b  |  c |  d  |${lineBreaks}c`;
+  const multilineWithStrongText = 'This is **the first** line\n\nThis is the second line';
 
   const doRenderText = (text, present) => {
     const Markdown = renderText(
@@ -363,6 +364,10 @@ describe('keepLineBreaksPlugin', () => {
     });
     it(`keeps line breaks around a table`, () => {
       const tree = doRenderText(tableText, present);
+      expect(tree).toMatchSnapshot();
+    });
+    it(`keeps line between lines with strong text`, () => {
+      const tree = doRenderText(multilineWithStrongText, present);
       expect(tree).toMatchSnapshot();
     });
   });

--- a/src/components/Message/renderText/remarkPlugins/keepLineBreaksPlugin.ts
+++ b/src/components/Message/renderText/remarkPlugins/keepLineBreaksPlugin.ts
@@ -12,7 +12,7 @@ const visitor: Visitor = (node, index, parent) => {
   const prevSibling = parent.children.at(index - 1);
   if (!prevSibling?.position) return;
 
-  if (node.position.start.line === prevSibling.position.start.line) return false;
+  if (node.position.start.line === prevSibling.position.start.line) return;
   const ownStartLine = node.position.start.line;
   const prevEndLine = prevSibling.position.end.line;
 


### PR DESCRIPTION

### 🛠 Implementation details

`keepLineBreaksPlugin`'s visitor function terminated tree traversal when encountered multiple markdown elements on one line.

fix: #2409 