### PR TITLE
fix: adjust ChannelActionContextValue type

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -757,9 +757,9 @@ const ChannelInner = <
 
   const clearHighlightedMessageTimeoutId = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const jumpToMessage = useCallback(
+  const jumpToMessage: ChannelActionContextValue<StreamChatGenerics>['jumpToMessage'] = useCallback(
     async (
-      messageId: string,
+      messageId,
       messageLimit = DEFAULT_JUMP_TO_PAGE_SIZE,
       highlightDuration = DEFAULT_HIGHLIGHT_DURATION,
     ) => {
@@ -794,7 +794,7 @@ const ChannelInner = <
     [channel, loadMoreFinished],
   );
 
-  const jumpToLatestMessage = useCallback(async () => {
+  const jumpToLatestMessage: ChannelActionContextValue<StreamChatGenerics>['jumpToLatestMessage'] = useCallback(async () => {
     await channel.state.loadMessageIntoState('latest');
     // FIXME: we cannot rely on constant value 25 as the page size can be customized by integrators
     const hasMoreOlder = channel.state.messages.length >= 25;
@@ -804,7 +804,7 @@ const ChannelInner = <
     });
   }, [channel, loadMoreFinished]);
 
-  const jumpToFirstUnreadMessage = useCallback(
+  const jumpToFirstUnreadMessage: ChannelActionContextValue<StreamChatGenerics>['jumpToFirstUnreadMessage'] = useCallback(
     async (
       queryMessageLimit = DEFAULT_JUMP_TO_PAGE_SIZE,
       highlightDuration = DEFAULT_HIGHLIGHT_DURATION,

--- a/src/context/ChannelActionContext.tsx
+++ b/src/context/ChannelActionContext.tsx
@@ -68,9 +68,12 @@ export type ChannelActionContextValue<
     message: UpdatedMessage<StreamChatGenerics>,
     options?: UpdateMessageOptions,
   ) => Promise<UpdateMessageAPIResponse<StreamChatGenerics> | void>;
-  jumpToFirstUnreadMessage: (queryMessageLimit?: number) => Promise<void>;
+  jumpToFirstUnreadMessage: (
+    queryMessageLimit?: number,
+    highlightDuration?: number,
+  ) => Promise<void>;
   jumpToLatestMessage: () => Promise<void>;
-  jumpToMessage: (messageId: string, limit?: number) => Promise<void>;
+  jumpToMessage: (messageId: string, limit?: number, highlightDuration?: number) => Promise<void>;
   loadMore: (limit?: number) => Promise<number>;
   loadMoreNewer: (limit?: number) => Promise<number>;
   loadMoreThread: () => Promise<void>;


### PR DESCRIPTION
### 🎯 Goal

Adjust `ChannelActionContextValue` type to include new `highlightDuration` parameter, pair the types to the functions so that we don't forget in the future (in case we need to adjust).
