### PR TITLE
fix: adapt audio recording wave form to the available space

### DIFF
--- a/src/components/Attachment/__tests__/VoiceRecording.test.js
+++ b/src/components/Attachment/__tests__/VoiceRecording.test.js
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom';
 import { generateVoiceRecordingAttachment } from '../../../mock-builders';
 import { VoiceRecording, VoiceRecordingPlayer } from '../VoiceRecording';
 import { ChannelActionProvider } from '../../../context';
+import { ResizeObserverMock } from '../../../mock-builders/browser';
 
 const AUDIO_RECORDING_PLAYER_TEST_ID = 'voice-recording-widget';
 const QUOTED_AUDIO_RECORDING_TEST_ID = 'quoted-voice-recording-widget';
@@ -12,6 +13,10 @@ const QUOTED_AUDIO_RECORDING_TEST_ID = 'quoted-voice-recording-widget';
 const FALLBACK_TITLE = 'Voice message';
 
 const attachment = generateVoiceRecordingAttachment();
+
+window.ResizeObserver = ResizeObserverMock;
+
+jest.spyOn(HTMLDivElement.prototype, 'getBoundingClientRect').mockReturnValue({ width: 120 });
 
 const clickPlay = async () => {
   await act(async () => {

--- a/src/components/Attachment/__tests__/WaveProgressBar.test.js
+++ b/src/components/Attachment/__tests__/WaveProgressBar.test.js
@@ -35,7 +35,7 @@ describe('WaveProgressBar', () => {
   it('renders with default number of bars', () => {
     render(<WaveProgressBar seek={jest.fn()} waveformData={originalSample} />);
     const root = screen.getByTestId(BAR_ROOT_TEST_ID);
-    expect(root.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-gap')).toBe(
+    expect(root.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-gap-width')).toBe(
       '1px',
     );
     const bars = screen.getAllByTestId(AMPLITUDE_BAR_TEST_ID);
@@ -58,7 +58,7 @@ describe('WaveProgressBar', () => {
       />,
     );
     const root = screen.getByTestId(BAR_ROOT_TEST_ID);
-    expect(root.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-gap')).toBe(
+    expect(root.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-gap-width')).toBe(
       '5px',
     );
     const bars = screen.getAllByTestId(AMPLITUDE_BAR_TEST_ID);
@@ -80,7 +80,7 @@ describe('WaveProgressBar', () => {
       activeObserver.cb([{ contentRect: { width: 21 } }]);
     });
     const root = screen.getByTestId(BAR_ROOT_TEST_ID);
-    expect(root.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-gap')).toBe(
+    expect(root.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-gap-width')).toBe(
       '1px',
     );
     const bars = screen.getAllByTestId(AMPLITUDE_BAR_TEST_ID);

--- a/src/components/Attachment/__tests__/WaveProgressBar.test.js
+++ b/src/components/Attachment/__tests__/WaveProgressBar.test.js
@@ -1,25 +1,113 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { WaveProgressBar } from '../components';
+import { ResizeObserverMock } from '../../../mock-builders/browser';
 
 jest.spyOn(console, 'warn').mockImplementation();
 const originalSample = Array.from({ length: 10 }, (_, i) => i);
 
+const BAR_ROOT_TEST_ID = 'wave-progress-bar-track';
 const PROGRESS_INDICATOR_TEST_ID = 'wave-progress-bar-progress-indicator';
+const AMPLITUDE_BAR_TEST_ID = 'amplitude-bar';
+window.ResizeObserver = ResizeObserverMock;
+
+const getBoundingClientRect = jest
+  .spyOn(HTMLDivElement.prototype, 'getBoundingClientRect')
+  .mockReturnValue({ width: 120 });
 
 describe('WaveProgressBar', () => {
+  beforeEach(() => {
+    ResizeObserverMock.observers = [];
+  });
+
   it('is not rendered if waveform data is missing', () => {
     render(<WaveProgressBar seek={jest.fn()} waveformData={[]} />);
-    expect(screen.queryByTestId('wave-progress-bar-track')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(BAR_ROOT_TEST_ID)).not.toBeInTheDocument();
   });
+
+  it('is not rendered if no space available', () => {
+    getBoundingClientRect.mockReturnValueOnce({ width: 0 });
+    render(<WaveProgressBar amplitudesCount={5} seek={jest.fn()} waveformData={originalSample} />);
+    expect(screen.queryByTestId(BAR_ROOT_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('renders with default number of bars', () => {
+    render(<WaveProgressBar seek={jest.fn()} waveformData={originalSample} />);
+    const root = screen.getByTestId(BAR_ROOT_TEST_ID);
+    expect(root.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-gap')).toBe(
+      '1px',
+    );
+    const bars = screen.getAllByTestId(AMPLITUDE_BAR_TEST_ID);
+    expect(
+      bars.every(
+        (b) =>
+          b.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-width') === '2px',
+      ),
+    ).toBeTruthy();
+    expect(screen.getAllByTestId(AMPLITUDE_BAR_TEST_ID)).toHaveLength(40);
+  });
+
+  it('adjusts the number of bars and gaps based on the custom ratio', () => {
+    render(
+      <WaveProgressBar
+        relativeAmplitudeBarWidth={3}
+        relativeAmplitudeGap={5}
+        seek={jest.fn()}
+        waveformData={originalSample}
+      />,
+    );
+    const root = screen.getByTestId(BAR_ROOT_TEST_ID);
+    expect(root.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-gap')).toBe(
+      '5px',
+    );
+    const bars = screen.getAllByTestId(AMPLITUDE_BAR_TEST_ID);
+    expect(
+      bars.every(
+        (b) =>
+          b.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-width') === '3px',
+      ),
+    ).toBeTruthy();
+    expect(bars).toHaveLength(15);
+  });
+
+  it('recalculates the number of bars on root resize', async () => {
+    render(<WaveProgressBar seek={jest.fn()} waveformData={originalSample} />);
+    expect(ResizeObserverMock.observers).toHaveLength(1);
+    const activeObserver = ResizeObserver.observers[0];
+    expect(activeObserver.active).toBeTruthy();
+    await act(() => {
+      activeObserver.cb([{ contentRect: { width: 21 } }]);
+    });
+    const root = screen.getByTestId(BAR_ROOT_TEST_ID);
+    expect(root.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-gap')).toBe(
+      '1px',
+    );
+    const bars = screen.getAllByTestId(AMPLITUDE_BAR_TEST_ID);
+    expect(
+      bars.every(
+        (b) =>
+          b.style.getPropertyValue('--str-chat__voice-recording-amplitude-bar-width') === '2px',
+      ),
+    ).toBeTruthy();
+    expect(screen.getAllByTestId(AMPLITUDE_BAR_TEST_ID)).toHaveLength(7);
+  });
+
+  it('does not recalculate the number of bars on root resize if ResizeObserver is unsupported', () => {
+    window.ResizeObserver = undefined;
+    render(<WaveProgressBar seek={jest.fn()} waveformData={originalSample} />);
+    expect(ResizeObserverMock.observers).toHaveLength(0);
+    window.ResizeObserver = ResizeObserverMock;
+  });
+
   it('is rendered with zero progress by default if waveform data is available', () => {
     const { container } = render(
       <WaveProgressBar amplitudesCount={5} seek={jest.fn()} waveformData={originalSample} />,
     );
     expect(container).toMatchSnapshot();
-    expect(screen.queryByTestId(PROGRESS_INDICATOR_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(PROGRESS_INDICATOR_TEST_ID)).toBeInTheDocument();
   });
+
   it('is rendered with highlighted bars with non-zero progress', () => {
     const { container } = render(
       <WaveProgressBar

--- a/src/components/Attachment/__tests__/__snapshots__/WaveProgressBar.test.js.snap
+++ b/src/components/Attachment/__tests__/__snapshots__/WaveProgressBar.test.js.snap
@@ -6,31 +6,32 @@ exports[`WaveProgressBar is rendered with zero progress by default if waveform d
     class="str-chat__wave-progress-bar__track"
     data-testid="wave-progress-bar-track"
     role="progressbar"
+    style="--str-chat__voice-recording-amplitude-bar-gap: 8px;"
   >
     <div
       class="str-chat__wave-progress-bar__amplitude-bar"
       data-testid="amplitude-bar"
-      style="--str-chat__wave-progress-bar__amplitude-bar-height: 0%;"
+      style="--str-chat__voice-recording-amplitude-bar-width: 16px; --str-chat__wave-progress-bar__amplitude-bar-height: 0%;"
     />
     <div
       class="str-chat__wave-progress-bar__amplitude-bar"
       data-testid="amplitude-bar"
-      style="--str-chat__wave-progress-bar__amplitude-bar-height: 200%;"
+      style="--str-chat__voice-recording-amplitude-bar-width: 16px; --str-chat__wave-progress-bar__amplitude-bar-height: 200%;"
     />
     <div
       class="str-chat__wave-progress-bar__amplitude-bar"
       data-testid="amplitude-bar"
-      style="--str-chat__wave-progress-bar__amplitude-bar-height: 500%;"
+      style="--str-chat__voice-recording-amplitude-bar-width: 16px; --str-chat__wave-progress-bar__amplitude-bar-height: 500%;"
     />
     <div
       class="str-chat__wave-progress-bar__amplitude-bar"
       data-testid="amplitude-bar"
-      style="--str-chat__wave-progress-bar__amplitude-bar-height: 700%;"
+      style="--str-chat__voice-recording-amplitude-bar-width: 16px; --str-chat__wave-progress-bar__amplitude-bar-height: 700%;"
     />
     <div
       class="str-chat__wave-progress-bar__amplitude-bar"
       data-testid="amplitude-bar"
-      style="--str-chat__wave-progress-bar__amplitude-bar-height: 900%;"
+      style="--str-chat__voice-recording-amplitude-bar-width: 16px; --str-chat__wave-progress-bar__amplitude-bar-height: 900%;"
     />
     <div
       class="str-chat__wave-progress-bar__progress-indicator"

--- a/src/components/Attachment/__tests__/__snapshots__/WaveProgressBar.test.js.snap
+++ b/src/components/Attachment/__tests__/__snapshots__/WaveProgressBar.test.js.snap
@@ -6,7 +6,7 @@ exports[`WaveProgressBar is rendered with zero progress by default if waveform d
     class="str-chat__wave-progress-bar__track"
     data-testid="wave-progress-bar-track"
     role="progressbar"
-    style="--str-chat__voice-recording-amplitude-bar-gap: 8px;"
+    style="--str-chat__voice-recording-amplitude-bar-gap-width: 8px;"
   >
     <div
       class="str-chat__wave-progress-bar__amplitude-bar"

--- a/src/components/Attachment/components/WaveProgressBar.tsx
+++ b/src/components/Attachment/components/WaveProgressBar.tsx
@@ -130,7 +130,7 @@ export const WaveProgressBar = ({
       role='progressbar'
       style={
         {
-          '--str-chat__voice-recording-amplitude-bar-gap': trackAxisX?.gap + 'px',
+          '--str-chat__voice-recording-amplitude-bar-gap-width': trackAxisX?.gap + 'px',
         } as React.CSSProperties
       }
     >

--- a/src/components/MediaRecorder/AudioRecorder/__tests__/AudioRecorder.test.js
+++ b/src/components/MediaRecorder/AudioRecorder/__tests__/AudioRecorder.test.js
@@ -27,6 +27,7 @@ import {
   AudioContextMock,
   EventEmitterMock,
   MediaRecorderMock,
+  ResizeObserverMock,
 } from '../../../../mock-builders/browser';
 import { generateDataavailableEvent } from '../../../../mock-builders/browser/events/dataavailable';
 import { AudioRecorder } from '../AudioRecorder';
@@ -54,6 +55,10 @@ const DEFAULT_RENDER_PARAMS = {
   },
   componentCtx: {},
 };
+
+window.ResizeObserver = ResizeObserverMock;
+
+jest.spyOn(HTMLDivElement.prototype, 'getBoundingClientRect').mockReturnValue({ width: 120 });
 
 const renderComponent = async ({
   channelActionCtx,

--- a/src/components/MediaRecorder/AudioRecorder/__tests__/__snapshots__/AudioRecorder.test.js.snap
+++ b/src/components/MediaRecorder/AudioRecorder/__tests__/__snapshots__/AudioRecorder.test.js.snap
@@ -382,206 +382,207 @@ exports[`AudioRecorder renders audio recording stopped UI with recording preview
           class="str-chat__wave-progress-bar__track"
           data-testid="wave-progress-bar-track"
           role="progressbar"
+          style="--str-chat__voice-recording-amplitude-bar-gap: 1px;"
         >
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 31.399506330490112%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 31.399506330490112%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 24.018539488315582%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 24.018539488315582%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 18.365363776683807%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 18.365363776683807%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 59.02017951011658%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 59.02017951011658%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 26.63217782974243%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 26.63217782974243%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 62.37155795097351%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 62.37155795097351%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 82.78987407684326%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 82.78987407684326%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 15.16059935092926%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 15.16059935092926%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 47.57987558841705%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 47.57987558841705%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 62.29274868965149%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 62.29274868965149%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 55.40405511856079%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 55.40405511856079%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 85.32787561416626%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 85.32787561416626%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 57.56412744522095%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 57.56412744522095%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 83.30334424972534%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 83.30334424972534%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 75.42996406555176%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 75.42996406555176%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 46.48399353027344%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 46.48399353027344%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 77.82987952232361%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 77.82987952232361%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 62.917882204055786%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 62.917882204055786%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 71.56173586845398%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 71.56173586845398%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 7.107513397932053%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 7.107513397932053%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 14.29901123046875%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 14.29901123046875%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 14.445610344409943%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 14.445610344409943%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 95.34039497375488%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 95.34039497375488%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 48.61070513725281%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 48.61070513725281%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 62.09651231765747%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 62.09651231765747%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 8.803673088550568%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 8.803673088550568%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 49.2523193359375%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 49.2523193359375%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 3.940269351005554%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 3.940269351005554%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 77.68490314483643%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 77.68490314483643%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 18.697471916675568%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 18.697471916675568%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 4.977691546082497%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 4.977691546082497%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 5.717025697231293%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 5.717025697231293%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 4.073379561305046%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 4.073379561305046%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 14.73514586687088%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 14.73514586687088%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 94.67474222183228%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 94.67474222183228%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 54.55475449562073%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 54.55475449562073%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 81.71653747558594%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 81.71653747558594%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 61.83612942695618%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 61.83612942695618%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 81.5593957901001%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 81.5593957901001%;"
           />
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"
             data-testid="amplitude-bar"
-            style="--str-chat__wave-progress-bar__amplitude-bar-height: 89.80446457862854%;"
+            style="--str-chat__voice-recording-amplitude-bar-width: 2px; --str-chat__wave-progress-bar__amplitude-bar-height: 89.80446457862854%;"
           />
           <div
             class="str-chat__wave-progress-bar__progress-indicator"

--- a/src/components/MediaRecorder/AudioRecorder/__tests__/__snapshots__/AudioRecorder.test.js.snap
+++ b/src/components/MediaRecorder/AudioRecorder/__tests__/__snapshots__/AudioRecorder.test.js.snap
@@ -382,7 +382,7 @@ exports[`AudioRecorder renders audio recording stopped UI with recording preview
           class="str-chat__wave-progress-bar__track"
           data-testid="wave-progress-bar-track"
           role="progressbar"
-          style="--str-chat__voice-recording-amplitude-bar-gap: 1px;"
+          style="--str-chat__voice-recording-amplitude-bar-gap-width: 1px;"
         >
           <div
             class="str-chat__wave-progress-bar__amplitude-bar"

--- a/src/mock-builders/browser/ResizeObserver.js
+++ b/src/mock-builders/browser/ResizeObserver.js
@@ -1,0 +1,18 @@
+export class ResizeObserverMock {
+  static observers = [];
+
+  active = false;
+  cb;
+
+  constructor(cb) {
+    this.cb = cb;
+    ResizeObserverMock.observers.push(this);
+  }
+
+  observe = jest.fn(() => {
+    this.active = true;
+  });
+  disconnect = jest.fn(() => {
+    this.active = false;
+  });
+}

--- a/src/mock-builders/browser/index.js
+++ b/src/mock-builders/browser/index.js
@@ -2,3 +2,4 @@ export * from './AnalyserNode';
 export * from './AudioContext';
 export * from './EventEmitter';
 export * from './MediaRecorder';
+export * from './ResizeObserver';


### PR DESCRIPTION
### 🎯 Goal

Adjust the number of bars and the gap width based on the available space.

### 🛠 Implementation details

The solution uses ResizeObserver as the only way to react to size change of the root div. The `window` `resize` would be useful only to mobile device screen rotation, but not possible message list resizing if implemented by integrators.

### 🎨 UI Changes

[6Y0O.webm](https://github.com/GetStream/stream-chat-react/assets/32706194/95c7b9d1-ed52-41e2-a15c-a86e500a9241)


