### PR TITLE
fix: always load thread replies on Thread opening

### DIFF
--- a/src/components/Channel/channelState.ts
+++ b/src/components/Channel/channelState.ts
@@ -208,6 +208,7 @@ export const channelReducer = <
       return {
         ...state,
         thread: message,
+        threadHasMore: true,
         threadMessages: message.id ? { ...channel.state.threads }[message.id] || [] : [],
         threadSuppressAutoscroll: false,
       };


### PR DESCRIPTION
### 🛠 Implementation details

When switching between threads, the threadHasMore flag has to be always re-enabled.

fix #2433 
