### PR TITLE
feat: configure message group size by max time between messages

### DIFF
--- a/docusaurus/docs/React/components/core-components/message-list.mdx
+++ b/docusaurus/docs/React/components/core-components/message-list.mdx
@@ -242,9 +242,9 @@ pinned [message object](https://getstream.io/chat/docs/javascript/message_format
 
 Callback function to map each message in the list to a group style (` 'middle' | 'top' | 'bottom' | 'single'`).
 
-| Type                                                                                                                       |
-| -------------------------------------------------------------------------------------------------------------------------- |
-| (message: StreamMessage, previousMessage: StreamMessage, nextMessage: StreamMessage, noGroupByUser: boolean) => GroupStyle |
+| Type                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| (message: StreamMessage, previousMessage: StreamMessage, nextMessage: StreamMessage, noGroupByUser: boolean, maxTimeBetweenGroupedMessages?: number) => GroupStyle |
 
 ### hasMore
 
@@ -301,6 +301,14 @@ Function called when more messages are to be loaded, provide your own function t
 | Type     | Default                                                                                  |
 | -------- | ---------------------------------------------------------------------------------------- |
 | function | [ChannelActionContextValue['loadMore']](../contexts/channel-action-context.mdx#loadmore) |
+
+### maxTimeBetweenGroupedMessages
+
+Maximum time in milliseconds that should occur between messages to still consider them grouped together.
+
+| Type   |
+| ------ |
+| number |
 
 ### Message
 

--- a/docusaurus/docs/React/components/core-components/virtualized-list.mdx
+++ b/docusaurus/docs/React/components/core-components/virtualized-list.mdx
@@ -129,9 +129,9 @@ If true, disables the injection of date separator UI components.
 
 Callback function to set group styles for each message.
 
-| Type                                                                                                                       |
-| -------------------------------------------------------------------------------------------------------------------------- |
-| (message: StreamMessage, previousMessage: StreamMessage, nextMessage: StreamMessage, noGroupByUser: boolean) => GroupStyle |
+| Type                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| (message: StreamMessage, previousMessage: StreamMessage, nextMessage: StreamMessage, noGroupByUser: boolean, maxTimeBetweenGroupedMessages?: number) => GroupStyle |
 
 ### hasMore
 
@@ -172,6 +172,14 @@ Function called when more messages are to be loaded, provide your own function t
 | Type     | Default                                                                                  |
 | -------- | ---------------------------------------------------------------------------------------- |
 | function | [ChannelActionContextValue['loadMore']](../contexts/channel-action-context.mdx#loadmore) |
+
+### maxTimeBetweenGroupedMessages
+
+Maximum time in milliseconds that should occur between messages to still consider them grouped together.
+
+| Type   |
+| ------ |
+| number |
 
 ### Message
 

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -64,6 +64,7 @@ const MessageListWithContext = <
       threshold: loadMoreScrollThreshold = DEFAULT_LOAD_PAGE_SCROLL_THRESHOLD,
       ...restInternalInfiniteScrollProps
     } = {},
+    maxTimeBetweenGroupedMessages,
     messageActions = Object.keys(MESSAGE_ACTIONS),
     messages = [],
     notifications,
@@ -138,6 +139,7 @@ const MessageListWithContext = <
     headerPosition,
     hideDeletedMessages,
     hideNewMessageSeparator,
+    maxTimeBetweenGroupedMessages,
     messages,
     noGroupByUser,
     reviewProcessedMessage,
@@ -320,6 +322,7 @@ export type MessageListProps<
     previousMessage: StreamMessage<StreamChatGenerics>,
     nextMessage: StreamMessage<StreamChatGenerics>,
     noGroupByUser: boolean,
+    maxTimeBetweenGroupedMessages?: number,
   ) => GroupStyle;
   /** Whether the list has more items to load */
   hasMore?: boolean;
@@ -343,6 +346,8 @@ export type MessageListProps<
   loadMore?: ChannelActionContextValue['loadMore'] | (() => Promise<void>);
   /** Function called when newer messages are to be loaded, defaults to function stored in [ChannelActionContext](https://getstream.io/chat/docs/sdk/react/contexts/channel_action_context/) */
   loadMoreNewer?: ChannelActionContextValue['loadMoreNewer'] | (() => Promise<void>);
+  /** Maximum time in milliseconds that should occur between messages to still consider them grouped together */
+  maxTimeBetweenGroupedMessages?: number;
   /** The limit to use when paginating messages */
   messageLimit?: number;
   /** The messages to render in the list, defaults to messages stored in [ChannelStateContext](https://getstream.io/chat/docs/sdk/react/contexts/channel_state_context/) */

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -193,6 +193,7 @@ const VirtualizedMessageListWithContext = <
     loadingMore,
     loadMore,
     loadMoreNewer,
+    maxTimeBetweenGroupedMessages,
     Message: MessageUIComponentFromProps,
     messageActions,
     messageLimit = DEFAULT_NEXT_CHANNEL_PAGE_SIZE,
@@ -312,13 +313,14 @@ const VirtualizedMessageListWithContext = <
           processedMessages[i - 1],
           processedMessages[i + 1],
           !shouldGroupByUser,
+          maxTimeBetweenGroupedMessages,
         );
         if (style) acc[message.id] = style;
         return acc;
       }, {}),
     // processedMessages were incorrectly rebuilt with a new object identity at some point, hence the .length usage
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [processedMessages.length, shouldGroupByUser, groupStylesFn],
+    [maxTimeBetweenGroupedMessages, processedMessages.length, shouldGroupByUser, groupStylesFn],
   );
 
   const {
@@ -542,6 +544,7 @@ export type VirtualizedMessageListProps<
     previousMessage: StreamMessage<StreamChatGenerics>,
     nextMessage: StreamMessage<StreamChatGenerics>,
     noGroupByUser: boolean,
+    maxTimeBetweenGroupedMessages?: number,
   ) => GroupStyle;
   /** Whether or not the list has more items to load */
   hasMore?: boolean;
@@ -566,6 +569,8 @@ export type VirtualizedMessageListProps<
   loadMore?: ChannelActionContextValue['loadMore'] | (() => Promise<void>);
   /** Function called when new messages are to be loaded, defaults to function stored in [ChannelActionContext](https://getstream.io/chat/docs/sdk/react/contexts/channel_action_context/) */
   loadMoreNewer?: ChannelActionContextValue['loadMore'] | (() => Promise<void>);
+  /** Maximum time in milliseconds that should occur between messages to still consider them grouped together */
+  maxTimeBetweenGroupedMessages?: number;
   /** Custom UI component to display a message, defaults to and accepts same props as [MessageSimple](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message/MessageSimple.tsx) */
   Message?: React.ComponentType<MessageUIComponentProps<StreamChatGenerics>>;
   /** The limit to use when paginating messages */

--- a/src/components/MessageList/VirtualizedMessageListComponents.tsx
+++ b/src/components/MessageList/VirtualizedMessageListComponents.tsx
@@ -173,6 +173,8 @@ export const messageRenderer = <
     messageList[streamMessageIndex - 1];
   const maybeNextMessage: StreamMessage<StreamChatGenerics> | undefined =
     messageList[streamMessageIndex + 1];
+
+  // FIXME: firstOfGroup & endOfGroup should be derived from groupStyles which apply a more complex logic
   const firstOfGroup =
     shouldGroupByUser &&
     (message.user?.id !== maybePrevMessage?.user?.id ||

--- a/src/components/MessageList/__tests__/utils.test.js
+++ b/src/components/MessageList/__tests__/utils.test.js
@@ -541,7 +541,7 @@ describe('getGroupStyles', () => {
     expect(getGroupStyles(message, previousMessage, nextMessage, noGroupByUser)).toBe('bottom');
   });
 
-  it('marks a message as bottom when next message is created later than maxTimeBetweenGroupedMessages milliseconds', () => {
+  it('marks a message as top when next message is created later than maxTimeBetweenGroupedMessages milliseconds', () => {
     const maxTimeBetweenGroupedMessages = 10;
     expect(
       getGroupStyles(
@@ -552,6 +552,35 @@ describe('getGroupStyles', () => {
         maxTimeBetweenGroupedMessages,
       ),
     ).toBe('bottom');
+  });
+
+  it('marks a message as bottom when next message is created later than maxTimeBetweenGroupedMessages milliseconds', () => {
+    const maxTimeBetweenGroupedMessages = 10;
+    message = { ...message, created_at: new Date(12) };
+    nextMessage = { ...nextMessage, created_at: new Date(14) };
+    expect(
+      getGroupStyles(
+        message,
+        previousMessage,
+        nextMessage,
+        noGroupByUser,
+        maxTimeBetweenGroupedMessages,
+      ),
+    ).toBe('top');
+  });
+
+  it('marks a message as single when next and previous message is created later than maxTimeBetweenGroupedMessages milliseconds', () => {
+    const maxTimeBetweenGroupedMessages = 10;
+    message = { ...message, created_at: new Date(12) };
+    expect(
+      getGroupStyles(
+        message,
+        previousMessage,
+        nextMessage,
+        noGroupByUser,
+        maxTimeBetweenGroupedMessages,
+      ),
+    ).toBe('single');
   });
 
   it('marks a message as middle when next message is created earlier than maxTimeBetweenGroupedMessages milliseconds', () => {

--- a/src/components/MessageList/hooks/MessageList/useEnrichedMessages.ts
+++ b/src/components/MessageList/hooks/MessageList/useEnrichedMessages.ts
@@ -31,8 +31,10 @@ export const useEnrichedMessages = <
     previousMessage: StreamMessage<StreamChatGenerics>,
     nextMessage: StreamMessage<StreamChatGenerics>,
     noGroupByUser: boolean,
+    maxTimeBetweenGroupedMessages?: number,
   ) => GroupStyle;
   headerPosition?: number;
+  maxTimeBetweenGroupedMessages?: number;
   reviewProcessedMessage?: ProcessMessagesParams<StreamChatGenerics>['reviewProcessedMessage'];
 }) => {
   const {
@@ -42,6 +44,7 @@ export const useEnrichedMessages = <
     headerPosition,
     hideDeletedMessages,
     hideNewMessageSeparator,
+    maxTimeBetweenGroupedMessages,
     messages,
     noGroupByUser,
     reviewProcessedMessage,
@@ -80,12 +83,13 @@ export const useEnrichedMessages = <
           messagesWithDates[i - 1],
           messagesWithDates[i + 1],
           noGroupByUser,
+          maxTimeBetweenGroupedMessages,
         );
         if (style) acc[message.id] = style;
         return acc;
       }, {}),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [messagesWithDates, noGroupByUser],
+    [maxTimeBetweenGroupedMessages, messagesWithDates, noGroupByUser],
   );
 
   return { messageGroupStyles, messages: messagesWithDates };

--- a/src/components/MessageList/utils.ts
+++ b/src/components/MessageList/utils.ts
@@ -292,6 +292,7 @@ export const getGroupStyles = <
   previousMessage: StreamMessage<StreamChatGenerics>,
   nextMessage: StreamMessage<StreamChatGenerics>,
   noGroupByUser: boolean,
+  maxTimeBetweenGroupedMessages?: number,
 ): GroupStyle => {
   if (message.customType === CUSTOM_MESSAGE_TYPE.date) return '';
   if (message.customType === CUSTOM_MESSAGE_TYPE.intro) return '';
@@ -303,24 +304,29 @@ export const getGroupStyles = <
     previousMessage.customType === CUSTOM_MESSAGE_TYPE.intro ||
     previousMessage.customType === CUSTOM_MESSAGE_TYPE.date ||
     previousMessage.type === 'system' ||
+    previousMessage.type === 'error' ||
     previousMessage.attachments?.length !== 0 ||
     message.user?.id !== previousMessage.user?.id ||
-    previousMessage.type === 'error' ||
     previousMessage.deleted_at ||
     (message.reaction_groups && Object.keys(message.reaction_groups).length > 0) ||
     isMessageEdited(previousMessage);
 
   const isBottomMessage =
     !nextMessage ||
+    nextMessage.customType === CUSTOM_MESSAGE_TYPE.intro ||
     nextMessage.customType === CUSTOM_MESSAGE_TYPE.date ||
     nextMessage.type === 'system' ||
-    nextMessage.customType === CUSTOM_MESSAGE_TYPE.intro ||
+    nextMessage.type === 'error' ||
     nextMessage.attachments?.length !== 0 ||
     message.user?.id !== nextMessage.user?.id ||
-    nextMessage.type === 'error' ||
     nextMessage.deleted_at ||
     (nextMessage.reaction_groups && Object.keys(nextMessage.reaction_groups).length > 0) ||
-    isMessageEdited(message);
+    isMessageEdited(message) ||
+    (maxTimeBetweenGroupedMessages !== undefined &&
+      nextMessage.created_at &&
+      message.created_at &&
+      new Date(nextMessage.created_at).getTime() - new Date(message.created_at).getTime() >
+        maxTimeBetweenGroupedMessages);
 
   if (!isTopMessage && !isBottomMessage) {
     if (message.deleted_at || message.type === 'error') return 'single';

--- a/src/components/MessageList/utils.ts
+++ b/src/components/MessageList/utils.ts
@@ -309,7 +309,12 @@ export const getGroupStyles = <
     message.user?.id !== previousMessage.user?.id ||
     previousMessage.deleted_at ||
     (message.reaction_groups && Object.keys(message.reaction_groups).length > 0) ||
-    isMessageEdited(previousMessage);
+    isMessageEdited(previousMessage) ||
+    (maxTimeBetweenGroupedMessages !== undefined &&
+      previousMessage.created_at &&
+      message.created_at &&
+      new Date(message.created_at).getTime() - new Date(previousMessage.created_at).getTime() >
+        maxTimeBetweenGroupedMessages);
 
   const isBottomMessage =
     !nextMessage ||


### PR DESCRIPTION
### 🎯 Goal

The goal is the parity with RN Chat SDK.

### 🛠 Implementation details

If the value of `maxTimeBetweenGroupedMessages` is greater then the difference btw the current and next message creation date, the groupd is considered to end with the current message. Effectively, what happens is that the message is applied  a class `str-chat__li--bottom`. The visual result is reflected in `MessageList` (each message has timestamp and author (metadata) shown) but not in `VirtualizedMessageList` which has additional logic that decides whether a group ends at a given message. This should be synced with the `MessageList` but potentially introducing breaking changes to the integrators using `VirtualizedMessageList` :it_is_what_it_is_emoji.
