### PR TITLE
feat: remove default timestamp formatting props from DateSeparator, EventComponent, MessageTimestamp

### DIFF
--- a/docusaurus/docs/React/guides/date-time-formatting.mdx
+++ b/docusaurus/docs/React/guides/date-time-formatting.mdx
@@ -18,7 +18,7 @@ The following components provided by the SDK display datetime:
 
 The datetime format customization can be done on multiple levels:
 
-1. Override the default component prop values
+1. Component prop values
 2. Supply custom formatting function
 3. Format date via i18n
 
@@ -29,11 +29,11 @@ All the mentioned components accept timestamp formatter props:
 ```ts
 export type TimestampFormatterOptions = {
   /* If true, call the `Day.js` calendar function to get the date string to display (e.g. "Yesterday at 3:58 PM"). */
-  calendar?: boolean | null;
+  calendar?: boolean;
   /* Object specifying date display formats for dates formatted with calendar extension. Active only if calendar prop enabled. */
-  calendarFormats?: Record<string, string> | null;
+  calendarFormats?: Record<string, string>;
   /* Overrides the default timestamp format if calendar is disabled. */
-  format?: string | null;
+  format?: string;
 };
 ```
 
@@ -54,7 +54,7 @@ If calendar formatting is enabled, the dates are formatted with time-relative wo
 If any of the `calendarFormats` keys are missing, then the underlying library will fall back to hard-coded english equivalents
 :::
 
-If `calendar` formatting is enabled, the `format` prop would be ignored. So to apply the `format` string, the `calendar` has to be disabled (applies to `DateSeparator` and `MessageTimestamp`.
+If `calendar` formatting is enabled, the `format` prop would be ignored. So to apply the `format` string, the `calendar` has to be disabled (applies to `DateSeparator` and `MessageTimestamp`).
 
 All the components can be overridden through `Channel` component context:
 
@@ -117,44 +117,32 @@ Until now, the datetime values could be customized within the `Channel` componen
 
 The default datetime formatting configuration is stored in the JSON translation files. The default translation keys are namespaced with prefix `timestamp/` followed by the component name. For example, the message date formatting can be targeted via `timestamp/MessageTimestamp`, because the underlying component is called `MessageTimestamp`.
 
-##### Overriding the prop defaults
-
-The default date and time rendering components in the SDK were created with default prop values that override the configuration parameters provided over JSON translations. Therefore, if we wanted to configure the formatting from JSON translation files, we need to nullify the prop defaults first. An example follows:
+You can change the default configuration by passing an object to `translationsForLanguage` `Streami18n` option with all or some of the relevant translation keys:
 
 ```tsx
-import {
-  DateSeparatorProps,
-  DateSeparator,
-  EventComponentProps,
-  EventComponent,
-  MessageTimestampProps,
-  MessageTimestamp,
-} from 'stream-chat-react';
+import { Chat, Streami18n } from 'stream-chat-react';
 
-const CustomDateSeparator = (props: DateSeparatorProps) => (
-  <DateSeparator {...props} calendar={null} /> // calendarFormats, neither format have default value
-);
+const i18n = new Streami18n({
+  language: 'de',
+  translationsForLanguage: {
+    'timestamp/DateSeparator': '{{ timestamp | timestampFormatter(calendar: false) }}',
+    'timestamp/MessageTimestamp':
+      '{{ timestamp | timestampFormatter(calendar: true; calendarFormats: {"lastDay": "[gestern um] LT", "lastWeek": "[letzten] dddd [um] LT", "nextDay": "[morgen um] LT", "nextWeek": "dddd [um] LT", "sameDay": "[heute um] LT", "sameElse": "L"}) }}',
+  },
+});
 
-const SystemMessage = (props: EventComponentProps) => (
-  <EventComponent {...props} format={null} /> // calendar  neither calendarFormats have default value
-);
-
-const CustomMessageTimestamp = (props: MessageTimestampProps) => (
-  <MessageTimestamp {...props} calendar={null} format={null} /> // calendarFormats do not have default value
-);
-```
-
-Now we can apply custom configuration in all the translation JSON files. It could look similar to the following key-value pair example.
-
-```json
-{
-  "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: YYYY) }}"
-}
+const ChatApp = ({ chatClient, children }) => {
+  return (
+    <Chat client={chatClient} i18nInstance={i18n}>
+      {children}
+    </Chat>
+  );
+};
 ```
 
 ##### Understanding the formatting syntax
 
-Once the default prop values are nullified, we override the default formatting rules in the JSON translation value. We can take a look at an example of German translation for SystemMessage:
+Once the default prop values are nullified, we override the default formatting rules. We can take a look at an example of German translation for SystemMessage (below a JSON example - note the escaped quotes):
 
 ```
 "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(calendar: true; calendarFormats: {\"lastDay\": \"[gestern um] LT\", \"lastWeek\": \"[letzten] dddd [um] LT\", \"nextDay\": \"[morgen um] LT\", \"nextWeek\": \"dddd [um] LT\", \"sameDay\": \"[heute um] LT\", \"sameElse\": \"L\"}) }}",
@@ -166,7 +154,7 @@ Let's dissect the example:
 - variable `timestamp` is the name of variable which value will be inserted into the string
 - value separator `|` signals the separation between the interpolated value and the formatting function name
 - `timestampFormatter` is the name of the formatting function that is used to convert the `timestamp` value into desired format
-- the `timestampFormatter` can be passed the same parameters as the React components (`calendar`, `calendarFormats`, `format`) as if the function was called with these values. The values can be simple scalar values as well as objects (note `calendarFormats` should be an object)
+- the `timestampFormatter` can be passed the same parameters as the React components (`calendar`, `calendarFormats`, `format`) as if the function was called with these values. The values can be simple scalar values as well as objects (note `calendarFormats` should be an object). The params should be separated by semicolon `;`.
 
 :::note
 The described rules follow the formatting rules required by the i18n library used under the hood - `i18next`. You can learn more about the rules in [the formatting section of the `i18next` documentation](https://www.i18next.com/translation-function/formatting#basic-usage).

--- a/docusaurus/docs/React/release-guides/upgrade-to-v12.mdx
+++ b/docusaurus/docs/React/release-guides/upgrade-to-v12.mdx
@@ -4,6 +4,21 @@ title: Upgrade to v12
 keywords: [migration guide, upgrade, v12, breaking changes]
 ---
 
+## Date & time formatting
+
+The components that display date and time are:
+
+- `DateSeparator` - separates message groups in message lists
+- `EventComponent` - displays system messages
+- `MessageTimestamp` - displays the creation timestamp for a message in a message list
+
+These components had previously default values for props like `format` or `calendar`. This setup required for a custom formatting to be set up via i18n service, the default values had to be nullified. For a better developer experience we decided to remove the default prop values and rely on default configuration provided via i18n translations. The value `null` is not a valid value for `format`, `calendar` or `calendarFormats` props.
+
+:::important
+**Action required**<br/>
+If you are not using the default translations provided with the SDK, make sure to follow the [date & time formatting guide](../guides/date-time-formatting) to verify that your dates are formatted according to your needs.
+:::
+
 ## Avatar changes
 
 The `Avatar` styles are applied through CSS from the version 12 upwards. Therefore, the following changes were applied:

--- a/src/components/DateSeparator/DateSeparator.tsx
+++ b/src/components/DateSeparator/DateSeparator.tsx
@@ -16,7 +16,7 @@ export type DateSeparatorProps = TimestampFormatterOptions & {
 
 const UnMemoizedDateSeparator = (props: DateSeparatorProps) => {
   const {
-    calendar = true,
+    calendar,
     date: messageCreatedAt,
     formatDate,
     position = 'right',

--- a/src/components/EventComponent/EventComponent.tsx
+++ b/src/components/EventComponent/EventComponent.tsx
@@ -26,7 +26,7 @@ const UnMemoizedEventComponent = <
 >(
   props: EventComponentProps<StreamChatGenerics>,
 ) => {
-  const { calendar, calendarFormats, format = 'dddd L', Avatar = DefaultAvatar, message } = props;
+  const { calendar, calendarFormats, format, Avatar = DefaultAvatar, message } = props;
 
   const { t, tDateTimeParser } = useTranslationContext('EventComponent');
   const { created_at = '', event, text, type } = message;

--- a/src/components/EventComponent/__tests__/EventComponent.test.js
+++ b/src/components/EventComponent/__tests__/EventComponent.test.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { cleanup } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { EventComponent } from '../EventComponent';
+import { Chat } from '../../Chat';
+import { getTestClient } from '../../../mock-builders';
+import { Streami18n } from '../../../i18n';
+
+const SYSTEM_MSG_TEST_ID = 'message-system';
 
 jest.mock('../../Avatar', () => ({
   Avatar: jest.fn(({ image = '', name = '' }) => (
@@ -14,46 +19,161 @@ jest.mock('../../Avatar', () => ({
 describe('EventComponent', () => {
   afterEach(cleanup);
 
+  const message = {
+    created_at: new Date('2020-03-13T10:18:38.148025Z'),
+    type: 'system',
+  };
+
+  const renderComponent = async ({ chatProps, props } = {}) => {
+    let result;
+    await act(() => {
+      result = render(
+        <Chat client={getTestClient()} {...chatProps}>
+          <EventComponent message={message} {...props} />
+        </Chat>,
+      );
+    });
+    return result;
+  };
+
   it('should render null for empty message', () => {
     const tree = renderer.create(<EventComponent message={{}} />).toJSON();
     expect(tree).toMatchInlineSnapshot(`null`);
   });
 
-  it('should render system events', () => {
-    const message = {
-      created_at: '2020-03-13T10:18:38.148025Z',
-      text: 'system event',
-      type: 'system',
-    };
-
-    const tree = renderer.create(<EventComponent message={message} />).toJSON();
-    expect(tree).toMatchInlineSnapshot(`
-      <div
-        className="str-chat__message--system"
-        data-testid="message-system"
-      >
+  it('should render system events', async () => {
+    const { container } = await renderComponent({
+      props: { message: { ...message, text: 'system event' } },
+    });
+    expect(container).toMatchInlineSnapshot(`
+      <div>
         <div
-          className="str-chat__message--system__text"
+          class="str-chat__message--system"
+          data-testid="message-system"
         >
           <div
-            className="str-chat__message--system__line"
-          />
-          <p>
-            system event
-          </p>
+            class="str-chat__message--system__text"
+          >
+            <div
+              class="str-chat__message--system__line"
+            />
+            <p>
+              system event
+            </p>
+            <div
+              class="str-chat__message--system__line"
+            />
+          </div>
           <div
-            className="str-chat__message--system__line"
-          />
-        </div>
-        <div
-          className="str-chat__message--system__date"
-        >
-          <strong>
-            Friday 03/13/2020
-          </strong>
+            class="str-chat__message--system__date"
+          >
+            <strong>
+              Friday 03/13/2020
+            </strong>
+          </div>
         </div>
       </div>
     `);
+  });
+
+  describe('timestamp formatting', () => {
+    it('should format date with default formatting rules provided by i18n service', async () => {
+      await renderComponent();
+      expect(screen.getByTestId(SYSTEM_MSG_TEST_ID)).toHaveTextContent('Friday 03/13/2020');
+    });
+
+    it('should format date with custom formatting rules provided by i18n service', async () => {
+      await renderComponent({
+        chatProps: {
+          i18nInstance: new Streami18n({
+            translationsForLanguage: {
+              'timestamp/SystemMessage': '{{ timestamp | timestampFormatter(format: "YYYY") }}',
+            },
+          }),
+        },
+      });
+      expect(screen.getByTestId(SYSTEM_MSG_TEST_ID)).toHaveTextContent('2020');
+    });
+
+    it('should combine the custom date formatting rules from i18n service with custom formatting props', async () => {
+      await renderComponent({
+        chatProps: {
+          i18nInstance: new Streami18n({
+            translationsForLanguage: {
+              'timestamp/SystemMessage': '{{ timestamp | timestampFormatter(calendar: true) }}',
+            },
+          }),
+        },
+        props: {
+          calendarFormats: {
+            lastDay: 'A YYYY',
+            lastWeek: 'B YYYY',
+            nextDay: 'C YYYY',
+            nextWeek: 'D YYYY',
+            sameDay: 'E YYYY',
+            sameElse: 'F YYYY',
+          },
+        },
+      });
+      expect(screen.getByTestId(SYSTEM_MSG_TEST_ID)).toHaveTextContent('F 2020');
+    });
+
+    it('should override the default date formatting rules from i18n service with custom formatting props', async () => {
+      await renderComponent({
+        props: {
+          calendar: true,
+          calendarFormats: {
+            lastDay: 'A YYYY',
+            lastWeek: 'B YYYY',
+            nextDay: 'C YYYY',
+            nextWeek: 'D YYYY',
+            sameDay: 'E YYYY',
+            sameElse: 'F YYYY',
+          },
+        },
+      });
+      expect(screen.getByTestId(SYSTEM_MSG_TEST_ID)).toHaveTextContent('F 2020');
+    });
+
+    it('should override the custom date formatting rules from i18n service with custom formatting props', async () => {
+      await renderComponent({
+        chatProps: {
+          i18nInstance: new Streami18n({
+            translationsForLanguage: {
+              'timestamp/SystemMessage': '{{ timestamp | timestampFormatter(calendar: false) }}',
+            },
+          }),
+        },
+        props: {
+          calendar: true,
+          calendarFormats: {
+            lastDay: 'A YYYY',
+            lastWeek: 'B YYYY',
+            nextDay: 'C YYYY',
+            nextWeek: 'D YYYY',
+            sameDay: 'E YYYY',
+            sameElse: 'F YYYY',
+          },
+        },
+      });
+      expect(screen.getByTestId(SYSTEM_MSG_TEST_ID)).toHaveTextContent('F 2020');
+    });
+
+    it('ignores calendarFormats if calendar is not enabled', async () => {
+      await renderComponent({
+        props: {
+          calendarFormats: {
+            lastDay: 'A YYYY',
+            lastWeek: 'B YYYY',
+            nextDay: 'C YYYY',
+            nextWeek: 'D YYYY',
+            sameDay: 'E YYYY',
+            sameElse: 'F YYYY',
+          },
+        },
+      });
+      expect(screen.getByTestId(SYSTEM_MSG_TEST_ID)).toHaveTextContent('Friday 03/13/2020');
+    });
   });
 
   describe('Channel events', () => {

--- a/src/components/Message/MessageSimple.tsx
+++ b/src/components/Message/MessageSimple.tsx
@@ -218,7 +218,7 @@ const MessageSimpleWithContext = <
                   {message.user.name || message.user.id}
                 </span>
               )}
-              <MessageTimestamp calendar customClass='str-chat__message-simple-timestamp' />
+              <MessageTimestamp customClass='str-chat__message-simple-timestamp' />
               {isEdited && (
                 <span className='str-chat__mesage-simple-edited'>{t<string>('Edited')}</span>
               )}

--- a/src/components/Message/MessageTimestamp.tsx
+++ b/src/components/Message/MessageTimestamp.tsx
@@ -7,8 +7,6 @@ import type { StreamMessage } from '../../context/ChannelStateContext';
 import type { DefaultStreamChatGenerics } from '../../types/types';
 import type { TimestampFormatterOptions } from '../../i18n/utils';
 
-export const defaultTimestampFormat = 'h:mmA';
-
 export type MessageTimestampProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = TimestampFormatterOptions & {

--- a/src/components/Message/Timestamp.tsx
+++ b/src/components/Message/Timestamp.tsx
@@ -11,16 +11,8 @@ export interface TimestampProps extends TimestampFormatterOptions {
   timestamp?: Date | string;
 }
 
-export const defaultTimestampFormat = 'h:mmA';
-
 export function Timestamp(props: TimestampProps) {
-  const {
-    calendar,
-    calendarFormats,
-    customClass,
-    format = defaultTimestampFormat,
-    timestamp,
-  } = props;
+  const { calendar, calendarFormats, customClass, format, timestamp } = props;
 
   const { formatDate } = useMessageContext('MessageTimestamp');
   const { t, tDateTimeParser } = useTranslationContext('MessageTimestamp');

--- a/src/components/Message/__tests__/MessageTimestamp.test.js
+++ b/src/components/Message/__tests__/MessageTimestamp.test.js
@@ -1,38 +1,94 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import renderer from 'react-test-renderer';
-import { cleanup, render } from '@testing-library/react';
+import { act, cleanup, render } from '@testing-library/react';
 import { generateMessage } from 'mock-builders';
 import { MessageTimestamp } from '../MessageTimestamp';
-import { MessageProvider, TranslationContext } from '../../../context';
+import { ComponentProvider, MessageProvider, TranslationContext } from '../../../context';
 import Dayjs from 'dayjs';
 import calendar from 'dayjs/plugin/calendar';
 import { notValidDateWarning } from '../../../i18n/utils';
+import { Chat } from '../../Chat';
+import { getTestClient } from '../../../mock-builders';
+import { Streami18n } from '../../../i18n';
 
 Dayjs.extend(calendar);
 
+const calendarFormats = {
+  lastDay: 'A YYYY',
+  lastWeek: 'B YYYY',
+  nextDay: 'C YYYY',
+  nextWeek: 'D YYYY',
+  sameDay: 'E YYYY',
+  sameElse: 'F YYYY',
+};
+
+const dateMock = 'the date';
+const formatDate = () => dateMock;
+
 const messageMock = generateMessage({
-  created_at: Dayjs(new Date('2019-04-03T14:42:47.087869Z')),
+  created_at: new Date('2019-04-03T14:42:47.087869Z'),
 });
+
+const renderComponent = async ({ chatProps, componentCtx, messageCtx, props } = {}) => {
+  let result;
+  await act(() => {
+    result = render(
+      <Chat client={getTestClient()} {...chatProps}>
+        <ComponentProvider value={componentCtx || {}}>
+          <MessageProvider value={{ message: messageMock, ...messageCtx }}>
+            <MessageTimestamp {...props} />
+          </MessageProvider>
+        </ComponentProvider>
+      </Chat>,
+    );
+  });
+  return result;
+};
+
 describe('<MessageTimestamp />', () => {
   afterEach(cleanup);
 
-  it('should render correctly', () => {
-    const tree = renderer
-      .create(
-        <MessageProvider value={{}}>
-          <MessageTimestamp message={messageMock} />
-        </MessageProvider>,
-      )
-      .toJSON();
-    expect(tree).toMatchInlineSnapshot(`
-      <time
-        dateTime={"2019-04-03T14:42:47.087Z"}
-        title={"2019-04-03T14:42:47.087Z"}
-      >
-        2:42PM
-      </time>
+  it('should render correctly', async () => {
+    const { container } = await renderComponent();
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <time
+          datetime="2019-04-03T14:42:47.087Z"
+          title="2019-04-03T14:42:47.087Z"
+        >
+          04/03/2019
+        </time>
+      </div>
     `);
+  });
+
+  it('should render non-Date timestamp value in datetime attribute without processing', async () => {
+    const { container } = await renderComponent({
+      messageCtx: { message: { ...messageMock, created_at: 28 } },
+    });
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <time
+          datetime="28"
+          title="28"
+        >
+          01/01/1970
+        </time>
+      </div>
+    `);
+  });
+
+  it('should prefer message passed through props over the context message', async () => {
+    const oneYearMs = 366 * 24 * 60 * 60 * 1000;
+    const { container } = await renderComponent({
+      props: {
+        message: {
+          ...messageMock,
+          created_at: new Date(messageMock.created_at.getTime() + oneYearMs),
+        },
+      },
+    });
+    expect(container).toHaveTextContent('04/03/2020');
   });
 
   it('should not render if no message is available', () => {
@@ -58,30 +114,87 @@ describe('<MessageTimestamp />', () => {
     expect(console.warn).toHaveBeenCalledWith(notValidDateWarning);
   });
 
-  it('should render message with custom datetime format if one is set', () => {
-    const format = 'LT';
-    const { queryByText } = render(
-      <MessageProvider value={{}}>
-        <MessageTimestamp format={format} message={messageMock} />
-      </MessageProvider>,
-    );
-    expect(queryByText('2:42 PM')).toBeInTheDocument();
+  it('should render with no format if provided i18n config disables formatting', async () => {
+    const { container } = await renderComponent({
+      chatProps: {
+        i18nInstance: new Streami18n({
+          translationsForLanguage: {
+            'timestamp/MessageTimestamp': '{{ timestamp | timestampFormatter(calendar: false) }}',
+          },
+        }),
+      },
+    });
+    expect(container).toHaveTextContent('2019-04-03T14:42:47+00:00');
   });
 
-  it('should render in calendar format if calendar is set to true', () => {
-    const calendarDateTimeParser = { calendar: jest.fn(), isSame: true };
-    render(
-      <TranslationContext.Provider
-        value={{
-          tDateTimeParser: () => calendarDateTimeParser,
-        }}
-      >
-        <MessageProvider value={{}}>
-          <MessageTimestamp calendar message={messageMock} />
-        </MessageProvider>
-      </TranslationContext.Provider>,
-    );
-    expect(calendarDateTimeParser.calendar).toHaveBeenCalledTimes(1);
+  it('should render with custom format provided via i18n service', async () => {
+    const { container } = await renderComponent({
+      chatProps: {
+        i18nInstance: new Streami18n({
+          translationsForLanguage: {
+            'timestamp/MessageTimestamp': '{{ timestamp | timestampFormatter(format: h:mmA) }}',
+          },
+        }),
+      },
+    });
+    expect(container).toHaveTextContent('2:42PM');
+  });
+
+  it('should override the default format provided via i18n service with component props', async () => {
+    const { container } = await renderComponent({
+      props: { format: 'YYYY' },
+    });
+    expect(container).toHaveTextContent(messageMock.created_at.getFullYear().toString());
+  });
+
+  it('should override the custom format provided via i18n service with component props', async () => {
+    const { container } = await renderComponent({
+      chatProps: {
+        i18nInstance: new Streami18n({
+          translationsForLanguage: {
+            'timestamp/MessageTimestamp': '{{ timestamp | timestampFormatter(format: h:mmA) }}',
+          },
+        }),
+      },
+      props: { format: 'YYYY' },
+    });
+    expect(container).toHaveTextContent(messageMock.created_at.getFullYear().toString());
+  });
+
+  it('should ignore the custom calendarFormats if calendar is disabled', async () => {
+    const { container } = await renderComponent({
+      chatProps: {
+        i18nInstance: new Streami18n({
+          translationsForLanguage: {
+            'timestamp/MessageTimestamp': '{{ timestamp | timestampFormatter(calendar: false) }}',
+          },
+        }),
+      },
+      props: { calendarFormats },
+    });
+    expect(container).toHaveTextContent('2019-04-03T14:42:47+00:00');
+  });
+
+  it('should reflect the custom calendarFormats if calendar is enabled', async () => {
+    const { container } = await renderComponent({
+      props: { calendarFormats },
+    });
+    expect(container).toHaveTextContent('F 2019');
+  });
+
+  it('should apply custom formatDate function over custom component props & over custom i18n config', async () => {
+    const { container } = await renderComponent({
+      chatProps: {
+        i18nInstance: new Streami18n({
+          translationsForLanguage: {
+            'timestamp/MessageTimestamp': '{{ timestamp | timestampFormatter(format: h:mmA) }}',
+          },
+        }),
+      },
+      messageCtx: { formatDate },
+      props: { format: 'YYYY' },
+    });
+    expect(container).toHaveTextContent(dateMock);
   });
 
   it('should not render if called in calendar mode but no calendar function is available from the datetime parser', () => {
@@ -99,23 +212,19 @@ describe('<MessageTimestamp />', () => {
     expect(container.children).toHaveLength(0);
   });
 
-  it('should render message with a custom css class when one is set', () => {
-    const customCssClass = 'custom-css-class';
-    const tree = renderer
-      .create(
-        <MessageProvider value={{}}>
-          <MessageTimestamp customClass={customCssClass} message={messageMock} />
-        </MessageProvider>,
-      )
-      .toJSON();
-    expect(tree).toMatchInlineSnapshot(`
-      <time
-        className="custom-css-class"
-        dateTime={"2019-04-03T14:42:47.087Z"}
-        title={"2019-04-03T14:42:47.087Z"}
-      >
-        2:42PM
-      </time>
+  it('should render message with a custom css class when one is set', async () => {
+    const customClass = 'custom-css-class';
+    const { container } = await renderComponent({ props: { customClass } });
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <time
+          class="custom-css-class"
+          datetime="2019-04-03T14:42:47.087Z"
+          title="2019-04-03T14:42:47.087Z"
+        >
+          04/03/2019
+        </time>
+      </div>
     `);
   });
 });

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -124,7 +124,7 @@
   "searchResultsCount_other": "{{ count }} Ergebnisse",
   "this content could not be displayed": "Dieser Inhalt konnte nicht angezeigt werden",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unban-command-args": "[@Benutzername]",
   "unban-command-description": "Einen Benutzer entbannen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -118,7 +118,7 @@
   "searchResultsCount_other": "{{ count }} results",
   "this content could not be displayed": "this content could not be displayed",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unreadMessagesSeparatorText_one": "1 unread message",
   "unreadMessagesSeparatorText_other": "{{count}} unread messages",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -126,7 +126,7 @@
   "searchResultsCount_other": "{{ count }} resultados",
   "this content could not be displayed": "este contenido no se pudo mostrar",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unban-command-args": "[@usuario]",
   "unban-command-description": "Quitar la prohibición a un usuario",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -126,7 +126,7 @@
   "searchResultsCount_other": "{{ count }} résultats",
   "this content could not be displayed": "ce contenu n'a pu être affiché",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unban-command-args": "[@nomdutilisateur]",
   "unban-command-description": "Débannir un utilisateur",

--- a/src/i18n/hi.json
+++ b/src/i18n/hi.json
@@ -125,7 +125,7 @@
   "searchResultsCount_other": "{{ count }} परिणाम",
   "this content could not be displayed": "यह कॉन्टेंट लोड नहीं हो पाया",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unban-command-args": "[@उपयोगकर्तनाम]",
   "unban-command-description": "एक उपयोगकर्ता को प्रतिषेध से मुक्त करें",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -126,7 +126,7 @@
   "searchResultsCount_other": "{{ count }} risultati",
   "this content could not be displayed": "questo contenuto non puó essere mostrato",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unban-command-args": "[@nomeutente]",
   "unban-command-description": "Togliere il divieto a un utente",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -124,7 +124,7 @@
   "searchResultsCount_other": "{{ count }}件の結果",
   "this content could not be displayed": "このコンテンツは表示できませんでした",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unban-command-args": "[@ユーザ名]",
   "unban-command-description": "ユーザーの禁止を解除する",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -124,7 +124,7 @@
   "searchResultsCount_other": "{{ count }}개 결과",
   "this content could not be displayed": "이 콘텐츠를 표시할 수 없습니다",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unban-command-args": "[@사용자이름]",
   "unban-command-description": "사용자 차단 해제",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -124,7 +124,7 @@
   "searchResultsCount_other": "{{ count }} resultaten",
   "this content could not be displayed": "Deze inhoud kan niet weergegeven worden",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unban-command-args": "[@gebruikersnaam]",
   "unban-command-description": "Een gebruiker debannen",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -126,7 +126,7 @@
   "searchResultsCount_other": "{{ count }} resultados",
   "this content could not be displayed": "este conteúdo não pôde ser exibido",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unban-command-args": "[@nomedeusuário]",
   "unban-command-description": "Desbanir um usuário",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -128,7 +128,7 @@
   "searchResultsCount_other": "{{ count }} результатов",
   "this content could not be displayed": "Этот контент не может быть отображен в данный момент",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unban-command-args": "[@имяпользователя]",
   "unban-command-description": "Разблокировать пользователя",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -124,7 +124,7 @@
   "searchResultsCount_other": "{{ count }} sonuç",
   "this content could not be displayed": "bu içerik gösterilemiyor",
   "timestamp/DateSeparator": "{{ timestamp | timestampFormatter(calendar: true) }}",
-  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true; format: h:mmA) }}",
+  "timestamp/MessageTimestamp": "{{ timestamp | timestampFormatter(calendar: true) }}",
   "timestamp/SystemMessage": "{{ timestamp | timestampFormatter(format: dddd L) }}",
   "unban-command-args": "[@kullanıcıadı]",
   "unban-command-description": "Bir kullanıcının yasağını kaldır",

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -11,11 +11,11 @@ import type { Streami18n } from './Streami18n';
 
 export type TimestampFormatterOptions = {
   /* If true, call the `Day.js` calendar function to get the date string to display (e.g. "Yesterday at 3:58 PM"). */
-  calendar?: boolean | null;
+  calendar?: boolean;
   /* Object specifying date display formats for dates formatted with calendar extension. Active only if calendar prop enabled. */
-  calendarFormats?: Record<string, string> | null;
+  calendarFormats?: Record<string, string>;
   /* Overrides the default timestamp format if calendar is disabled. */
-  format?: string | null;
+  format?: string;
 };
 
 type DateFormatterOptions = TimestampFormatterOptions & {


### PR DESCRIPTION
### 🎯 Goal

Provide a betted DX for those that want to override the defaults via i18n. This way there is no need to nullify the default component prop values. Based on direct customer feedback.


BREAKING CHANGE: Removed default values for timestamp formatting props like calendar or format for DateSeparator, EventComponent, MessageTimestamp. The formatting configuration now entirely relies on i18n translations.