### PR TITLE
fix: start audio recorder timer if already recording

### DIFF
--- a/src/components/MediaRecorder/AudioRecorder/AudioRecordingInProgress.tsx
+++ b/src/components/MediaRecorder/AudioRecorder/AudioRecordingInProgress.tsx
@@ -52,8 +52,12 @@ export const AudioRecordingInProgress = () => {
 
   useEffect(() => {
     if (!recorder?.mediaRecorder) return;
-
     const { mediaRecorder } = recorder;
+
+    if (mediaRecorder.state === 'recording') {
+      startCounter();
+    }
+
     mediaRecorder.addEventListener('start', startCounter);
     mediaRecorder.addEventListener('resume', startCounter);
     mediaRecorder.addEventListener('stop', stopCounter);

--- a/src/components/MessageInput/hooks/useTimeElapsed.ts
+++ b/src/components/MessageInput/hooks/useTimeElapsed.ts
@@ -10,6 +10,7 @@ export const useTimeElapsed = ({ startOnMount }: UseTimeElapsedParams = {}) => {
   const updateInterval = useRef<ReturnType<typeof setInterval>>();
 
   const startCounter = useCallback(() => {
+    if (updateInterval.current) return;
     updateInterval.current = setInterval(() => {
       setSecondsElapsed((prev) => prev + 1);
     }, 1000);
@@ -17,17 +18,16 @@ export const useTimeElapsed = ({ startOnMount }: UseTimeElapsedParams = {}) => {
 
   const stopCounter = useCallback(() => {
     clearInterval(updateInterval.current);
+    updateInterval.current = undefined;
   }, []);
 
   useEffect(() => {
     if (!startOnMount) return;
-    updateInterval.current = setInterval(() => {
-      setSecondsElapsed((prev) => prev + 1);
-    }, 1000);
+    startCounter();
     return () => {
       stopCounter();
     };
-  }, [startOnMount, stopCounter]);
+  }, [startCounter, startOnMount, stopCounter]);
 
   return {
     secondsElapsed,


### PR DESCRIPTION
### 🎯 Goal

`MediaRecorder` is already in `"recording"` state when `AudioRecordingInProgress` component is rendered on iOS.

fix #2452
