### PR TITLE
docs: remove EmojiPicker remnants

### DIFF
--- a/docusaurus/docs/React/components/contexts/message-input-context.mdx
+++ b/docusaurus/docs/React/components/contexts/message-input-context.mdx
@@ -69,22 +69,6 @@ Function to manually close the list of supported slash commands.
 | ---------- |
 | () => void |
 
-### closeEmojiPicker
-
-Function to close the `EmojiPicker` component.
-
-| Type                                        |
-| ------------------------------------------- |
-| React.MouseEventHandler<HTMLButtonElement\> |
-
-### closeEmojiPickerOnClick
-
-If true, picking an emoji from the `EmojiPicker` component will close the picker.
-
-| Type    |
-| ------- |
-| boolean |
-
 ### closeMentionsList
 
 Function to manually close the list of potential users to mention.

--- a/docusaurus/docs/React/components/message-input-components/message-input.mdx
+++ b/docusaurus/docs/React/components/message-input-components/message-input.mdx
@@ -51,14 +51,6 @@ Function to clear the editing state while editing a message.
 | ---------- |
 | () => void |
 
-### closeEmojiPickerOnClick
-
-If true, picking an emoji from the `EmojiPicker` component will close the picker.
-
-| Type    | Default |
-| ------- | ------- |
-| boolean | false   |
-
 ### disabled
 
 If true, disables the text input.

--- a/docusaurus/react_versioned_docs/version-11.x.x/components/contexts/message-input-context.mdx
+++ b/docusaurus/react_versioned_docs/version-11.x.x/components/contexts/message-input-context.mdx
@@ -69,22 +69,6 @@ Function to manually close the list of supported slash commands.
 | ---------- |
 | () => void |
 
-### closeEmojiPicker
-
-Function to close the `EmojiPicker` component.
-
-| Type                                        |
-| ------------------------------------------- |
-| React.MouseEventHandler<HTMLButtonElement\> |
-
-### closeEmojiPickerOnClick
-
-If true, picking an emoji from the `EmojiPicker` component will close the picker.
-
-| Type    |
-| ------- |
-| boolean |
-
 ### closeMentionsList
 
 Function to manually close the list of potential users to mention.
@@ -250,7 +234,7 @@ Function that runs onSubmit to the underlying `textarea` component.
 Allows to hide MessageInput's send button. Used by `MessageSimple` to hide the send button in `EditMessageForm`. Received from `MessageInputProps`.
 
 | Type    | Default |
-|---------|---------|
+| ------- | ------- |
 | boolean | false   |
 
 ### imageOrder

--- a/docusaurus/react_versioned_docs/version-11.x.x/components/message-input-components/message-input.mdx
+++ b/docusaurus/react_versioned_docs/version-11.x.x/components/message-input-components/message-input.mdx
@@ -51,14 +51,6 @@ Function to clear the editing state while editing a message.
 | ---------- |
 | () => void |
 
-### closeEmojiPickerOnClick
-
-If true, picking an emoji from the `EmojiPicker` component will close the picker.
-
-| Type    | Default |
-| ------- | ------- |
-| boolean | false   |
-
 ### disabled
 
 If true, disables the text input.
@@ -128,7 +120,7 @@ If true, expands the text input vertically for new lines.
 Allows to hide MessageInput's send button. Used by `MessageSimple` to hide the send button in `EditMessageForm`.
 
 | Type    | Default |
-|---------|---------|
+| ------- | ------- |
 | boolean | false   |
 
 ### Input


### PR DESCRIPTION
### 🎯 Goal

Remove forgotten and no longer functional EmojiPicker mentions from docs.