### PR TITLE
fix: MessageActions adjustments

### DIFF
--- a/src/components/Message/MessageOptions.tsx
+++ b/src/components/Message/MessageOptions.tsx
@@ -5,14 +5,14 @@ import {
   ReactionIcon as DefaultReactionIcon,
   ThreadIcon as DefaultThreadIcon,
 } from './icons';
-import { MESSAGE_ACTIONS, showMessageActionsBox } from './utils';
+import { MESSAGE_ACTIONS, shouldRenderMessageActions } from './utils';
 
 import { MessageActions } from '../MessageActions';
 
 import { MessageContextValue, useMessageContext } from '../../context/MessageContext';
 
 import type { DefaultStreamChatGenerics, IconProps } from '../../types/types';
-import { useTranslationContext } from '../../context';
+import { useComponentContext, useTranslationContext } from '../../context';
 
 export type MessageOptionsProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
@@ -57,13 +57,20 @@ const UnMemoizedMessageOptions = <
     threadList,
   } = useMessageContext<StreamChatGenerics>('MessageOptions');
 
+  const { CustomMessageActionsList } = useComponentContext('MessageOptions');
+
   const { t } = useTranslationContext('MessageOptions');
 
   const handleOpenThread = propHandleOpenThread || contextHandleOpenThread;
 
   const messageActions = getMessageActions();
-  const showActionsBox =
-    showMessageActionsBox(messageActions, threadList) || !!customMessageActions;
+  const renderMessageActions = shouldRenderMessageActions({
+    // @ts-ignore
+    customMessageActions,
+    CustomMessageActionsList,
+    inThread: threadList,
+    messageActions,
+  });
 
   const shouldShowReactions = messageActions.indexOf(MESSAGE_ACTIONS.react) > -1;
   const shouldShowReplies =
@@ -85,7 +92,7 @@ const UnMemoizedMessageOptions = <
 
   return (
     <div className={rootClassName} data-testid='message-options'>
-      {showActionsBox && (
+      {renderMessageActions && (
         <MessageActions ActionsIcon={ActionsIcon} messageWrapperRef={messageWrapperRef} />
       )}
       {shouldShowReplies && (

--- a/src/components/Message/MessageOptions.tsx
+++ b/src/components/Message/MessageOptions.tsx
@@ -5,14 +5,14 @@ import {
   ReactionIcon as DefaultReactionIcon,
   ThreadIcon as DefaultThreadIcon,
 } from './icons';
-import { MESSAGE_ACTIONS, shouldRenderMessageActions } from './utils';
+import { MESSAGE_ACTIONS } from './utils';
 
 import { MessageActions } from '../MessageActions';
 
 import { MessageContextValue, useMessageContext } from '../../context/MessageContext';
 
 import type { DefaultStreamChatGenerics, IconProps } from '../../types/types';
-import { useComponentContext, useTranslationContext } from '../../context';
+import { useTranslationContext } from '../../context';
 
 export type MessageOptionsProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
@@ -47,7 +47,6 @@ const UnMemoizedMessageOptions = <
   } = props;
 
   const {
-    customMessageActions,
     getMessageActions,
     handleOpenThread: contextHandleOpenThread,
     initialMessage,
@@ -57,20 +56,11 @@ const UnMemoizedMessageOptions = <
     threadList,
   } = useMessageContext<StreamChatGenerics>('MessageOptions');
 
-  const { CustomMessageActionsList } = useComponentContext('MessageOptions');
-
   const { t } = useTranslationContext('MessageOptions');
 
   const handleOpenThread = propHandleOpenThread || contextHandleOpenThread;
 
   const messageActions = getMessageActions();
-  const renderMessageActions = shouldRenderMessageActions({
-    // @ts-ignore
-    customMessageActions,
-    CustomMessageActionsList,
-    inThread: threadList,
-    messageActions,
-  });
 
   const shouldShowReactions = messageActions.indexOf(MESSAGE_ACTIONS.react) > -1;
   const shouldShowReplies =
@@ -92,9 +82,7 @@ const UnMemoizedMessageOptions = <
 
   return (
     <div className={rootClassName} data-testid='message-options'>
-      {renderMessageActions && (
-        <MessageActions ActionsIcon={ActionsIcon} messageWrapperRef={messageWrapperRef} />
-      )}
+      <MessageActions ActionsIcon={ActionsIcon} messageWrapperRef={messageWrapperRef} />
       {shouldShowReplies && (
         <button
           aria-label={t('aria/Open Thread')}

--- a/src/components/Message/__tests__/MessageOptions.test.js
+++ b/src/components/Message/__tests__/MessageOptions.test.js
@@ -197,7 +197,7 @@ describe('<MessageOptions />', () => {
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
       customMessageProps: { messageActions: [] },
     });
-    expect(MessageActionsMock).not.toHaveBeenCalled();
+    expect(MessageActionsMock).;
   });
 
   it('should not show actions box for message in thread if only non-thread actions are available', async () => {

--- a/src/components/Message/__tests__/MessageOptions.test.js
+++ b/src/components/Message/__tests__/MessageOptions.test.js
@@ -9,7 +9,6 @@ import { MessageSimple } from '../MessageSimple';
 import { ACTIONS_NOT_WORKING_IN_THREAD, MESSAGE_ACTIONS } from '../utils';
 
 import { Attachment } from '../../Attachment';
-import { MessageActions as MessageActionsMock } from '../../MessageActions';
 
 import { ChannelActionProvider } from '../../../context/ChannelActionContext';
 import { ChannelStateProvider } from '../../../context/ChannelStateContext';
@@ -23,9 +22,7 @@ import {
   getTestClientWithUser,
 } from '../../../mock-builders';
 
-jest.mock('../../MessageActions', () => ({
-  MessageActions: jest.fn(() => <div />),
-}));
+const MESSAGE_ACTIONS_TEST_ID = 'message-actions';
 
 const minimumCapabilitiesToRenderMessageActions = { 'delete-any-message': true };
 const alice = generateUser({ name: 'alice' });
@@ -185,43 +182,45 @@ describe('<MessageOptions />', () => {
   });
 
   it('should render message actions', async () => {
-    await renderMessageOptions({
+    const { queryByTestId } = await renderMessageOptions({
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
     });
-    // eslint-disable-next-line jest/prefer-called-with
-    expect(MessageActionsMock).toHaveBeenCalled();
+
+    expect(queryByTestId(MESSAGE_ACTIONS_TEST_ID)).toBeInTheDocument();
   });
 
   it('should not show message actions button if actions are disabled', async () => {
-    await renderMessageOptions({
+    const { queryByTestId } = await renderMessageOptions({
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
       customMessageProps: { messageActions: [] },
     });
-    expect(MessageActionsMock).;
+
+    expect(queryByTestId(MESSAGE_ACTIONS_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('should not show actions box for message in thread if only non-thread actions are available', async () => {
-    await renderMessageOptions({
+    const { queryByTestId } = await renderMessageOptions({
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
       customMessageProps: { messageActions: ACTIONS_NOT_WORKING_IN_THREAD, threadList: true },
     });
-    expect(MessageActionsMock).not.toHaveBeenCalled();
+
+    expect(queryByTestId(MESSAGE_ACTIONS_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('should show actions box for message in thread if not only non-thread actions are available', async () => {
-    await renderMessageOptions({
+    const { queryByTestId } = await renderMessageOptions({
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
       customMessageProps: {
         messageActions: [...ACTIONS_NOT_WORKING_IN_THREAD, MESSAGE_ACTIONS.delete],
         threadList: true,
       },
     });
-    // eslint-disable-next-line jest/prefer-called-with
-    expect(MessageActionsMock).toHaveBeenCalled();
+
+    expect(queryByTestId(MESSAGE_ACTIONS_TEST_ID)).toBeInTheDocument();
   });
 
   it('should show actions box for a message in thread if custom actions provided are non-thread', async () => {
-    await renderMessageOptions({
+    const { queryByTestId } = await renderMessageOptions({
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
       customMessageProps: {
         customMessageActions: ACTIONS_NOT_WORKING_IN_THREAD,
@@ -229,78 +228,76 @@ describe('<MessageOptions />', () => {
         threadList: true,
       },
     });
-    // eslint-disable-next-line jest/prefer-called-with
-    expect(MessageActionsMock).toHaveBeenCalled();
+    expect(queryByTestId(MESSAGE_ACTIONS_TEST_ID)).toBeInTheDocument();
   });
 
   it('should not show actions box for message outside thread with single action "react"', async () => {
-    await renderMessageOptions({
+    const { queryByTestId } = await renderMessageOptions({
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
       customMessageProps: {
         messageActions: [MESSAGE_ACTIONS.react],
       },
     });
-    // eslint-disable-next-line jest/prefer-called-with
-    expect(MessageActionsMock).not.toHaveBeenCalled();
+    expect(queryByTestId(MESSAGE_ACTIONS_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('should show actions box for message outside thread with single action "react" if custom actions available', async () => {
-    await renderMessageOptions({
+    const { queryByTestId } = await renderMessageOptions({
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
       customMessageProps: {
         customMessageActions: [MESSAGE_ACTIONS.react],
         messageActions: [MESSAGE_ACTIONS.react],
       },
     });
-    // eslint-disable-next-line jest/prefer-called-with
-    expect(MessageActionsMock).toHaveBeenCalled();
+
+    expect(queryByTestId(MESSAGE_ACTIONS_TEST_ID)).toBeInTheDocument();
   });
 
   it('should not show actions box for message outside thread with single action "reply"', async () => {
-    await renderMessageOptions({
+    const { queryByTestId } = await renderMessageOptions({
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
       customMessageProps: {
         messageActions: [MESSAGE_ACTIONS.reply],
       },
     });
-    // eslint-disable-next-line jest/prefer-called-with
-    expect(MessageActionsMock).not.toHaveBeenCalled();
+
+    expect(queryByTestId(MESSAGE_ACTIONS_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('should show actions box for message outside thread with single action "reply" if custom actions available', async () => {
-    await renderMessageOptions({
+    const { queryByTestId } = await renderMessageOptions({
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
       customMessageProps: {
         customMessageActions: [MESSAGE_ACTIONS.reply],
         messageActions: [MESSAGE_ACTIONS.reply],
       },
     });
-    // eslint-disable-next-line jest/prefer-called-with
-    expect(MessageActionsMock).toHaveBeenCalled();
+
+    expect(queryByTestId(MESSAGE_ACTIONS_TEST_ID)).toBeInTheDocument();
   });
 
   it('should not show actions box for message outside thread with two actions "react" & "reply"', async () => {
     const actions = [MESSAGE_ACTIONS.react, MESSAGE_ACTIONS.reply];
-    await renderMessageOptions({
+    const { queryByTestId } = await renderMessageOptions({
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
       customMessageProps: {
         messageActions: actions,
       },
     });
-    // eslint-disable-next-line jest/prefer-called-with
-    expect(MessageActionsMock).not.toHaveBeenCalled();
+
+    expect(queryByTestId(MESSAGE_ACTIONS_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('should show actions box for message outside thread with single actions "react" & "reply" if custom actions available', async () => {
     const actions = [MESSAGE_ACTIONS.react, MESSAGE_ACTIONS.reply];
-    await renderMessageOptions({
+    const { queryByTestId } = await renderMessageOptions({
       channelStateOpts: { channelCapabilities: minimumCapabilitiesToRenderMessageActions },
       customMessageProps: {
         customMessageActions: actions,
         messageActions: actions,
       },
     });
-    // eslint-disable-next-line jest/prefer-called-with
-    expect(MessageActionsMock).toHaveBeenCalled();
+
+    expect(queryByTestId(MESSAGE_ACTIONS_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -219,15 +219,17 @@ export const showMessageActionsBox = (
   inThread?: boolean | undefined,
 ) => shouldRenderMessageActions({ inThread, messageActions: actions });
 
-export const shouldRenderMessageActions = ({
+export const shouldRenderMessageActions = <
+  SCG extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
+>({
   customMessageActions,
   CustomMessageActionsList,
   inThread,
   messageActions,
 }: {
   messageActions: MessageActionsArray;
-  customMessageActions?: CustomMessageActions;
-  CustomMessageActionsList?: ComponentContextValue['CustomMessageActionsList'];
+  customMessageActions?: CustomMessageActions<SCG>;
+  CustomMessageActionsList?: ComponentContextValue<SCG>['CustomMessageActionsList'];
   inThread?: boolean;
 }) => {
   if (

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -5,7 +5,12 @@ import type { TFunction } from 'i18next';
 import type { MessageResponse, Mute, StreamChat, UserResponse } from 'stream-chat';
 import type { PinPermissions } from './hooks';
 import type { MessageProps } from './types';
-import type { MessageContextValue, StreamMessage } from '../../context';
+import type {
+  ComponentContextValue,
+  CustomMessageActions,
+  MessageContextValue,
+  StreamMessage,
+} from '../../context';
 import type { DefaultStreamChatGenerics } from '../../types/types';
 
 /**
@@ -206,26 +211,53 @@ export const ACTIONS_NOT_WORKING_IN_THREAD = [
   MESSAGE_ACTIONS.markUnread,
 ];
 
+/**
+ * @deprecated use `shouldRenderMessageActions` instead
+ */
 export const showMessageActionsBox = (
   actions: MessageActionsArray,
   inThread?: boolean | undefined,
-) => {
-  if (actions.length === 0) {
-    return false;
-  }
+) => shouldRenderMessageActions({ inThread, messageActions: actions });
+
+export const shouldRenderMessageActions = ({
+  customMessageActions,
+  CustomMessageActionsList,
+  inThread,
+  messageActions,
+}: {
+  messageActions: MessageActionsArray;
+  customMessageActions?: CustomMessageActions;
+  CustomMessageActionsList?: ComponentContextValue['CustomMessageActionsList'];
+  inThread?: boolean;
+}) => {
+  if (
+    typeof CustomMessageActionsList !== 'undefined' ||
+    typeof customMessageActions !== 'undefined'
+  )
+    return true;
+
+  if (!messageActions.length) return false;
 
   if (
     inThread &&
-    actions.filter((action) => !ACTIONS_NOT_WORKING_IN_THREAD.includes(action)).length === 0
+    messageActions.filter((action) => !ACTIONS_NOT_WORKING_IN_THREAD.includes(action)).length === 0
   ) {
     return false;
   }
 
-  if (actions.length === 1 && (actions.includes('react') || actions.includes('reply'))) {
+  if (
+    messageActions.length === 1 &&
+    (messageActions.includes(MESSAGE_ACTIONS.react) ||
+      messageActions.includes(MESSAGE_ACTIONS.reply))
+  ) {
     return false;
   }
 
-  if (actions.length === 2 && actions.includes('react') && actions.includes('reply')) {
+  if (
+    messageActions.length === 2 &&
+    messageActions.includes(MESSAGE_ACTIONS.react) &&
+    messageActions.includes(MESSAGE_ACTIONS.reply)
+  ) {
     return false;
   }
 

--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import clsx from 'clsx';
 
 import { MessageActionsBox } from './MessageActionsBox';
 
@@ -65,7 +66,6 @@ export const MessageActions = <
 
   const { mutes } = useChatContext<StreamChatGenerics>('MessageActions');
   const {
-    customMessageActions,
     getMessageActions: contextGetMessageActions,
     handleDelete: contextHandleDelete,
     handleFlag: contextHandleFlag,
@@ -98,7 +98,6 @@ export const MessageActions = <
     }
     setActionsBoxOpen(false);
   }, []);
-  const messageActions = getMessageActions();
   const messageDeletedAt = !!message?.deleted_at;
 
   useEffect(() => {
@@ -132,8 +131,6 @@ export const MessageActions = <
     placement: isMine ? 'top-end' : 'top-start',
     referenceElement: actionsBoxButtonRef.current,
   });
-
-  if (!messageActions.length && !customMessageActions) return null;
 
   return (
     <MessageActionsWrapper
@@ -178,10 +175,11 @@ export type MessageActionsWrapperProps = {
 const MessageActionsWrapper = (props: PropsWithChildren<MessageActionsWrapperProps>) => {
   const { children, customWrapperClass, inline, setActionsBoxOpen } = props;
 
-  const defaultWrapperClass = `
-  str-chat__message-simple__actions__action
-  str-chat__message-simple__actions__action--options
-  str-chat__message-actions-container`;
+  const defaultWrapperClass = clsx(
+    'str-chat__message-simple__actions__action',
+    'str-chat__message-simple__actions__action--options',
+    'str-chat__message-actions-container',
+  );
 
   const wrapperClass = customWrapperClass || defaultWrapperClass;
 

--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -80,7 +80,7 @@ export const MessageActions = <
     threadList,
   } = useMessageContext<StreamChatGenerics>('MessageActions');
 
-  const { CustomMessageActionsList } = useComponentContext('MessageActions');
+  const { CustomMessageActionsList } = useComponentContext<StreamChatGenerics>('MessageActions');
 
   const { t } = useTranslationContext('MessageActions');
 
@@ -99,8 +99,7 @@ export const MessageActions = <
 
   const messageActions = getMessageActions();
 
-  const renderMessageActions = shouldRenderMessageActions({
-    // @ts-expect-error
+  const renderMessageActions = shouldRenderMessageActions<StreamChatGenerics>({
     customMessageActions,
     CustomMessageActionsList,
     inThread: threadList,

--- a/src/components/MessageActions/__tests__/MessageActions.test.js
+++ b/src/components/MessageActions/__tests__/MessageActions.test.js
@@ -65,10 +65,7 @@ describe('<MessageActions /> component', () => {
     const tree = renderMessageActions({}, testRenderer.create);
     expect(tree.toJSON()).toMatchInlineSnapshot(`
       <div
-        className="
-        str-chat__message-simple__actions__action
-        str-chat__message-simple__actions__action--options
-        str-chat__message-actions-container"
+        className="str-chat__message-simple__actions__action str-chat__message-simple__actions__action--options str-chat__message-actions-container"
         data-testid="message-actions"
         onClick={[Function]}
       >
@@ -276,10 +273,7 @@ describe('<MessageActions /> component', () => {
     );
     expect(tree.toJSON()).toMatchInlineSnapshot(`
       <span
-        className="
-        str-chat__message-simple__actions__action
-        str-chat__message-simple__actions__action--options
-        str-chat__message-actions-container"
+        className="str-chat__message-simple__actions__action str-chat__message-simple__actions__action--options str-chat__message-actions-container"
         data-testid="message-actions"
         onClick={[Function]}
       >


### PR DESCRIPTION
### 🎯 Goal

This change allows rendering `CustomMessageActionsList` component without having to provide empty `customMessageActions` object.