### PR TITLE
fix: use the client pagination indicators for ChannelStateContext's hasMore and hasMoreNewer flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "rollup-plugin-url": "^3.0.1",
     "rollup-plugin-visualizer": "^4.2.0",
     "semantic-release": "^19.0.5",
-    "stream-chat": "^8.33.1",
+    "stream-chat": "8.39.0",
     "style-loader": "^2.0.0",
     "ts-jest": "^28.0.8",
     "typescript": "^4.7.4",

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -1327,10 +1327,6 @@ const ChannelInner = <
     );
   }
 
-  // @ts-ignore
-  window['channel'] = channel;
-  // @ts-ignore
-  window['client'] = client;
   return (
     <div className={clsx(className, windowsEmojiClass)}>
       <ChannelStateProvider value={channelStateContextValue}>

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -413,7 +413,11 @@ const ChannelInner = <
     channelReducer,
     // channel.initialized === false if client.channel().query() was not called, e.g. ChannelList is not used
     // => Channel will call channel.watch() in useLayoutEffect => state.loading is used to signal the watch() call state
-    { ...initialState, loading: !channel.initialized },
+    {
+      ...initialState,
+      hasMore: channel.state.messagePagination.hasPrev,
+      loading: !channel.initialized,
+    },
   );
 
   const isMounted = useIsMounted();
@@ -571,7 +575,6 @@ const ChannelInner = <
   useLayoutEffect(() => {
     let errored = false;
     let done = false;
-    let channelInitializedExternally = true;
 
     (async () => {
       if (!channel.initialized && initializeOnMount) {
@@ -597,7 +600,6 @@ const ChannelInner = <
           await getChannel({ channel, client, members, options: channelQueryOptions });
           const config = channel.getConfig();
           setChannelConfig(config);
-          channelInitializedExternally = false;
         } catch (e) {
           dispatch({ error: e as Error, type: 'setError' });
           errored = true;
@@ -610,12 +612,7 @@ const ChannelInner = <
       if (!errored) {
         dispatch({
           channel,
-          hasMore:
-            channelInitializedExternally ||
-            hasMoreMessagesProbably(
-              channel.state.messages.length,
-              channelQueryOptions.messages.limit,
-            ),
+          hasMore: channel.state.messagePagination.hasPrev,
           type: 'initStateFromChannel',
         });
 
@@ -690,7 +687,8 @@ const ChannelInner = <
   );
 
   const loadMore = async (limit = DEFAULT_NEXT_CHANNEL_PAGE_SIZE) => {
-    if (!online.current || !window.navigator.onLine || !state.hasMore) return 0;
+    if (!online.current || !window.navigator.onLine || !channel.state.messagePagination.hasPrev)
+      return 0;
 
     // prevent duplicate loading events...
     const oldestMessage = state?.messages?.[0];
@@ -716,14 +714,14 @@ const ChannelInner = <
       return 0;
     }
 
-    const hasMoreMessages = queryResponse.messages.length === perPage;
-    loadMoreFinished(hasMoreMessages, channel.state.messages);
+    loadMoreFinished(channel.state.messagePagination.hasPrev, channel.state.messages);
 
     return queryResponse.messages.length;
   };
 
   const loadMoreNewer = async (limit = DEFAULT_NEXT_CHANNEL_PAGE_SIZE) => {
-    if (!online.current || !window.navigator.onLine || !state.hasMoreNewer) return 0;
+    if (!online.current || !window.navigator.onLine || !channel.state.messagePagination.hasNext)
+      return 0;
 
     const newestMessage = state?.messages?.[state?.messages?.length - 1];
     if (state.loadingMore || state.loadingMoreNewer) return 0;
@@ -745,10 +743,8 @@ const ChannelInner = <
       return 0;
     }
 
-    const hasMoreNewerMessages = channel.state.messages !== channel.state.latestMessages;
-
     dispatch({
-      hasMoreNewer: hasMoreNewerMessages,
+      hasMoreNewer: channel.state.messagePagination.hasNext,
       messages: channel.state.messages,
       type: 'loadMoreNewerFinished',
     });
@@ -766,18 +762,9 @@ const ChannelInner = <
       dispatch({ loadingMore: true, type: 'setLoadingMore' });
       await channel.state.loadMessageIntoState(messageId, undefined, messageLimit);
 
-      /**
-       * if the message we are jumping to has less than half of the page size older messages,
-       * we have jumped to the beginning of the channel.
-       */
-      const indexOfMessage = channel.state.messages.findIndex(
-        (message) => message.id === messageId,
-      );
-      const hasMoreMessages = indexOfMessage >= Math.floor(messageLimit / 2);
-
-      loadMoreFinished(hasMoreMessages, channel.state.messages);
+      loadMoreFinished(channel.state.messagePagination.hasPrev, channel.state.messages);
       dispatch({
-        hasMoreNewer: channel.state.messages !== channel.state.latestMessages,
+        hasMoreNewer: channel.state.messagePagination.hasNext,
         highlightedMessageId: messageId,
         type: 'jumpToMessageFinished',
       });
@@ -796,9 +783,7 @@ const ChannelInner = <
 
   const jumpToLatestMessage: ChannelActionContextValue<StreamChatGenerics>['jumpToLatestMessage'] = useCallback(async () => {
     await channel.state.loadMessageIntoState('latest');
-    // FIXME: we cannot rely on constant value 25 as the page size can be customized by integrators
-    const hasMoreOlder = channel.state.messages.length >= 25;
-    loadMoreFinished(hasMoreOlder, channel.state.messages);
+    loadMoreFinished(channel.state.messagePagination.hasPrev, channel.state.messages);
     dispatch({
       type: 'jumpToLatestMessage',
     });
@@ -813,7 +798,6 @@ const ChannelInner = <
       let lastReadMessageId = channelUnreadUiState?.last_read_message_id;
       let firstUnreadMessageId = channelUnreadUiState?.first_unread_message_id;
       let isInCurrentMessageSet = false;
-      let hasMoreMessages = true;
 
       if (firstUnreadMessageId) {
         const result = findInMsgSetById(firstUnreadMessageId, channel.state.messages);
@@ -852,14 +836,14 @@ const ChannelInner = <
             ).messages;
           } catch (e) {
             addNotification(t('Failed to jump to the first unread message'), 'error');
-            loadMoreFinished(hasMoreMessages, channel.state.messages);
+            loadMoreFinished(channel.state.messagePagination.hasPrev, channel.state.messages);
             return;
           }
 
           const firstMessageWithCreationDate = messages.find((msg) => msg.created_at);
           if (!firstMessageWithCreationDate) {
             addNotification(t('Failed to jump to the first unread message'), 'error');
-            loadMoreFinished(hasMoreMessages, channel.state.messages);
+            loadMoreFinished(channel.state.messagePagination.hasPrev, channel.state.messages);
             return;
           }
           const firstMessageTimestamp = new Date(
@@ -868,13 +852,11 @@ const ChannelInner = <
           if (lastReadTimestamp < firstMessageTimestamp) {
             // whole channel is unread
             firstUnreadMessageId = firstMessageWithCreationDate.id;
-            hasMoreMessages = false;
           } else {
             const result = findInMsgSetByDate(channelUnreadUiState.last_read, messages);
             lastReadMessageId = result.target?.id;
-            hasMoreMessages = result.index >= Math.floor(queryMessageLimit / 2);
           }
-          loadMoreFinished(hasMoreMessages, channel.state.messages);
+          loadMoreFinished(channel.state.messagePagination.hasPrev, channel.state.messages);
         }
       }
 
@@ -895,13 +877,12 @@ const ChannelInner = <
           const indexOfTarget = channel.state.messages.findIndex(
             (message) => message.id === targetId,
           ) as number;
-          hasMoreMessages = indexOfTarget >= Math.floor(queryMessageLimit / 2);
-          loadMoreFinished(hasMoreMessages, channel.state.messages);
+          loadMoreFinished(channel.state.messagePagination.hasPrev, channel.state.messages);
           firstUnreadMessageId =
             firstUnreadMessageId ?? channel.state.messages[indexOfTarget + 1]?.id;
         } catch (e) {
           addNotification(t('Failed to jump to the first unread message'), 'error');
-          loadMoreFinished(hasMoreMessages, channel.state.messages);
+          loadMoreFinished(channel.state.messagePagination.hasPrev, channel.state.messages);
           return;
         }
       }
@@ -918,7 +899,7 @@ const ChannelInner = <
         });
 
       dispatch({
-        hasMoreNewer: channel.state.messages !== channel.state.latestMessages,
+        hasMoreNewer: channel.state.messagePagination.hasNext,
         highlightedMessageId: firstUnreadMessageId,
         type: 'jumpToMessageFinished',
       });
@@ -1346,6 +1327,10 @@ const ChannelInner = <
     );
   }
 
+  // @ts-ignore
+  window['channel'] = channel;
+  // @ts-ignore
+  window['client'] = client;
   return (
     <div className={clsx(className, windowsEmojiClass)}>
       <ChannelStateProvider value={channelStateContextValue}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13292,10 +13292,10 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-chat@^8.33.1:
-  version "8.33.1"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.33.1.tgz#d4e7f3bb10ac4564572431922c97e7c4eda7fe3b"
-  integrity sha512-r4vUjjsBTtCER2wEFYJzbgSY7eipPkM9gyQNV5VVdZhegY/NggeinwY1bYpBXBpQ5JIEvNFIWWRPOFYkMae3MQ==
+stream-chat@8.39.0:
+  version "8.39.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.39.0.tgz#f4cb86bd5cac4c1272c24cd66ed4752bcda8d717"
+  integrity sha512-zQZR1tPrgGBbu+Gnv9F9KQx3OPUMvb0FN+39BEjkjgjRPm2JYhF78jfcYutQMiC538t3V+NgFGgj5N4sZvSsUA==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"


### PR DESCRIPTION
### 🎯 Goal

Use the pagination flags from the the client, which actually performs the queries and thus share the information btw React components that are siblings (`ChannelList` queries channels and `Channel` will know, what channels have less than the 1st page size message count).

depends on https://github.com/GetStream/stream-chat-js/pull/1332


