### PR TITLE
fix: quote replies in threads

### DIFF
--- a/src/components/MessageInput/MessageInputFlat.tsx
+++ b/src/components/MessageInput/MessageInputFlat.tsx
@@ -49,6 +49,7 @@ export const MessageInputFlat = <
     maxFilesLeft,
     message,
     numberOfUploads,
+    parent,
     recordingController,
     setCooldownRemaining,
     text,
@@ -129,7 +130,7 @@ export const MessageInputFlat = <
 
   // TODO: "!message" condition is a temporary fix for shared
   // state when editing a message (fix shared state issue)
-  const displayQuotedMessage = !message && quotedMessage && !quotedMessage.parent_id;
+  const displayQuotedMessage = !message && quotedMessage && quotedMessage.parent_id === parent?.id;
   const recordingEnabled = !!(recordingController.recorder && navigator.mediaDevices); // account for requirement on iOS as per this bug report: https://bugs.webkit.org/show_bug.cgi?id=252303
   const isRecording = !!recordingController.recordingState;
 


### PR DESCRIPTION
### 🎯 Goal

It's perfectly normal to quote a message that is part of a thread, as long as it's quoted in the same thread. Looks like this logic has been broken for some time. This PR fixes it.

### 🛠 Implementation details

Take a look at how quoted message is handled in `Channel`:

```
const messageData = {
  // ...
  quoted_message_id: parent_id === quotedMessage?.parent_id ? quotedMessage?.id : undefined
};
```

Quoting is allowed as long as the quoted message is part of the same thread, or both are regular non-thread messages.

However, there was a mismatch in how `MessageInputFlat` displays a quoted message: it was always hidden for thread messages, which lead to confusing behavior.

Now the logic is the same in both places.