### PR TITLE
fix: add theme to ChatView component

### DIFF
--- a/src/components/ChatView/ChatView.tsx
+++ b/src/components/ChatView/ChatView.tsx
@@ -7,6 +7,7 @@ import { useChatContext } from '../../context';
 
 import type { PropsWithChildren } from 'react';
 import type { Thread, ThreadManagerState } from 'stream-chat';
+import clsx from 'clsx';
 
 const availableChatViews = ['channels', 'threads'] as const;
 
@@ -25,11 +26,13 @@ export const ChatView = ({ children }: PropsWithChildren) => {
     'channels',
   );
 
+  const { theme } = useChatContext();
+
   const value = useMemo(() => ({ activeChatView, setActiveChatView }), [activeChatView]);
 
   return (
     <ChatViewContext.Provider value={value}>
-      <div className='str-chat str-chat__chat-view'>{children}</div>
+      <div className={clsx('str-chat', theme, 'str-chat__chat-view')}>{children}</div>
     </ChatViewContext.Provider>
   );
 };


### PR DESCRIPTION
### 🎯 Goal

`ChatView` component wraps whole `Chat` inner component tree but components rendered outside `Channel` component tree can only access default theme variables as `theme` property is only applied to the element `Channel` component renders. To make theming work for thread-related components too, the `theme` is also applied to the element `ChatView` renders.