### PR TITLE
fix: remove the use of deprecated query operator $ne

### DIFF
--- a/src/components/ChannelSearch/__tests__/ChannelSearch.test.js
+++ b/src/components/ChannelSearch/__tests__/ChannelSearch.test.js
@@ -125,9 +125,11 @@ describe('ChannelSearch', () => {
   });
 
   it('search is performed by default on users and not channels', async () => {
+    const limit = 8;
+    const otherUsers = Array.from({ length: limit }, generateUser);
     jest.useFakeTimers('modern');
     const client = await getTestClientWithUser(user);
-    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [user] });
+    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [...otherUsers, user] });
     jest.spyOn(client, 'queryChannels').mockImplementation();
     const { typeText } = await renderSearch({ client });
     await act(() => {
@@ -141,21 +143,26 @@ describe('ChannelSearch', () => {
     expect(client.queryUsers).toHaveBeenCalledWith(
       expect.objectContaining({
         $or: [{ id: { $autocomplete: typedText } }, { name: { $autocomplete: typedText } }],
-        id: { $ne: 'id' },
       }),
       { id: 1 },
-      { limit: 8 },
+      { limit },
     );
     expect(client.queryUsers).toHaveBeenCalledTimes(1);
     expect(client.queryChannels).not.toHaveBeenCalled();
+    otherUsers.forEach((user) => {
+      expect(screen.queryByText(user.name)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(user.name)).not.toBeInTheDocument();
 
     jest.useRealTimers();
   });
 
   it('search is performed on users and channels if enabled', async () => {
+    const limit = 8;
+    const otherUsers = Array.from({ length: limit }, generateUser);
     jest.useFakeTimers('modern');
     const client = await getTestClientWithUser(user);
-    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [user] });
+    jest.spyOn(client, 'queryUsers').mockResolvedValue({ users: [...otherUsers, user] });
     jest.spyOn(client, 'queryChannels').mockResolvedValue([channelResponseData]);
 
     const { typeText } = await renderSearch({ client, props: { searchForChannels: true } });
@@ -169,7 +176,10 @@ describe('ChannelSearch', () => {
 
     expect(client.queryUsers).toHaveBeenCalledTimes(1);
     expect(client.queryChannels).toHaveBeenCalledTimes(1);
-
+    otherUsers.forEach((user) => {
+      expect(screen.queryByText(user.name)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(user.name)).not.toBeInTheDocument();
     jest.useRealTimers();
   });
 
@@ -270,7 +280,6 @@ describe('ChannelSearch', () => {
     expect(client.queryUsers).toHaveBeenCalledWith(
       expect.objectContaining({
         $or: [{ id: { $autocomplete: textToQuery } }, { name: { $autocomplete: textToQuery } }],
-        id: { $ne: 'id' },
       }),
       { id: 1 },
       { limit: 8 },
@@ -311,7 +320,6 @@ describe('ChannelSearch', () => {
     expect(client.queryUsers).toHaveBeenCalledWith(
       expect.objectContaining({
         $or: [{ id: { $autocomplete: textToQuery } }, { name: { $autocomplete: textToQuery } }],
-        id: { $ne: 'id' },
       }),
       { id: 1 },
       { limit: 8 },

--- a/src/components/ChannelSearch/hooks/useChannelSearch.ts
+++ b/src/components/ChannelSearch/hooks/useChannelSearch.ts
@@ -216,7 +216,6 @@ export const useChannelSearch = <
           // @ts-expect-error
           {
             $or: [{ id: { $autocomplete: text } }, { name: { $autocomplete: text } }],
-            id: { $ne: client.userID },
             ...searchQueryParams?.userFilters?.filters,
           },
           { id: 1, ...searchQueryParams?.userFilters?.sort },
@@ -226,7 +225,7 @@ export const useChannelSearch = <
         if (!searchForChannels) {
           searchQueryPromiseInProgress.current = userQueryPromise;
           const { users } = await searchQueryPromiseInProgress.current;
-          results = users;
+          results = users.filter((u) => u.id !== client.user?.id);
         } else {
           const channelQueryPromise = client.queryChannels(
             // @ts-expect-error
@@ -245,7 +244,7 @@ export const useChannelSearch = <
 
           const [channels, { users }] = await searchQueryPromiseInProgress.current;
 
-          results = [...channels, ...users];
+          results = [...channels, ...users.filter((u) => u.id !== client.user?.id)];
         }
       } catch (error) {
         console.error(error);

--- a/src/components/MessageInput/hooks/useUserTrigger.ts
+++ b/src/components/MessageInput/hooks/useUserTrigger.ts
@@ -103,7 +103,6 @@ export const useUserTrigger = <
         // @ts-expect-error
         {
           $or: [{ id: { $autocomplete: query } }, { name: { $autocomplete: query } }],
-          id: { $ne: client.userID },
           ...(typeof mentionQueryParams.filters === 'function'
             ? mentionQueryParams.filters(query)
             : mentionQueryParams.filters),


### PR DESCRIPTION
### 🎯 Goal

The `$nin` and the `$ne` operators cause bad performance on the backend, and they will be deprecated (and eventually removed). The SDK used only `$ne` operator which is now removed. It also means that the own user will not be anymore filtered out of the selection list of users to mention if `mentionAllAppUsers` is enabled on `MessageInput`. Own user will be  always included on the list if matched.

