### PR TITLE
chore: make branch release-v11 a version branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,12 +2,12 @@
   "branches": [
     {
       "name": "master",
-      "channel": "rc",
-      "prerelease": true
+      "channel": "latest"
     },
     {
       "name": "release-v11",
-      "channel": "latest"
+      "channel": "v11",
+      "range": "11.x"
     },
     {
       "name": "release-v10",


### PR DESCRIPTION
### 🎯 Goal

Release to v11 channel from release-v11 branch.

