### PR TITLE
docs: make v12 the last version and redirect /v12 routes to /

### DIFF
--- a/docusaurus/react-docusaurus-dontent-docs.plugin.js
+++ b/docusaurus/react-docusaurus-dontent-docs.plugin.js
@@ -3,21 +3,34 @@ module.exports = {
     [
       '@docusaurus/plugin-content-docs',
       {
-        lastVersion: '11.x.x',
+        lastVersion: 'current',
         versions: {
           current: {
-            banner: 'unreleased',
-            label: 'v12 (rc)',
-            path: 'v12',
+            label: 'v12',
           },
           '11.x.x': {
             label: 'v11',
+            path: 'v11',
           },
           '11.x.x-legacy': {
             label: 'v11 (legacy)',
             path: 'v11-legacy',
             banner: 'unmaintained',
           },
+        },
+      },
+    ],
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        createRedirects(existingPath) {
+          // we need to replace /v12 in the path to the current version as v12 was previously rc
+          const replacedToken = '/v12';
+          if (existingPath.includes(replacedToken)) {
+            // Redirect from /v12/X to /
+            return [existingPath.replace('/', replacedToken)];
+          }
+          return undefined; // Return a falsy value: no redirect created
         },
       },
     ],

--- a/docusaurus/react_versioned_docs/version-11.x.x/theming/introduction.mdx
+++ b/docusaurus/react_versioned_docs/version-11.x.x/theming/introduction.mdx
@@ -142,7 +142,7 @@ The `str-chat` class is applied to the [channel list](../components/ChannelListC
 <SDKSpecific name="react">
 
 :::note
-The `str-chat` class is applied to the [`ChannelList`](../core-components/channel-list.mdx) and [`Channel`](../core-components/channel.mdx) components, all CSS variables are declared on this level.
+The `str-chat` class is applied to the [`ChannelList`](../components/core-components/channel-list.mdx) and [`Channel`](../core-components/channel.mdx) components, all CSS variables are declared on this level.
 :::
 
 </SDKSpecific>


### PR DESCRIPTION
We cannot test redirect in development mode. Followed [docusaurus redirects example](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-client-redirects#ex-config)