### PR TITLE
perf: prevent filtering a message which is being reacted to

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -885,9 +885,13 @@ const ChannelInner = <
 
   const updateMessage = (
     updatedMessage: MessageToSend<StreamChatGenerics> | StreamMessage<StreamChatGenerics>,
+    timestampChanged = true,
   ) => {
     // add the message to the local channel state
-    channel.state.addMessageSorted(updatedMessage as MessageResponse<StreamChatGenerics>, true);
+    channel.state.addMessageSorted(
+      updatedMessage as MessageResponse<StreamChatGenerics>,
+      timestampChanged,
+    );
 
     dispatch({
       channel,

--- a/src/components/Message/hooks/useReactionHandler.ts
+++ b/src/components/Message/hooks/useReactionHandler.ts
@@ -93,7 +93,7 @@ export const useReactionHandler = <
     const tempMessage = createMessagePreview(add, newReaction, message);
 
     try {
-      updateMessage(tempMessage);
+      updateMessage(tempMessage, false);
       // @ts-expect-error
       thread?.upsertReplyLocally({ message: tempMessage });
 
@@ -102,10 +102,10 @@ export const useReactionHandler = <
         : await channel.deleteReaction(id, type);
 
       // seems useless as we're expecting WS event to come in and replace this anyway
-      updateMessage(messageResponse.message);
+      updateMessage(messageResponse.message, false);
     } catch (error) {
       // revert to the original message if the API call fails
-      updateMessage(message);
+      updateMessage(message, false);
       // @ts-expect-error
       thread?.upsertReplyLocally({ message });
     }

--- a/src/context/ChannelActionContext.tsx
+++ b/src/context/ChannelActionContext.tsx
@@ -95,7 +95,7 @@ export type ChannelActionContextValue<
   setQuotedMessage: React.Dispatch<
     React.SetStateAction<StreamMessage<StreamChatGenerics> | undefined>
   >;
-  updateMessage: (message: StreamMessage<StreamChatGenerics>) => void;
+  updateMessage: (message: StreamMessage<StreamChatGenerics>, timestampChanged?: boolean) => void;
 };
 
 export const ChannelActionContext = React.createContext<ChannelActionContextValue | undefined>(


### PR DESCRIPTION
### 🎯 Goal

The `updateMessage` function has been missing `timestampChanged` parameter, which if set to `false` prevents underlying `addToMessageList` function from filtering the message that is being altered in a way, where `created_at` has not been changed.
