### PR TITLE
feat: add MessageListMainPanel to ComponentContext

### DIFF
--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -30,7 +30,7 @@ import { InfiniteScroll, InfiniteScrollProps } from '../InfiniteScrollPaginator/
 import { LoadingIndicator as DefaultLoadingIndicator } from '../Loading';
 import { defaultPinPermissions, MESSAGE_ACTIONS } from '../Message/utils';
 import { TypingIndicator as DefaultTypingIndicator } from '../TypingIndicator';
-import { MessageListMainPanel } from './MessageListMainPanel';
+import { MessageListMainPanel as DefaultMessageListMainPanel } from './MessageListMainPanel';
 
 import { defaultRenderMessages, MessageRenderer } from './renderMessages';
 
@@ -104,6 +104,7 @@ const MessageListWithContext = <
     MessageNotification = DefaultMessageNotification,
     TypingIndicator = DefaultTypingIndicator,
     UnreadMessagesNotification = DefaultUnreadMessagesNotification,
+    MessageListMainPanel = DefaultMessageListMainPanel,
   } = useComponentContext<StreamChatGenerics>('MessageList');
 
   const {

--- a/src/components/MessageList/MessageListMainPanel.tsx
+++ b/src/components/MessageList/MessageListMainPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { PropsWithChildrenOnly } from '../../types/types';
 
-export const MESSAGE_LIST_MAIN_PANEL_CLASS = 'str-chat__main-panel-inner' as const;
+export const MESSAGE_LIST_MAIN_PANEL_CLASS = 'str-chat__main-panel-inner str-chat__message-list-main-panel' as const;
 
 export const MessageListMainPanel = ({ children }: PropsWithChildrenOnly) => (
   <div className={MESSAGE_LIST_MAIN_PANEL_CLASS}>{children}</div>

--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -23,7 +23,7 @@ import { useMarkRead } from './hooks/useMarkRead';
 
 import { MessageNotification as DefaultMessageNotification } from './MessageNotification';
 import { MessageListNotifications as DefaultMessageListNotifications } from './MessageListNotifications';
-import { MessageListMainPanel } from './MessageListMainPanel';
+import { MessageListMainPanel as DefaultMessageListMainPanel } from './MessageListMainPanel';
 import {
   getGroupStyles,
   getLastReceived,
@@ -235,6 +235,7 @@ const VirtualizedMessageListWithContext = <
     MessageListNotifications = DefaultMessageListNotifications,
     MessageNotification = DefaultMessageNotification,
     MessageSystem = DefaultMessageSystem,
+    MessageListMainPanel = DefaultMessageListMainPanel,
     UnreadMessagesNotification = DefaultUnreadMessagesNotification,
     UnreadMessagesSeparator = DefaultUnreadMessagesSeparator,
     VirtualMessage: MessageUIComponentFromContext = MessageSimple,

--- a/src/context/ComponentContext.tsx
+++ b/src/context/ComponentContext.tsx
@@ -49,7 +49,12 @@ import type {
 
 import type { MessageBouncePromptProps } from '../components/MessageBounce';
 import type { TimestampProps } from '../components/Message/Timestamp';
-import type { CustomTrigger, DefaultStreamChatGenerics, UnknownType } from '../types/types';
+import type {
+  CustomTrigger,
+  DefaultStreamChatGenerics,
+  PropsWithChildrenOnly,
+  UnknownType,
+} from '../types/types';
 
 export type ComponentContextValue<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -78,6 +83,7 @@ export type ComponentContextValue<
   Message?: React.ComponentType<MessageUIComponentProps<StreamChatGenerics>>;
   MessageBouncePrompt?: React.ComponentType<MessageBouncePromptProps>;
   MessageDeleted?: React.ComponentType<MessageDeletedProps<StreamChatGenerics>>;
+  MessageListMainPanel?: React.ComponentType<PropsWithChildrenOnly>;
   MessageListNotifications?: React.ComponentType<MessageListNotificationsProps>;
   MessageNotification?: React.ComponentType<MessageNotificationProps>;
   MessageOptions?: React.ComponentType<MessageOptionsProps<StreamChatGenerics>>;


### PR DESCRIPTION
### 🎯 Goal

Allows to override `MessageListMainPanel` component especially for integrators migrating to `v12` where `MessageListMainPanel` now always renders a `div` since the theming v2 is now a default.