### PR TITLE
fix: get correct lastMessage and latestMessagePreview from channel state

### DIFF
--- a/docusaurus/docs/React/components/core-components/channel-list.mdx
+++ b/docusaurus/docs/React/components/core-components/channel-list.mdx
@@ -110,7 +110,7 @@ re-setting the list state, you can customize behavior and UI.
 | `channel.truncated`                                                                       | Updates the channel                              | [onChannelTruncated](#onchanneltruncated)     |
 | `channel.updated`                                                                         | Updates the channel                              | [onChannelUpdated](#onchannelupdated)         |
 | `channel.visible`                                                                         | Adds channel to list                             | [onChannelVisible](#onchannelvisible)         |
-| `connection.recovered`                                                                    | Forces a component render                        |  N/A                                          |
+| `connection.recovered`                                                                    | Forces a component render                        | N/A                                           |
 | `message.new`                                                                             | Moves channel to top of list                     | [onMessageNewHandler](#onmessagenewhandler)   |
 | `notification.added_to_channel`                                                           | Moves channel to top of list and starts watching | [onAddedToChannel](#onaddedtochannel)         |
 | `notification.message_new`                                                                | Moves channel to top of list and starts watching | [onMessageNew](#onmessagenew)                 |
@@ -225,13 +225,14 @@ Custom function that handles the channel pagination.
 Takes parameters:
 
 | Parameter         | Description                                                                                                                                                           |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `currentChannels` | The state of loaded `Channel` objects queried thus far. Has to be set with `setChannels` (see below).                                                                 |
 | `queryType`       | A string indicating, whether the channels state has to be reset to the first page ('reload') or newly queried channels should be appended to the `currentChannels`.   |
 | `setChannels`     | Function that allows us to set the channels state reflected in `currentChannels`.                                                                                     |
 | `setHasNextPage`  | Flag indicating whether there are more items to be loaded from the API. Should be infered from the comparison of the query result length and the query options limit. |
 
 The function has to:
+
 1. build / provide own query filters, sort and options parameters
 2. query and append channels to the current channels state
 3. update the `hasNext` pagination flag after each query with `setChannels` function
@@ -239,14 +240,11 @@ The function has to:
 An example below implements a custom query function that uses different filters sequentially once a preceding filter is exhausted:
 
 ```ts
-import uniqBy from "lodash.uniqby";
+import uniqBy from 'lodash.uniqby';
 import throttle from 'lodash.throttle';
-import {useCallback, useRef} from 'react';
-import {ChannelFilters, ChannelOptions, ChannelSort, StreamChat} from 'stream-chat';
-import {
-    CustomQueryChannelParams,
-    useChatContext,
-} from 'stream-chat-react';
+import { useCallback, useRef } from 'react';
+import { ChannelFilters, ChannelOptions, ChannelSort, StreamChat } from 'stream-chat';
+import { CustomQueryChannelParams, useChatContext } from 'stream-chat-react';
 
 const DEFAULT_PAGE_SIZE = 30 as const;
 
@@ -312,7 +310,7 @@ export const useCustomQueryChannels = () => {
 It is recommended to control for duplicate requests by throttling the custom function calls.
 
 | Type                                                                                              |
-|---------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------------------------------------------- |
 | <GHComponentLink text='CustomQueryChannelsFn' path='/ChannelList/hooks/usePaginatedChannels.ts'/> |
 
 ### EmptyStateIndicator
@@ -331,6 +329,14 @@ for more information.
 | Type   |
 | ------ |
 | object |
+
+### getLatestMessagePreview
+
+Custom function that generates the message preview in ChannelPreview component.
+
+| Type                                                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------------------------- |
+| `(channel: Channel, t: TranslationContextValue['t'], userLanguage: TranslationContextValue['userLanguage']) => string \| JSX.Element` |
 
 ### List
 
@@ -425,7 +431,7 @@ Function to override the default behavior when a message is received on a channe
 Function to override the default behavior when a message is received on a channel being watched. Handles `message.new` event.
 
 | Type                                                                                                                                |
-|-------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------------------------------------------------------------------------------------------------------------------------- |
 | `(setChannels: React.Dispatch<React.SetStateAction<Array<Channel<StreamChatGenerics>>>>, event: Event<StreamChatGenerics>) => void` |
 
 ### onRemovedFromChannel
@@ -491,7 +497,7 @@ const App = () => (
 ```
 
 | Type   | Default |
-|--------|---------|
+| ------ | ------- |
 | number | 5000    |
 
 ### renderChannels

--- a/docusaurus/docs/React/components/utility-components/channel-preview-ui.mdx
+++ b/docusaurus/docs/React/components/utility-components/channel-preview-ui.mdx
@@ -18,12 +18,12 @@ For even deeper customization of the channel list and channel previews, use the 
 To customize the `ChannelList` item UI simply pass your custom `Preview` component to the `ChannelList`. See [The Preview Prop Component](../../guides/customization/channel-list-preview.mdx#the-preview-prop-component) for the extended guide.
 
 ```tsx
-const CustomChannelPreviewUI = ({ latestMessage, lastMessage }) => {
+const CustomChannelPreviewUI = ({ latestMessagePreview, lastMessage }) => {
   // "lastMessage" property is for the last
   // message that has been interacted with (pinned/edited/deleted)
 
-  // to display last message of the channel use "latestMessage" property
-  return <span>{latestMessage}</span>;
+  // to display last message of the channel use "latestMessagePreview" property
+  return <span>{latestMessagePreview}</span>;
 };
 
 <ChannelList Preview={CustomChannelPreviewUI} />;
@@ -104,6 +104,14 @@ The last message received in a channel.
 | `StreamMessage` |
 
 ### latestMessage
+
+Deprecated, use `latestMessagePreview` instead.
+
+| Type                    |
+| ----------------------- |
+| `string \| JSX.Element` |
+
+### latestMessagePreview
 
 Latest message preview to display. Will be either a string or a JSX.Element rendering markdown.
 

--- a/docusaurus/docs/React/components/utility-components/channel-preview-ui.mdx
+++ b/docusaurus/docs/React/components/utility-components/channel-preview-ui.mdx
@@ -95,6 +95,14 @@ Title of channel to display.
 | -------- |
 | `string` |
 
+### getLatestMessagePreview
+
+Custom function that generates the message preview in ChannelPreview component.
+
+| Type                                                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------------------------- |
+| `(channel: Channel, t: TranslationContextValue['t'], userLanguage: TranslationContextValue['userLanguage']) => string \| JSX.Element` |
+
 ### lastMessage
 
 The last message received in a channel.

--- a/docusaurus/docs/React/components/utility-components/channel-preview.mdx
+++ b/docusaurus/docs/React/components/utility-components/channel-preview.mdx
@@ -55,6 +55,14 @@ Custom class for the channel preview root
 | -------- |
 | `string` |
 
+### getLatestMessagePreview
+
+Custom function that generates the message preview in ChannelPreview component.
+
+| Type                                                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------------------------- |
+| `(channel: Channel, t: TranslationContextValue['t'], userLanguage: TranslationContextValue['userLanguage']) => string \| JSX.Element` |
+
 ### onSelect
 
 Custom handler invoked when the `ChannelPreview` is clicked. The SDK uses `ChannelPreview` to display items of channel search results. There, behind the scenes, the new active channel is set.

--- a/docusaurus/docs/React/guides/customization/channel-list-preview.mdx
+++ b/docusaurus/docs/React/guides/customization/channel-list-preview.mdx
@@ -55,12 +55,12 @@ Let's implement a simple custom preview:
 <TabItem value="js" label="React">
 
 ```jsx
-const CustomChannelPreview = ({ displayImage, displayTitle, latestMessage }) => (
+const CustomChannelPreview = ({ displayImage, displayTitle, latestMessagePreview }) => (
   <div className='channel-preview'>
     <img className='channel-preview__avatar' src={displayImage} alt='' />
     <div className='channel-preview__main'>
       <div className='channel-preview__header'>{displayTitle}</div>
-      <div className='channel-preview__message'>{latestMessage}</div>
+      <div className='channel-preview__message'>{latestMessagePreview}</div>
     </div>
   </div>
 );
@@ -122,7 +122,7 @@ message in the channel:
 
 ```jsx
 const CustomChannelPreview = (props) => {
-  const { channel, displayImage, displayTitle, latestMessage } = props;
+  const { channel, displayImage, displayTitle, latestMessagePreview } = props;
   const { userLanguage } = useTranslationContext();
   const latestMessageAt = channel.state.last_message_at;
 
@@ -146,7 +146,7 @@ const CustomChannelPreview = (props) => {
             {timestamp}
           </time>
         </div>
-        <div className='channel-preview__message'>{latestMessage}</div>
+        <div className='channel-preview__message'>{latestMessagePreview}</div>
       </div>
     </div>
   );
@@ -217,7 +217,7 @@ const CustomChannelPreview = (props) => {
     activeChannel,
     displayImage,
     displayTitle,
-    latestMessage,
+    latestMessagePreview,
     setActiveChannel,
   } = props;
   const latestMessageAt = channel.state.last_message_at;
@@ -252,7 +252,7 @@ const CustomChannelPreview = (props) => {
             {timestamp}
           </time>
         </div>
-        <div className='channel-preview__message'>{latestMessage}</div>
+        <div className='channel-preview__message'>{latestMessagePreview}</div>
       </div>
     </button>
   );

--- a/src/components/ChannelList/ChannelList.tsx
+++ b/src/components/ChannelList/ChannelList.tsx
@@ -35,7 +35,7 @@ import { ChannelListContextProvider } from '../../context';
 import { useChatContext } from '../../context/ChatContext';
 
 import type { Channel, ChannelFilters, ChannelOptions, ChannelSort, Event } from 'stream-chat';
-
+import type { TranslationContextValue } from '../../context/TranslationContext';
 import type { DefaultStreamChatGenerics, PaginatorProps } from '../../types/types';
 
 const DEFAULT_FILTERS = {};
@@ -70,6 +70,12 @@ export type ChannelListProps<
   EmptyStateIndicator?: React.ComponentType<EmptyStateIndicatorProps>;
   /** An object containing channel query filters */
   filters?: ChannelFilters<StreamChatGenerics>;
+  /** Custom function that generates the message preview in ChannelPreview component */
+  getLatestMessagePreview?: (
+    channel: Channel<StreamChatGenerics>,
+    t: TranslationContextValue['t'],
+    userLanguage: TranslationContextValue['userLanguage'],
+  ) => string | JSX.Element;
   /** Custom UI component to display the container for the queried channels, defaults to and accepts same props as: [ChannelListMessenger](https://github.com/GetStream/stream-chat-react/blob/master/src/components/ChannelList/ChannelListMessenger.tsx) */
   List?: React.ComponentType<ChannelListMessengerProps<StreamChatGenerics>>;
   /** Custom UI component to display the loading error indicator, defaults to and accepts same props as: [ChatDown](https://github.com/GetStream/stream-chat-react/blob/master/src/components/ChatDown/ChatDown.tsx) */
@@ -168,6 +174,7 @@ const UnMemoizedChannelList = <
     customQueryChannels,
     EmptyStateIndicator = DefaultEmptyStateIndicator,
     filters,
+    getLatestMessagePreview,
     LoadingErrorIndicator = ChatDown,
     LoadingIndicator = LoadingChannels,
     List = ChannelListMessenger,
@@ -333,6 +340,7 @@ const UnMemoizedChannelList = <
       channel: item,
       // forces the update of preview component on channel update
       channelUpdateCount,
+      getLatestMessagePreview,
       key: item.cid,
       Preview,
       setActiveChannel,

--- a/src/components/ChannelList/__tests__/ChannelList.test.js
+++ b/src/components/ChannelList/__tests__/ChannelList.test.js
@@ -60,11 +60,11 @@ const channelsQueryStateMock = {
  * to those components might end up breaking tests for ChannelList, which will be quite painful
  * to debug then.
  */
-const ChannelPreviewComponent = ({ channel, channelUpdateCount, latestMessage }) => (
+const ChannelPreviewComponent = ({ channel, channelUpdateCount, latestMessagePreview }) => (
   <div data-testid={channel.id} role='listitem'>
     <div data-testid='channelUpdateCount'>{channelUpdateCount}</div>
     <div>{channel.data.name}</div>
-    <div>{latestMessage}</div>
+    <div>{latestMessagePreview}</div>
   </div>
 );
 
@@ -454,6 +454,36 @@ describe('ChannelList', () => {
       expect(screen.getByTestId(testChannel2.channel.id)).toBeInTheDocument();
       expect(screen.getByTestId(testChannel3.channel.id)).toBeInTheDocument();
       expect(screen.getAllByRole('listitem')).toHaveLength(3);
+    });
+  });
+
+  it('allows to customize latest message preview generation', async () => {
+    const previewText = 'custom preview text';
+    const getLatestMessagePreview = () => previewText;
+
+    useMockedApis(chatClient, [queryChannelsApi([testChannel1])]);
+    const { rerender } = render(
+      <Chat client={chatClient}>
+        <ChannelList filters={{}} options={{ limit: 2 }} />
+      </Chat>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Nothing yet...')).toBeInTheDocument();
+    });
+
+    rerender(
+      <Chat client={chatClient}>
+        <ChannelList
+          filters={{}}
+          getLatestMessagePreview={getLatestMessagePreview}
+          options={{ limit: 2 }}
+        />
+      </Chat>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(previewText)).toBeInTheDocument();
     });
   });
 

--- a/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/src/components/ChannelPreview/ChannelPreview.tsx
@@ -137,7 +137,7 @@ export const ChannelPreview = <
     refreshUnreadCount();
 
     const handleEvent = () => {
-      setLastMessage(channel.state.messages[channel.state.messages.length - 1]);
+      setLastMessage(channel.state.latestMessages[channel.state.latestMessages.length - 1]);
       refreshUnreadCount();
     };
 

--- a/src/components/ChannelPreview/ChannelPreview.tsx
+++ b/src/components/ChannelPreview/ChannelPreview.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { ChannelPreviewMessenger } from './ChannelPreviewMessenger';
 import { useIsChannelMuted } from './hooks/useIsChannelMuted';
 import { useChannelPreviewInfo } from './hooks/useChannelPreviewInfo';
-import { getLatestMessagePreview } from './utils';
+import { getLatestMessagePreview as defaultGetLatestMessagePreview } from './utils';
 
 import { ChatContextValue, useChatContext } from '../../context/ChatContext';
 import { useTranslationContext } from '../../context/TranslationContext';
@@ -15,7 +15,7 @@ import type { Channel, Event } from 'stream-chat';
 import type { AvatarProps } from '../Avatar/Avatar';
 
 import type { StreamMessage } from '../../context/ChannelStateContext';
-
+import type { TranslationContextValue } from '../../context/TranslationContext';
 import type { DefaultStreamChatGenerics } from '../../types/types';
 
 export type ChannelPreviewUIComponentProps<
@@ -52,6 +52,12 @@ export type ChannelPreviewProps<
   channelUpdateCount?: number;
   /** Custom class for the channel preview root */
   className?: string;
+  /** Custom function that generates the message preview in ChannelPreview component */
+  getLatestMessagePreview?: (
+    channel: Channel<StreamChatGenerics>,
+    t: TranslationContextValue['t'],
+    userLanguage: TranslationContextValue['userLanguage'],
+  ) => string | JSX.Element;
   key?: string;
   /** Custom ChannelPreview click handler function */
   onSelect?: (event: React.MouseEvent) => void;
@@ -68,7 +74,12 @@ export const ChannelPreview = <
 >(
   props: ChannelPreviewProps<StreamChatGenerics>,
 ) => {
-  const { channel, Preview = ChannelPreviewMessenger, channelUpdateCount } = props;
+  const {
+    channel,
+    Preview = ChannelPreviewMessenger,
+    channelUpdateCount,
+    getLatestMessagePreview = defaultGetLatestMessagePreview,
+  } = props;
   const { channel: activeChannel, client, setActiveChannel } = useChatContext<StreamChatGenerics>(
     'ChannelPreview',
   );

--- a/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
+++ b/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
@@ -18,7 +18,7 @@ const UnMemoizedChannelPreviewMessenger = <
     className: customClassName = '',
     displayImage,
     displayTitle,
-    latestMessage,
+    latestMessagePreview,
     onSelect: customOnSelectChannel,
     setActiveChannel,
     unread,
@@ -70,7 +70,9 @@ const UnMemoizedChannelPreviewMessenger = <
             </div>
           )}
         </div>
-        <div className='str-chat__channel-preview-messenger--last-message'>{latestMessage}</div>
+        <div className='str-chat__channel-preview-messenger--last-message'>
+          {latestMessagePreview}
+        </div>
       </div>
     </button>
   );

--- a/src/components/ChannelPreview/__tests__/ChannelPreviewMessenger.test.js
+++ b/src/components/ChannelPreview/__tests__/ChannelPreviewMessenger.test.js
@@ -30,7 +30,7 @@ describe('ChannelPreviewMessenger', () => {
           channel={channel}
           displayImage='https://randomimage.com/src.jpg'
           displayTitle='Channel name'
-          latestMessage='Latest message!'
+          latestMessagePreview='Latest message!'
           setActiveChannel={jest.fn()}
           unread={10}
           {...props}

--- a/src/components/ChannelPreview/utils.tsx
+++ b/src/components/ChannelPreview/utils.tsx
@@ -32,8 +32,7 @@ export const getLatestMessagePreview = <
   }
 
   if (previewTextToRender) {
-    const renderedText = renderPreviewText(previewTextToRender);
-    return renderedText;
+    return renderPreviewText(previewTextToRender);
   }
 
   if (latestMessage.command) {

--- a/src/components/ChannelPreview/utils.tsx
+++ b/src/components/ChannelPreview/utils.tsx
@@ -17,7 +17,7 @@ export const getLatestMessagePreview = <
   t: TranslationContextValue['t'],
   userLanguage: TranslationContextValue['userLanguage'] = 'en',
 ): string | JSX.Element => {
-  const latestMessage = channel.state.messages[channel.state.messages.length - 1];
+  const latestMessage = channel.state.latestMessages[channel.state.latestMessages.length - 1];
 
   const previewTextToRender =
     latestMessage?.i18n?.[`${userLanguage}_text` as `${TranslationLanguages}_text`] ||

--- a/src/mock-builders/event/messageUndeleted.js
+++ b/src/mock-builders/event/messageUndeleted.js
@@ -1,0 +1,10 @@
+export default (client, message, channel = {}) => {
+  const [channel_id, channel_type] = channel.cid.split(':');
+  client.dispatchEvent({
+    channel_id,
+    channel_type,
+    cid: channel.cid,
+    message,
+    type: 'message.undeleted',
+  });
+};


### PR DESCRIPTION
### 🎯 Goal

Fix bug of not syncing `lastMessage` and `latestMessage`. Meanwhile the `latestMessage` was correctly taken from the channel state, the `lastMessage` was set as any message coming with `message.new`, `message.updated` and `message.deleted`. Moreover, `message.undeleted` and `channel.truncate` were not taken into consideration when setting `lastMessage`. Now both are set from the `channel.state`.

Another fix is that `latestMessage` was derived from `channel.state.messages` what is a getter that returns the currently viewed message set in the message list, but not the latest message set. This had to be changed to `channel.state.latestMessages`.

I have deprecated `latestMessage` in favor of `latestMessagePreview` because for integrators (and for me) it was unclear how does it differ from `lastMessage`.

Finally I have added possibility to customize the possibility of generating latest message preview through new prop `getLatestMessagePreview` to `ChannelList` and `ChannelPreview`.

