### PR TITLE
fix: remove rejected channel query promises from channel query lock

### DIFF
--- a/src/utils/getChannel.ts
+++ b/src/utils/getChannel.ts
@@ -71,10 +71,8 @@ export const getChannel = async <
     try {
       WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid] = theChannel.watch(options);
       await WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
+    } finally {
       delete WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
-    } catch (e) {
-      delete WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
-      throw e;
     }
   }
 

--- a/src/utils/getChannel.ts
+++ b/src/utils/getChannel.ts
@@ -68,9 +68,14 @@ export const getChannel = async <
   if (queryPromise) {
     await queryPromise;
   } else {
-    WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid] = theChannel.watch(options);
-    await WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
-    delete WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
+    try {
+      WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid] = theChannel.watch(options);
+      await WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
+      delete WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
+    } catch (e) {
+      delete WATCH_QUERY_IN_PROGRESS_FOR_CHANNEL[originalCid];
+      throw e;
+    }
   }
 
   return theChannel;


### PR DESCRIPTION
### 🎯 Goal

Remove stale promise references from the channel query lock. If not removed, even if the whole chat is remounted, the rejected promise from the past leads to display of error in the chat UI. This is because the lock is located in the global scope.

