### PR TITLE
fix: change SuggestionEmoji to extended EmojiSearchIndexResult

### DIFF
--- a/src/components/ChatAutoComplete/ChatAutoComplete.tsx
+++ b/src/components/ChatAutoComplete/ChatAutoComplete.tsx
@@ -11,7 +11,7 @@ import type { CommandResponse, UserResponse } from 'stream-chat';
 
 import type { TriggerSettings } from '../MessageInput/DefaultTriggerProvider';
 import type { CustomTrigger, DefaultStreamChatGenerics, UnknownType } from '../../types/types';
-import type { EmojiSearchIndex } from '../MessageInput';
+import { EmojiSearchIndex, EmojiSearchIndexResult } from '../MessageInput';
 
 type ObjectUnion<T> = T[keyof T];
 
@@ -23,9 +23,7 @@ export type SuggestionUser<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 > = UserResponse<StreamChatGenerics>;
 
-export type SuggestionEmoji<T extends UnknownType = UnknownType> = Awaited<
-  ReturnType<EmojiSearchIndex<T>['search']>
->;
+export type SuggestionEmoji<T extends UnknownType = UnknownType> = EmojiSearchIndexResult & T;
 
 export type SuggestionItem<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,


### PR DESCRIPTION
### 🎯 Goal

[the type `SuggestionItem`](https://github.com/GetStream/stream-chat-react/blob/949446b6b5e5193da590e92487a9997fdd6da20d/src/components/ChatAutoComplete/ChatAutoComplete.tsx#L30) uses [type `SuggestionEmoji`](https://github.com/GetStream/stream-chat-react/blob/949446b6b5e5193da590e92487a9997fdd6da20d/src/components/ChatAutoComplete/ChatAutoComplete.tsx#L26) which is declared as an array (result of emoji search). But this cannot be right as every suggestion item component receives a single data point from an array. This iteration and passing of single objects is done in [`SuggestionList`]( https://github.com/GetStream/stream-chat-react/blob/949446b6b5e5193da590e92487a9997fdd6da20d/src/components/AutoCompleteTextarea/List.jsx#L121).

Without doing this change, it is impossible to implement custom suggestion list item component, because TS says the component would get **single** `CommandResponse` or `UserResponse` or an **array** of `EmojiSearchIndexResults`.
