### PR TITLE
fix: give preference to pasting text over files

### DIFF
--- a/src/components/MessageInput/hooks/usePasteHandler.ts
+++ b/src/components/MessageInput/hooks/usePasteHandler.ts
@@ -1,9 +1,5 @@
 import { useCallback } from 'react';
-import {
-  // dataTransferItemsHaveFiles,
-  dataTransferItemsToFiles,
-  FileLike,
-} from '../../ReactFileUtilities';
+import { dataTransferItemsToFiles, FileLike } from '../../ReactFileUtilities';
 import type { EnrichURLsController } from './useLinkPreviews';
 import { SetLinkPreviewMode } from '../types';
 
@@ -35,17 +31,15 @@ export const usePasteHandler = (
         }
 
         const fileLikes = await dataTransferItemsToFiles(Array.from(items));
-        if (fileLikes.length && isUploadEnabled) {
-          uploadNewFiles(fileLikes);
-          return;
-        }
 
-        // fallback to regular text paste
         if (plainTextPromise) {
           const pastedText = await plainTextPromise;
           insertText(pastedText);
           findAndEnqueueURLsToEnrich?.(pastedText, SetLinkPreviewMode.UPSERT);
           findAndEnqueueURLsToEnrich?.flush();
+        } else if (fileLikes.length && isUploadEnabled) {
+          uploadNewFiles(fileLikes);
+          return;
         }
       })(clipboardEvent);
     },


### PR DESCRIPTION
### 🎯 Goal

When a website content is copied or MS Word content is copied, the clipboards DataTransferItemList contains two items:

```
{kind: "string", type: "text/plain"}
{kind: "string", type: "text/html"}
```

The type `text/html` carries information about images, that can be uploaded to the back-end. Until now, if both item types were present, the `text/plain` type was ignored and images were extracted and uploaded from the `text/html` type. This lead to surprising behavior of user instead of observing the copied text to be pasted into the message composer, the images to be added as attachments.

This PR changes this behavior by giving preference to pasting text over images as chat applications usually do. The `text/html` content us thus ignored.