### PR TITLE
feat: support moderation v2 workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "emoji-mart": "^5.4.0",
     "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
     "react-dom": "^18.0.0 || ^17.0.0 || ^16.8.0",
-    "stream-chat": "^8.42.0"
+    "stream-chat": "^8.45.0"
   },
   "peerDependenciesMeta": {
     "@breezystack/lamejs": {
@@ -255,7 +255,7 @@
     "react-dom": "^18.1.0",
     "react-test-renderer": "^18.1.0",
     "semantic-release": "^19.0.5",
-    "stream-chat": "^8.42.0",
+    "stream-chat": "^8.45.0",
     "ts-jest": "^29.1.4",
     "typescript": "^5.4.5"
   },

--- a/src/components/Message/__tests__/MessageSimple.test.js
+++ b/src/components/Message/__tests__/MessageSimple.test.js
@@ -639,14 +639,26 @@ describe('<MessageSimple />', () => {
     expect(results).toHaveNoViolations();
   });
 
-  describe('bounced message', () => {
-    const bouncedMessageOptions = {
-      moderation_details: {
-        action: 'MESSAGE_RESPONSE_ACTION_BOUNCE',
+  describe.each([
+    [
+      'v1',
+      {
+        moderation_details: {
+          action: 'MESSAGE_RESPONSE_ACTION_BOUNCE',
+        },
+        type: 'error',
       },
-      type: 'error',
-    };
-
+    ],
+    [
+      'v2',
+      {
+        moderation: {
+          action: 'bounce',
+        },
+        type: 'error',
+      },
+    ],
+  ])('bounced message %s', (_, bouncedMessageOptions) => {
     it('should render error badge for bounced messages', async () => {
       const message = generateAliceMessage(bouncedMessageOptions);
       const { queryByTestId } = await renderMessageSimple({ message });

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -485,10 +485,11 @@ export const isOnlyEmojis = (text?: string) => {
 export const isMessageBounced = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 >(
-  message: Pick<StreamMessage<StreamChatGenerics>, 'type' | 'moderation_details'>,
+  message: Pick<StreamMessage<StreamChatGenerics>, 'type' | 'moderation' | 'moderation_details'>,
 ) =>
   message.type === 'error' &&
-  message.moderation_details?.action === 'MESSAGE_RESPONSE_ACTION_BOUNCE';
+  (message.moderation_details?.action === 'MESSAGE_RESPONSE_ACTION_BOUNCE' ||
+    message.moderation?.action === 'bounce');
 
 export const isMessageEdited = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics

--- a/yarn.lock
+++ b/yarn.lock
@@ -12200,10 +12200,10 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
-stream-chat@^8.42.0:
-  version "8.42.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.42.0.tgz#124ea2c10c6e8f7990304e1101c66751daf63e6c"
-  integrity sha512-8xZz+fmdHSOa3L1rHUOC4Wah+ipvLvdiOmeOfGK6uXnLOKlSHMOblwmQErrOoFM4SKfX9Bea3V8viaKUu6bPng==
+stream-chat@^8.45.0:
+  version "8.45.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.45.0.tgz#bbb18ea897138dabb5ccd045a40958ec7242923c"
+  integrity sha512-re6GPh4F50ksB5/5GG5FtNAji+ZFTmIcLBIUhkGlnCwNaM8Ub59jcoI21Rtf/51+Nwrcitld2MzzlY49RlkwOA==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"


### PR DESCRIPTION
### 🎯 Goal

Support moderation v2 workflow

Depends on https://github.com/GetStream/stream-chat-js/pull/1392

### 🛠 Implementation details

The moderation v2 workflow is the same as v1. The only difference is that the moderation data is received with `message.moderation` object instead of `message.moderation_details`. The new moderation object contains more attributes that can be later acted on.

The SDK will now also mark message as bounced if it carries `moderation` object with `action` attribute value equal to `bounce`.

### 🎨 UI Changes

No changes, the workflow is kept the same.
