### PR TITLE
fix: change useStateStore to use useSyncExternalStore

### DIFF
--- a/src/store/hooks/useStateStore.ts
+++ b/src/store/hooks/useStateStore.ts
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
 
 import type { StateStore } from 'stream-chat';
 

--- a/src/store/hooks/useStateStore.ts
+++ b/src/store/hooks/useStateStore.ts
@@ -26,18 +26,35 @@ export function useStateStore<
   );
 
   const wrappedSnapshot = useMemo(() => {
-    let cached: [T, O];
+    let cachedTuple: [T, O];
+
     return () => {
-      const current = store?.getLatestValue();
+      const currentValue = store?.getLatestValue();
 
-      if (!current) return undefined;
+      if (!currentValue) return undefined;
 
-      if (!cached || cached[0] !== current) {
-        cached = [current, selector(current)];
-        return cached[1];
+      // store value hasn't changed, no need to compare individual values
+      if (cachedTuple && cachedTuple[0] === currentValue) {
+        return cachedTuple[1];
       }
 
-      return cached[1];
+      const newlySelected = selector(currentValue);
+
+      // store value changed but selected values wouldn't have to, double-check selected
+      if (cachedTuple) {
+        let selectededAreEqualToCached = true;
+
+        for (const key in cachedTuple[1]) {
+          if (cachedTuple[1][key] === newlySelected[key]) continue;
+          selectededAreEqualToCached = false;
+          break;
+        }
+
+        if (selectededAreEqualToCached) return cachedTuple[1];
+      }
+
+      cachedTuple = [currentValue, newlySelected];
+      return cachedTuple[1];
     };
   }, [store, selector]);
 


### PR DESCRIPTION
### 🎯 Goal

Changing stores on the fly would keep previously calculated state for a bit before the effect would run to recalculate it - using `useSyncExternalStore` (thank you, @myandrienko) should alleviate this issue. Both `subscribe` and `getSnapshot` functions required by the React hook are wrapped to allow for selector functionality, [`geSnapshot` requires the output to be cached](https://react.dev/reference/react/useSyncExternalStore#parameters) so the wrapper reuses similar cache check mechanism as `subscribeWithSelector` does internally.