### PR TITLE
fix: channel-pinning related improvements

### DIFF
--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -14,7 +14,6 @@ import {
   ThreadList,
   ChatView,
 } from 'stream-chat-react';
-import 'stream-chat-react/css/v2/index.css';
 
 const params = (new Proxy(new URLSearchParams(window.location.search), {
   get: (searchParams, property) => searchParams.get(property as string),
@@ -38,7 +37,7 @@ const filters: ChannelFilters = {
   archived: false,
 };
 const options: ChannelOptions = { limit: 5, presence: true, state: true };
-const sort: ChannelSort = [{ pinned_at: 1 }, { last_message_at: -1 }, { updated_at: -1 }];
+const sort: ChannelSort = { pinned_at: 1, last_message_at: -1, updated_at: -1 };
 
 type LocalAttachmentType = Record<string, unknown>;
 type LocalChannelType = Record<string, unknown>;

--- a/examples/vite/src/index.scss
+++ b/examples/vite/src/index.scss
@@ -12,6 +12,12 @@ body,
   height: 100%;
 }
 
+@layer stream, emoji-replacement;
+
+@import url('stream-chat-react/css/v2/index.css') layer(stream);
+// use in combination with useImageFlagEmojisOnWindows prop on Chat component
+// @import url('stream-chat-react/css/v2/emoji-replacement.css') layer(emoji-replacement);
+
 #root {
   display: flex;
   height: 100%;

--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "textarea-caret": "^3.1.0",
     "tslib": "^2.6.2",
     "unist-builder": "^3.0.0",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "use-sync-external-store": "^1.4.0"
   },
   "optionalDependencies": {
     "@stream-io/transliterate": "^1.5.5",
@@ -207,6 +208,7 @@
     "@types/react-image-gallery": "^1.2.4",
     "@types/react-is": "^18.2.4",
     "@types/textarea-caret": "3.0.0",
+    "@types/use-sync-external-store": "^0.0.6",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "emoji-mart": "^5.4.0",
     "react": "^18.0.0 || ^17.0.0 || ^16.8.0",
     "react-dom": "^18.0.0 || ^17.0.0 || ^16.8.0",
-    "stream-chat": "^8.46.1"
+    "stream-chat": "^8.50.0"
   },
   "peerDependenciesMeta": {
     "@breezystack/lamejs": {
@@ -257,7 +257,7 @@
     "react-dom": "^18.1.0",
     "react-test-renderer": "^18.1.0",
     "semantic-release": "^19.0.5",
-    "stream-chat": "^8.47.1",
+    "stream-chat": "^8.50.0",
     "ts-jest": "^29.1.4",
     "typescript": "^5.4.5"
   },

--- a/src/components/ChannelList/hooks/useChannelMembershipState.ts
+++ b/src/components/ChannelList/hooks/useChannelMembershipState.ts
@@ -1,28 +1,15 @@
-import { useEffect, useState } from 'react';
-import type { Channel, ChannelState, ExtendableGenerics } from 'stream-chat';
+import type { Channel, ChannelMemberResponse, EventTypes, ExtendableGenerics } from 'stream-chat';
+import { useSelectedChannelState } from './useSelectedChannelState';
 
-import { useChatContext } from '../../../context';
+const selector = <SCG extends ExtendableGenerics>(c: Channel<SCG>) => c.state.membership;
+const keys: EventTypes[] = ['member.updated'];
 
-export const useChannelMembershipState = <SCG extends ExtendableGenerics>(
-  channel?: Channel<SCG>,
-) => {
-  const [membership, setMembership] = useState<ChannelState<SCG>['membership']>(
-    channel?.state.membership || {},
-  );
-
-  const { client } = useChatContext<SCG>();
-
-  useEffect(() => {
-    if (!channel) return;
-
-    const subscriptions = ['member.updated'].map((v) =>
-      client.on(v, () => {
-        setMembership(channel.state.membership);
-      }),
-    );
-
-    return () => subscriptions.forEach((subscription) => subscription.unsubscribe());
-  }, [client, channel]);
-
-  return membership;
-};
+export function useChannelMembershipState<SCG extends ExtendableGenerics>(
+  channel: Channel<SCG>,
+): ChannelMemberResponse<SCG>;
+export function useChannelMembershipState<SCG extends ExtendableGenerics>(
+  channel?: Channel<SCG> | undefined,
+): ChannelMemberResponse<SCG> | undefined;
+export function useChannelMembershipState<SCG extends ExtendableGenerics>(channel?: Channel<SCG>) {
+  return useSelectedChannelState({ channel, selector, stateChangeEventKeys: keys });
+}

--- a/src/components/ChannelList/hooks/useSelectedChannelState.ts
+++ b/src/components/ChannelList/hooks/useSelectedChannelState.ts
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
+import type { Channel, EventTypes, ExtendableGenerics } from 'stream-chat';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+export function useSelectedChannelState<SCG extends ExtendableGenerics, O>(_: {
+  channel: Channel<SCG>;
+  selector: (channel: Channel<SCG>) => O;
+  stateChangeEventKeys?: EventTypes[];
+}): O;
+export function useSelectedChannelState<SCG extends ExtendableGenerics, O>(_: {
+  selector: (channel: Channel<SCG>) => O;
+  channel?: Channel<SCG> | undefined;
+  stateChangeEventKeys?: EventTypes[];
+}): O | undefined;
+export function useSelectedChannelState<SCG extends ExtendableGenerics, O>({
+  channel,
+  stateChangeEventKeys = ['all'],
+  selector,
+}: {
+  selector: (channel: Channel<SCG>) => O;
+  channel?: Channel<SCG>;
+  stateChangeEventKeys?: EventTypes[];
+}): O | undefined {
+  const subscribe = useCallback(
+    (onStoreChange: (value: O) => void) => {
+      if (!channel) return noop;
+
+      const subscriptions = stateChangeEventKeys.map((et) =>
+        channel.on(et, () => {
+          onStoreChange(selector(channel));
+        }),
+      );
+
+      return () => subscriptions.forEach((subscription) => subscription.unsubscribe());
+    },
+    [channel, selector, stateChangeEventKeys],
+  );
+
+  const getSnapshot = useCallback(() => {
+    if (!channel) return undefined;
+
+    return selector(channel);
+  }, [channel, selector]);
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/src/components/ChannelList/utils.ts
+++ b/src/components/ChannelList/utils.ts
@@ -67,9 +67,6 @@ type MoveChannelUpwardsParams<SCG extends DefaultStreamChatGenerics = DefaultStr
   channelToMoveIndexWithinChannels?: number;
 };
 
-/**
- * This function should not be used to move pinned already channels.
- */
 export const moveChannelUpwards = <
   SCG extends DefaultStreamChatGenerics = DefaultStreamChatGenerics
 >({
@@ -90,8 +87,11 @@ export const moveChannelUpwards = <
   // receive messages and are not pinned should move upwards but only under the last pinned channel
   // in the list
   const considerPinnedChannels = shouldConsiderPinnedChannels(sort);
+  const isTargetChannelPinned = isChannelPinned(channelToMove);
 
-  if (targetChannelAlreadyAtTheTop) return channels;
+  if (targetChannelAlreadyAtTheTop || (considerPinnedChannels && isTargetChannelPinned)) {
+    return channels;
+  }
 
   const newChannels = [...channels];
 
@@ -118,7 +118,9 @@ export const moveChannelUpwards = <
 };
 
 /**
- * Returns `true` only if `{ pinned_at: -1 }` or `{ pinned_at: 1 }` option is first within the `sort` array or if `pinned_at` key of the `sort` object gets picked first when using `for...in`.
+ * Returns `true` only if object with `pinned_at` property is first within the `sort` array
+ * or if `pinned_at` key of the `sort` object gets picked first when using `for...in` looping mechanism
+ * and value of the `pinned_at` is either `1` or `-1`.
  */
 export const shouldConsiderPinnedChannels = <SCG extends ExtendableGenerics>(
   sort: ChannelListProps<SCG>['sort'],
@@ -166,7 +168,7 @@ export const extractSortValue = <SCG extends ExtendableGenerics>({
 };
 
 /**
- * Returns `true` only if `archived` property is set to `false` within `filters`.
+ * Returns `true` only if `archived` property is of type `boolean` within `filters` object.
  */
 export const shouldConsiderArchivedChannels = <SCG extends ExtendableGenerics>(
   filters: ChannelListProps<SCG>['filters'],
@@ -176,18 +178,24 @@ export const shouldConsiderArchivedChannels = <SCG extends ExtendableGenerics>(
   return typeof filters.archived === 'boolean';
 };
 
+/**
+ * Returns `true` only if `pinned_at` property is of type `string` within `membership` object.
+ */
 export const isChannelPinned = <SCG extends ExtendableGenerics>(channel: Channel<SCG>) => {
   if (!channel) return false;
 
-  const member = channel.state.membership;
+  const membership = channel.state.membership;
 
-  return !!member?.pinned_at;
+  return typeof membership.pinned_at === 'string';
 };
 
+/**
+ * Returns `true` only if `archived_at` property is of type `string` within `membership` object.
+ */
 export const isChannelArchived = <SCG extends ExtendableGenerics>(channel: Channel<SCG>) => {
   if (!channel) return false;
 
-  const member = channel.state.membership;
+  const membership = channel.state.membership;
 
-  return !!member?.archived_at;
+  return typeof membership.archived_at === 'string';
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12231,10 +12231,10 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
-stream-chat@^8.47.1:
-  version "8.47.1"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.47.1.tgz#5390c87cbb1929e7ca183aa1204dae3ab38469a2"
-  integrity sha512-raMAGYLT4UCVluMF0TMfdPKH9OUhDjH6e1HQdJIlllAFLaA8oxtG+e/7jyuPmVodLPzYCPqOt2eBH7soAkhV/A==
+stream-chat@^8.50.0:
+  version "8.50.0"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.50.0.tgz#ae9bd40da3d38a0302d62d0165b2b8f45d500ae2"
+  integrity sha512-n7iAp0QTpZmRbygKFdwKlJy4QhhWep+6mQ+ctn2OjBEkrhtKITc4fIaMcQT4lOc7om0K9YTskMRvdWa2ZBvEWg==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,6 +2769,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@types/use-sync-external-store@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz#60be8d21baab8c305132eb9cb912ed497852aadc"
+  integrity sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==
+
 "@types/uuid@^8.3.0":
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
@@ -12232,9 +12237,9 @@ statuses@2.0.1:
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
 stream-chat@^8.50.0:
-  version "8.50.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.50.0.tgz#ae9bd40da3d38a0302d62d0165b2b8f45d500ae2"
-  integrity sha512-n7iAp0QTpZmRbygKFdwKlJy4QhhWep+6mQ+ctn2OjBEkrhtKITc4fIaMcQT4lOc7om0K9YTskMRvdWa2ZBvEWg==
+  version "8.52.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-8.52.1.tgz#8c73627937a55d24e66685db3e32653d4e8022ba"
+  integrity sha512-Z17M3xr3KYl/vdko20YiNA5uZ0iKjAut3GOEI8hQ3nNm/wqkPkS6f5zsgu0axrshXlkoOSETI9zvJm13RLXlYA==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@types/jsonwebtoken" "~9.0.0"
@@ -13196,6 +13201,11 @@ use-latest@^1.0.0:
   integrity sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
+
+use-sync-external-store@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
+  integrity sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
### 🎯 Goal

Adjust certain conditions to match behavior of the RN implementation, add missing handler for the `notification.added_to_channel`.

#### Notable Changes
- `notification.added_to_channel` is being handled properly (considers pinned channels)
- if `sort` is an object and `pinned_at` is first in chronological order of property creation `{ pinned_at: 1 | -1 }` then pinned channels are considered (https://github.com/GetStream/stream-chat-react/issues/2595#issuecomment-2569118691)

Related PR: https://github.com/GetStream/stream-chat-js/pull/1430


