### PR TITLE
feat: add disabled prop to ChatAutoComplete

### DIFF
--- a/src/components/ChatAutoComplete/ChatAutoComplete.tsx
+++ b/src/components/ChatAutoComplete/ChatAutoComplete.tsx
@@ -96,6 +96,8 @@ export type SuggestionListProps<
 >;
 
 export type ChatAutoCompleteProps<T extends UnknownType = UnknownType> = {
+  /** Override the default disabled state of the underlying `textarea` component */
+  disabled?: boolean;
   /** Function to override the default submit handler on the underlying `textarea` component */
   handleSubmit?: (event: React.BaseSyntheticEvent) => void;
   /** Function to run on blur of the underlying `textarea` component */
@@ -167,7 +169,7 @@ const UnMemoizedChatAutoComplete = <
       closeCommandsList={messageInput.closeCommandsList}
       closeMentionsList={messageInput.closeMentionsList}
       containerClassName='str-chat__textarea str-chat__message-textarea-react-host'
-      disabled={disabled || !!cooldownRemaining}
+      disabled={props.disabled ?? (disabled || !!cooldownRemaining)}
       disableMentions={messageInput.disableMentions}
       grow={messageInput.grow}
       handleSubmit={props.handleSubmit || messageInput.handleSubmit}


### PR DESCRIPTION
### 🎯 Goal

Per convo in our shared Slack channel, I thought it would be useful if you could pass in a `disabled` prop to the `ChatAutoComplete` component which would be forwarded to the underlying textArea component. This becomes useful when implementing a custom `Input` component so that you can disable the text area from within the component instead of having to hoist state one level up and pass in a prop into the `MessageInput` instead which can lead to unnecessary rerenders of the parent component and feels like an extra level of indirection.

### 🛠 Implementation details

Add support for a `disabled` prop in the `ChatAutoComplete` component which overwrites and takes precedence over the initial disabled logic and corresponding message input context value.

### 🎨 UI Changes

N/A
