### PR TITLE
feat: render Markdown within quoted message components

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "@semantic-release/changelog": "^6.0.2",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@stream-io/stream-chat-css": "^5.7.0",
+    "@stream-io/stream-chat-css": "^5.7.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/src/components/Message/QuotedMessage.tsx
+++ b/src/components/Message/QuotedMessage.tsx
@@ -56,8 +56,8 @@ export const QuotedMessage = <
       : null;
 
   const renderedText = useMemo(
-    () => renderText(quotedMessageText),
-    [quotedMessageText, renderText],
+    () => renderText(quotedMessageText, quoted_message?.mentioned_users),
+    [quotedMessageText, quoted_message?.mentioned_users, renderText],
   );
 
   if (!quoted_message) return null;

--- a/src/components/MessageInput/MessageInputFlat.tsx
+++ b/src/components/MessageInput/MessageInputFlat.tsx
@@ -141,7 +141,8 @@ export const MessageInputFlat = <
   const recordingEnabled = !!(recordingController.recorder && navigator.mediaDevices); // account for requirement on iOS as per this bug report: https://bugs.webkit.org/show_bug.cgi?id=252303
   const isRecording = !!recordingController.recordingState;
 
-  /* This bit here is needed to make sure that we can get rid of the default behaviour
+  /**
+   * This bit here is needed to make sure that we can get rid of the default behaviour
    * if need be. Essentially this allows us to pass StopAIGenerationButton={null} and
    * completely circumvent the default logic if it's not what we want. We need it as a
    * prop because there is no other trivial way to override the SendMessage button otherwise.

--- a/src/components/MessageInput/QuotedMessagePreview.tsx
+++ b/src/components/MessageInput/QuotedMessagePreview.tsx
@@ -12,7 +12,9 @@ import { useTranslationContext } from '../../context/TranslationContext';
 
 import type { TranslationLanguages } from 'stream-chat';
 import type { StreamMessage } from '../../context/ChannelStateContext';
+import type { MessageContextValue } from '../../context';
 import type { DefaultStreamChatGenerics } from '../../types/types';
+import { renderText as defaultRenderText } from '../Message';
 
 export const QuotedMessagePreviewHeader = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
@@ -41,12 +43,14 @@ export type QuotedMessagePreviewProps<
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 > = {
   quotedMessage: StreamMessage<StreamChatGenerics>;
+  renderText?: MessageContextValue<StreamChatGenerics>['renderText'];
 };
 
 export const QuotedMessagePreview = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
 >({
   quotedMessage,
+  renderText = defaultRenderText,
 }: QuotedMessagePreviewProps<StreamChatGenerics>) => {
   const { client } = useChatContext();
   const { Attachment = DefaultAttachment, Avatar = DefaultAvatar } =
@@ -56,6 +60,11 @@ export const QuotedMessagePreview = <
   const quotedMessageText =
     quotedMessage.i18n?.[`${userLanguage}_text` as `${TranslationLanguages}_text`] ||
     quotedMessage.text;
+
+  const renderedText = useMemo(
+    () => renderText(quotedMessageText, quotedMessage.mentioned_users),
+    [quotedMessage.mentioned_users, quotedMessageText, renderText],
+  );
 
   const quotedMessageAttachment = useMemo(() => {
     const [attachment] = quotedMessage.attachments ?? [];
@@ -91,7 +100,7 @@ export const QuotedMessagePreview = <
               className='str-chat__quoted-message-text'
               data-testid='quoted-message-text'
             >
-              <p>{quotedMessageText}</p>
+              {renderedText}
             </div>
           </>
         )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2359,10 +2359,10 @@
   resolved "https://registry.yarnpkg.com/@stream-io/escape-string-regexp/-/escape-string-regexp-5.0.1.tgz#362505c92799fea6afe4e369993fbbda8690cc37"
   integrity sha512-qIaSrzJXieZqo2fZSYTdzwSbZgHHsT3tkd646vvZhh4fr+9nO4NlvqGmPF43Y+OfZiWf+zYDFgNiPGG5+iZulQ==
 
-"@stream-io/stream-chat-css@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@stream-io/stream-chat-css/-/stream-chat-css-5.7.0.tgz#9626f35ae4eb5320bec90ba27a343c00e5bbd3e7"
-  integrity sha512-3CtbS5BV0PfW1kTDJtj1oSoPEreINu2Q9cJEEXUmRguOLb6LMjS3OsSnZq78RYHdECNfta3I2M8JxdFlRTEKSA==
+"@stream-io/stream-chat-css@^5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@stream-io/stream-chat-css/-/stream-chat-css-5.7.1.tgz#051fb336126e9141bb77bdfd8535326702c6e9ff"
+  integrity sha512-iFar7bsI0Rh5aLG3Joeh3kHK6pkulX6alcC9l5D8zN+w7pXOQIQ87jOjIFjqTnxkQp80s2RgehNZt9Vy3zTaIg==
 
 "@stream-io/transliterate@^1.5.5":
   version "1.5.5"


### PR DESCRIPTION
### 🎯 Goal

Currently, Markdown text is not being rendered properly within quoted messages (`renderText` omitted). This PR aims at adding `renderText` to both `QuotedMessage` and `QuotedMessagePreview` components.

#### Missing

- [x] CSS adjustment to mention `span` selector (must include message input too), [PR](https://github.com/GetStream/stream-chat-css/pull/325)
- [x] tests, [07fc7cf](https://github.com/GetStream/stream-chat-react/pull/2640/commits/07fc7cf6f7c7e5eb816b14052bf1d9f09c58ad8d)

#### DO NOT MERGE BEFORE INSTALLING LATEST `@stream-io/stream-chat-css`