### PR TITLE
feat: default data interfaces

### DIFF
--- a/src/@types/stream-chat-common-custom-data.d.ts
+++ b/src/@types/stream-chat-common-custom-data.d.ts
@@ -1,9 +1,0 @@
-import 'stream-chat';
-
-declare module 'stream-chat' {
-  interface CustomChannelData {
-    image?: string;
-    name?: string;
-    subtitle?: string;
-  }
-}

--- a/src/@types/stream-chat-custom-data.d.ts
+++ b/src/@types/stream-chat-custom-data.d.ts
@@ -1,0 +1,39 @@
+import 'stream-chat';
+
+import {
+  DefaultAttachmentData,
+  DefaultChannelData,
+  DefaultCommandData,
+  DefaultEventData,
+  DefaultMemberData,
+  DefaultMessageData,
+  DefaultPollData,
+  DefaultPollOptionData,
+  DefaultReactionData,
+  DefaultThreadData,
+  DefaultUserData,
+} from '../types/defaultDataInterfaces';
+
+declare module 'stream-chat' {
+  interface CustomChannelData extends DefaultChannelData {}
+
+  interface CustomAttachmentData extends DefaultAttachmentData {}
+
+  interface CustomCommandData extends DefaultCommandData {}
+
+  interface CustomEventData extends DefaultEventData {}
+
+  interface CustomMemberData extends DefaultMemberData {}
+
+  interface CustomMessageData extends DefaultMessageData {}
+
+  interface CustomPollOptionData extends DefaultPollOptionData {}
+
+  interface CustomPollData extends DefaultPollData {}
+
+  interface CustomReactionData extends DefaultReactionData {}
+
+  interface CustomUserData extends DefaultUserData {}
+
+  interface CustomThreadData extends DefaultThreadData {}
+}

--- a/src/types/defaultDataInterfaces.ts
+++ b/src/types/defaultDataInterfaces.ts
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+export interface DefaultChannelData {
+  image?: string;
+  name?: string;
+  subtitle?: string;
+}
+
+export interface DefaultAttachmentData {}
+
+export interface DefaultCommandData {}
+
+export interface DefaultEventData {}
+
+export interface DefaultMemberData {}
+
+export interface DefaultMessageData {}
+
+export interface DefaultPollOptionData {}
+
+export interface DefaultPollData {}
+
+export interface DefaultReactionData {}
+
+export interface DefaultUserData {}
+
+export interface DefaultThreadData {}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export type { ChannelUnreadUiState } from './types';
+export type * from './defaultDataInterfaces';

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,13 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import type { LoadingIndicatorProps } from '../components/Loading/LoadingIndicator';
-import type {
-  APIErrorResponse,
-  Attachment,
-  ErrorFromResponse,
-  Event,
-  Mute,
-  ChannelState as StreamChannelState,
-} from 'stream-chat';
+import type { Attachment, ChannelState as StreamChannelState } from 'stream-chat';
 
 export type UnknownType = Record<string, unknown>;
 export type PropsWithChildrenOnly = PropsWithChildren<Record<never, never>>;
@@ -20,42 +13,6 @@ export type CustomTrigger = {
 };
 
 export type CustomMessageType = 'channel.intro' | 'message.date';
-
-export type DefaultAttachmentType = UnknownType & {
-  asset_url?: string;
-  file_size?: number;
-  id?: string;
-  images?: Array<{
-    image_url?: string;
-    thumb_url?: string;
-  }>;
-};
-
-export type DefaultChannelType = UnknownType & {
-  frozen?: boolean;
-  image?: string;
-  member_count?: number;
-  subtitle?: string;
-};
-
-export type DefaultMessageType = UnknownType & {
-  customType?: CustomMessageType;
-  date?: string | Date;
-  error?: ErrorFromResponse<APIErrorResponse>;
-  errorStatusCode?: number;
-  event?: Event;
-  unread?: boolean;
-};
-
-export type DefaultUserTypeInternal = {
-  image?: string;
-  status?: string;
-};
-
-export type DefaultUserType = UnknownType &
-  DefaultUserTypeInternal & {
-    mutes?: Array<Mute>;
-  };
 
 export type GiphyVersions =
   | 'original'
@@ -117,7 +74,7 @@ export type VideoAttachmentSizeHandler = (
 
 export type ChannelUnreadUiState = Omit<ValuesType<StreamChannelState['read']>, 'user'>;
 
-// todo: fix export from stream-chat - for some reason not exported
+// TODO: fix export from stream-chat - for some reason not exported
 export type SendMessageOptions = {
   force_moderation?: boolean;
   is_pending_message?: boolean;


### PR DESCRIPTION
### 🎯 Goal

Introduce default data interfaces which are used to extend `stream-chat` interfaces with custom data used across the SDK. These defaults can be used by our integrators who use our default components which expect this custom data to be present.
