### PR TITLE
feat: introduce WithDragAndDropUpload component

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -212,7 +212,10 @@ export type ChannelProps<
     updatedMessage: UpdatedMessage<StreamChatGenerics>,
     options?: UpdateMessageOptions,
   ) => ReturnType<StreamChat<StreamChatGenerics>['updateMessage']>;
-  /** If true, chat users will be able to drag and drop file uploads to the entire channel window */
+  /**
+   * @deprecated Use `WithDragAndDropUpload` instead (wrap draggable-to elements with this component).
+   * @description If true, chat users will be able to drag and drop file uploads to the entire channel window
+   */
   dragAndDropWindow?: boolean;
   /** Custom UI component to be shown if no active channel is set, defaults to null and skips rendering the Channel component */
   EmptyPlaceholder?: React.ReactElement;
@@ -246,7 +249,10 @@ export type ChannelProps<
   onMentionsClick?: OnMentionAction<StreamChatGenerics>;
   /** Custom action handler function to run on hover of an @mention in a message */
   onMentionsHover?: OnMentionAction<StreamChatGenerics>;
-  /** If `dragAndDropWindow` prop is true, the props to pass to the MessageInput component (overrides props placed directly on MessageInput) */
+  /**
+   * @deprecated Use `WithDragAndDropUpload` instead (wrap draggable-to elements with this component).
+   * @description If `dragAndDropWindow` prop is `true`, the props to pass to the `MessageInput` component (overrides props placed directly on `MessageInput`)
+   */
   optionalMessageInputProps?: MessageInputProps<StreamChatGenerics, V>;
   /** You can turn on/off thumbnail generation for video attachments */
   shouldGenerateVideoThumbnail?: boolean;

--- a/src/components/MessageInput/MessageInput.tsx
+++ b/src/components/MessageInput/MessageInput.tsx
@@ -26,6 +26,7 @@ import type {
 } from '../../types/types';
 import type { URLEnrichmentConfig } from './hooks/useLinkPreviews';
 import type { CustomAudioRecordingConfig } from '../MediaRecorder';
+import { useHandleDragAndDropQueuedFiles } from './WithDragAndDropUpload';
 
 export type EmojiSearchIndexResult = {
   id: string;
@@ -150,6 +151,9 @@ const MessageInputProvider = <
     ...props,
     emojiSearchIndex: props.emojiSearchIndex ?? emojiSearchIndex,
   });
+
+  // @ts-expect-error generics to be removed
+  useHandleDragAndDropQueuedFiles(messageInputContextValue);
 
   return (
     <MessageInputContextProvider<StreamChatGenerics, V> value={messageInputContextValue}>

--- a/src/components/MessageInput/MessageInputFlat.tsx
+++ b/src/components/MessageInput/MessageInputFlat.tsx
@@ -131,7 +131,7 @@ export const MessageInputFlat = <
     !!StopAIGenerationButton;
 
   return (
-    <WithDragAndDropUpload as='div' className='str-chat__message-input'>
+    <WithDragAndDropUpload className='str-chat__message-input' component='div'>
       {recordingEnabled &&
         recordingController.permissionState === 'denied' &&
         showRecordingPermissionDeniedNotification && (

--- a/src/components/MessageInput/WithDragAndDropUpload.tsx
+++ b/src/components/MessageInput/WithDragAndDropUpload.tsx
@@ -1,0 +1,149 @@
+import React, {
+  CSSProperties,
+  ElementType,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  MessageInputContextValue,
+  useChannelStateContext,
+  useMessageInputContext,
+  useTranslationContext,
+} from '../../context';
+import { useDropzone } from 'react-dropzone';
+import clsx from 'clsx';
+
+const DragAndDropUploadContext = React.createContext<{
+  fileQueue: File[];
+  addFilesToQueue: ((files: File[]) => void) | null;
+  removeFilesFromQueue: ((files: File[]) => void) | null;
+}>({
+  addFilesToQueue: null,
+  fileQueue: [],
+  removeFilesFromQueue: null,
+});
+
+export const useDragAndDropUploadContext = () => useContext(DragAndDropUploadContext);
+
+/**
+ * @private To maintain top -> bottom data flow, the drag-and-drop functionality allows dragging any files to the queue - the closest
+ * `MessageInputProvider` will be notified through `DragAndDropUploadContext.fileQueue` and starts the upload with `uploadNewAttachments`,
+ * forwarded files are immediately after removed from the queue.
+ */
+export const useHandleDragAndDropQueuedFiles = ({
+  uploadNewFiles,
+}: MessageInputContextValue) => {
+  const { fileQueue, removeFilesFromQueue } = useDragAndDropUploadContext();
+
+  // const uploadNewFilesReference = useRef<((f: File[]) => void) | undefined>(undefined);
+
+  // uploadNewFilesReference.current = (f) => messageInputContextValue.uploadNewFiles(f);
+
+  useEffect(() => {
+    if (!removeFilesFromQueue) return;
+
+    // uploadNewFilesReference.current?.(fileQueue);
+    uploadNewFiles(fileQueue);
+
+    removeFilesFromQueue(fileQueue);
+  }, [fileQueue, removeFilesFromQueue, uploadNewFiles]);
+};
+
+/**
+ * Wrapper to replace now deprecated `Channel.dragAndDropWindow` option.
+ *
+ * @example
+ * ```tsx
+ * <Channel>
+ *  <WithDragAndDropUpload as="section" className="message-list-dnd-wrapper">
+ *    <Window>
+ *      <MessageList />
+ *      <MessageInput />
+ *    </Window>
+ *  </WithDragAndDropUpload>
+ *  <Thread />
+ * <Channel>
+ * ```
+ */
+export const WithDragAndDropUpload = ({
+  as: Component = 'div',
+  children,
+  className,
+  style,
+}: PropsWithChildren<{
+  as?: ElementType;
+  className?: string;
+  style?: CSSProperties;
+}>) => {
+  const [files, setFiles] = useState<File[]>([]);
+  const { acceptedFiles = [], multipleUploads } = useChannelStateContext();
+  const { t } = useTranslationContext();
+
+  const messageInputContext = useMessageInputContext();
+  const dragAndDropUploadContext = useDragAndDropUploadContext();
+
+  // if message input context is available, there's no need to use the queue
+  const isWithinMessageInputContext =
+    typeof messageInputContext.uploadNewFiles === 'function';
+
+  const accept = useMemo(
+    () =>
+      acceptedFiles.reduce<Record<string, Array<string>>>((mediaTypeMap, mediaType) => {
+        mediaTypeMap[mediaType] ??= [];
+        return mediaTypeMap;
+      }, {}),
+    [acceptedFiles],
+  );
+
+  const addFilesToQueue = useCallback((files: File[]) => {
+    setFiles((cv) => cv.concat(files));
+  }, []);
+
+  const removeFilesFromQueue = useCallback((files: File[]) => {
+    if (!files.length) return;
+    setFiles((cv) => cv.filter((f) => files.indexOf(f) === -1));
+  }, []);
+
+  const { getRootProps, isDragActive, isDragReject } = useDropzone({
+    accept,
+    disabled: isWithinMessageInputContext
+      ? !messageInputContext.isUploadEnabled || messageInputContext.maxFilesLeft === 0
+      : false,
+    multiple: multipleUploads,
+    noClick: true,
+    onDrop: isWithinMessageInputContext
+      ? messageInputContext.uploadNewFiles
+      : addFilesToQueue,
+  });
+
+  // nested WithDragAndDropUpload components render wrappers without functionality
+  // (MessageInputFlat has a default WithDragAndDropUpload)
+  if (dragAndDropUploadContext.removeFilesFromQueue !== null) {
+    return <Component className={className}>{children}</Component>;
+  }
+
+  return (
+    <DragAndDropUploadContext.Provider
+      value={{ addFilesToQueue, fileQueue: files, removeFilesFromQueue }}
+    >
+      <Component {...getRootProps({ className, style })}>
+        {/* TODO: could be a replaceable component */}
+        {isDragActive && (
+          <div
+            className={clsx('str-chat__dropzone-container', {
+              'str-chat__dropzone-container--not-accepted': isDragReject,
+            })}
+          >
+            {!isDragReject && <p>{t<string>('Drag your files here')}</p>}
+            {isDragReject && <p>{t<string>('Some of the files will not be accepted')}</p>}
+          </div>
+        )}
+        {children}
+      </Component>
+    </DragAndDropUploadContext.Provider>
+  );
+};

--- a/src/components/MessageInput/WithDragAndDropUpload.tsx
+++ b/src/components/MessageInput/WithDragAndDropUpload.tsx
@@ -32,21 +32,16 @@ export const useDragAndDropUploadContext = () => useContext(DragAndDropUploadCon
 /**
  * @private To maintain top -> bottom data flow, the drag-and-drop functionality allows dragging any files to the queue - the closest
  * `MessageInputProvider` will be notified through `DragAndDropUploadContext.fileQueue` and starts the upload with `uploadNewAttachments`,
- * forwarded files are immediately after removed from the queue.
+ * forwarded files are removed from the queue immediately after.
  */
 export const useHandleDragAndDropQueuedFiles = ({
   uploadNewFiles,
 }: MessageInputContextValue) => {
   const { fileQueue, removeFilesFromQueue } = useDragAndDropUploadContext();
 
-  // const uploadNewFilesReference = useRef<((f: File[]) => void) | undefined>(undefined);
-
-  // uploadNewFilesReference.current = (f) => messageInputContextValue.uploadNewFiles(f);
-
   useEffect(() => {
     if (!removeFilesFromQueue) return;
 
-    // uploadNewFilesReference.current?.(fileQueue);
     uploadNewFiles(fileQueue);
 
     removeFilesFromQueue(fileQueue);
@@ -59,7 +54,7 @@ export const useHandleDragAndDropQueuedFiles = ({
  * @example
  * ```tsx
  * <Channel>
- *  <WithDragAndDropUpload as="section" className="message-list-dnd-wrapper">
+ *  <WithDragAndDropUpload component="section" className="message-list-dnd-wrapper">
  *    <Window>
  *      <MessageList />
  *      <MessageInput />
@@ -70,12 +65,16 @@ export const useHandleDragAndDropQueuedFiles = ({
  * ```
  */
 export const WithDragAndDropUpload = ({
-  as: Component = 'div',
   children,
   className,
+  component: Component = 'div',
   style,
 }: PropsWithChildren<{
-  as?: ElementType;
+  /**
+   * @description An element to render as a wrapper onto which drag & drop functionality will be applied.
+   * @default 'div'
+   */
+  component?: ElementType;
   className?: string;
   style?: CSSProperties;
 }>) => {
@@ -110,6 +109,8 @@ export const WithDragAndDropUpload = ({
 
   const { getRootProps, isDragActive, isDragReject } = useDropzone({
     accept,
+    // apply `disabled` rules if available, otherwise allow anything and
+    // let the `uploadNewFiles` handle the limitations internally
     disabled: isWithinMessageInputContext
       ? !messageInputContext.isUploadEnabled || messageInputContext.maxFilesLeft === 0
       : false,

--- a/src/components/MessageInput/index.ts
+++ b/src/components/MessageInput/index.ts
@@ -18,4 +18,5 @@ export * from './MessageInput';
 export * from './MessageInputFlat';
 export * from './QuotedMessagePreview';
 export * from './SendButton';
+export { WithDragAndDropUpload } from './WithDragAndDropUpload';
 export * from './types';

--- a/src/context/MessageInputContext.tsx
+++ b/src/context/MessageInputContext.tsx
@@ -44,15 +44,12 @@ export const useMessageInputContext = <
   StreamChatGenerics extends DefaultStreamChatGenerics = DefaultStreamChatGenerics,
   V extends CustomTrigger = CustomTrigger,
 >(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   componentName?: string,
 ) => {
   const contextValue = useContext(MessageInputContext);
 
   if (!contextValue) {
-    console.warn(
-      `The useMessageInputContext hook was called outside of the MessageInputContext provider. Make sure this hook is called within the MessageInput's UI component. The errored call is located in the ${componentName} component.`,
-    );
-
     return {} as MessageInputContextValue<StreamChatGenerics, V>;
   }
 


### PR DESCRIPTION
### 🎯 Goal

Current `Channel.dragAndDropWindow` and `Channel.optionalMessageInputProps` architecture which used to allow drag&drop file upload by dropping files onto the message list (channel) component suffers from a few pain points: 
- duplicate `MessageInputContextProvider` initialization, see [here](https://github.com/GetStream/stream-chat-react/blob/5fa6b0fc239a7d48032ae4c3d34e29969c52bd0c/src/components/Channel/Channel.tsx#L1479-L1484), [here](https://github.com/GetStream/stream-chat-react/blob/5fa6b0fc239a7d48032ae4c3d34e29969c52bd0c/src/components/MessageInput/MessageInput.tsx#L137-L159) and [here](https://github.com/GetStream/stream-chat-react/blob/5fa6b0fc239a7d48032ae4c3d34e29969c52bd0c/src/components/MessageInput/DropzoneProvider.tsx#L47-L67) ([related issue](https://getstream.slack.com/archives/C02R5UCGN6N/p1740392263047589))
- broken styling ([v2 vendor folder](https://github.com/GetStream/stream-chat-css/tree/v5.8.0/src/v2/styles/vendor) is missing [react-file-utils styling](https://github.com/GetStream/stream-chat-css/blob/v5.8.0/src/vendor/react-file-utils.scss))

New solution allows dragging and uploading files both in "channel" and in thread individually - which was previously impossible. The new solution also reuses drag and drop styling which is used by default in `MessageInputFlat` component (some minor adjustments from integrators are needed - such as setting relative positioning on required parents).

#### Old API:

```tsx
<Channel dragAndDropWindow>
  <Window>
    <ChannelHeader />
    <MessageList />
    <AIStateIndicator />
    <MessageInput focus />
  </Window>
  <Thread virtualized />
</Channel>
```

#### New API:

```tsx
<Channel>
  <WithDragAndDropUpload className='str-chat__main-panel'>
    <ChannelHeader/>
    <MessageList />
    <AIStateIndicator />
    <MessageInput focus />
  </WithDragAndDropUpload>
  <WithDragAndDropUpload>
    <Thread virtualized />
  </WithDragAndDropUpload>
</Channel>
```

### Deprecations

#### Public

- `Channel.dragAndDropWindow` prop (will remove in v13)
- `Channel.optionalMessageInputProps` prop (will remove in v13)

#### Private

- `DropzoneProvider`
- `DropzoneInner`
- `ImageDropzone`

Note: This is not a direct fix of the issue I mentioned above (Slack link), I believe the proper fix is to move away from this messy architecture (by removing deprecated components and options which we'll do in v13 once this PR is merged).

THIS PR RELIES ON [CSS CHANGES](https://github.com/GetStream/stream-chat-css/pull/329)

### 🎨 UI Changes
Before:
![image](https://github.com/user-attachments/assets/0514c338-8d52-44d8-aecd-60bf86acdee2)
After:
![image](https://github.com/user-attachments/assets/3afd1468-d552-4180-9be6-b9ffbe503526)

