### PR TITLE
fix: prevent sorting poll options in place

### DIFF
--- a/src/components/Poll/PollActions/PollResults/PollResults.tsx
+++ b/src/components/Poll/PollActions/PollResults/PollResults.tsx
@@ -14,7 +14,7 @@ type PollStateSelectorReturnValue = {
 };
 const pollStateSelector = (nextValue: PollState): PollStateSelectorReturnValue => ({
   name: nextValue.name,
-  options: nextValue.options,
+  options: [...nextValue.options],
   vote_counts_by_option: nextValue.vote_counts_by_option,
 });
 


### PR DESCRIPTION
### 🎯 Goal

Prevent options mutation in place and thus modifying the state store without call to next / partialNext