### PR TITLE
fix: prevent rendering placeholder for empty message list if messages are actually loaded 

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -326,6 +326,7 @@ const ChannelInner = (
       ...initialState,
       hasMore: channel.state.messagePagination.hasPrev,
       loading: !channel.initialized,
+      messages: channel.state.messages,
     },
   );
   const jumpToMessageFromSearch = useSearchFocusedMessage();

--- a/src/components/MessageList/VirtualizedMessageListComponents.tsx
+++ b/src/components/MessageList/VirtualizedMessageListComponents.tsx
@@ -87,6 +87,13 @@ export const EmptyPlaceholder = ({ context }: CommonVirtuosoComponentProps) => {
   const { EmptyStateIndicator = DefaultEmptyStateIndicator } = useComponentContext(
     'VirtualizedMessageList',
   );
+  // prevent showing that there are no messages if there actually are messages (for some reason virtuoso decides to render empty placeholder first, even though it has the totalCount prop > 0)
+  if (
+    typeof context?.processedMessages !== 'undefined' &&
+    context.processedMessages.length > 0
+  )
+    return null;
+
   return (
     <>
       {EmptyStateIndicator && (


### PR DESCRIPTION
### 🎯 Goal

Closes REACT-411 

Prevent showing empty message list indicator when we already have message loaded in state.

