### PR TITLE
fix: make MessageThreadReplyInChannelButtonIndicator to MessageIsThreadReplyInChannelButtonIndicator

### DIFF
--- a/src/components/Message/MessageIsThreadReplyInChannelButtonIndicator.tsx
+++ b/src/components/Message/MessageIsThreadReplyInChannelButtonIndicator.tsx
@@ -9,7 +9,7 @@ import {
   useTranslationContext,
 } from '../../context';
 
-export const MessageThreadReplyInChannelButtonIndicator = () => {
+export const MessageIsThreadReplyInChannelButtonIndicator = () => {
   const { client } = useChatContext();
   const { t } = useTranslationContext();
   const { channel } = useChannelStateContext();
@@ -36,7 +36,7 @@ export const MessageThreadReplyInChannelButtonIndicator = () => {
           },
           origin: {
             context: { threadReply: message },
-            emitter: 'MessageThreadReplyInChannelButtonIndicator',
+            emitter: 'MessageIsThreadReplyInChannelButtonIndicator',
           },
         });
       });

--- a/src/components/Message/MessageSimple.tsx
+++ b/src/components/Message/MessageSimple.tsx
@@ -12,7 +12,7 @@ import { MessageText } from './MessageText';
 import { MessageTimestamp as DefaultMessageTimestamp } from './MessageTimestamp';
 import { StreamedMessageText as DefaultStreamedMessageText } from './StreamedMessageText';
 import { isDateSeparatorMessage } from '../MessageList';
-import { MessageThreadReplyInChannelButtonIndicator as DefaultMessageIsThreadReplyInChannelButtonIndicator } from './MessageThreadReplyInChannelButtonIndicator';
+import { MessageIsThreadReplyInChannelButtonIndicator as DefaultMessageIsThreadReplyInChannelButtonIndicator } from './MessageIsThreadReplyInChannelButtonIndicator';
 import { ReminderNotification as DefaultReminderNotification } from './ReminderNotification';
 import { useMessageReminder } from './hooks';
 import {

--- a/src/context/ComponentContext.tsx
+++ b/src/context/ComponentContext.tsx
@@ -125,7 +125,7 @@ export type ComponentContextValue = {
   MessageBlocked?: React.ComponentType;
   /** Custom UI component for a deleted message, defaults to and accepts same props as: [MessageDeleted](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message/MessageDeleted.tsx) */
   MessageDeleted?: React.ComponentType<MessageDeletedProps>;
-  /** Custom UI component for an indicator that a message is a thread reply sent to channel list: [MessageThreadReplyInChannelButtonIndicator](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message/MessageIsThreadReplyInChannelButtonIndicator.tsx) */
+  /** Custom UI component for an indicator that a message is a thread reply sent to channel list: [MessageIsThreadReplyInChannelButtonIndicator](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message/MessageIsThreadReplyInChannelButtonIndicator.tsx) */
   MessageIsThreadReplyInChannelButtonIndicator?: React.ComponentType;
   MessageListMainPanel?: React.ComponentType<PropsWithChildrenOnly>;
   /** Custom UI component that displays message and connection status notifications in the `MessageList`, defaults to and accepts same props as [DefaultMessageListNotifications](https://github.com/GetStream/stream-chat-react/blob/master/src/components/MessageList/MessageListNotifications.tsx) */


### PR DESCRIPTION
### 🎯 Goal

Unify default component name with the actual  component context name - MessageIsThreadReplyInChannelButtonIndicator.