### PR TITLE
fix: allow to pre-register TranslationTopic translator functions

### DIFF
--- a/src/context/ComponentContext.tsx
+++ b/src/context/ComponentContext.tsx
@@ -175,6 +175,7 @@ export type ComponentContextValue = {
   /** Custom UI component to display the reactions modal, defaults to and accepts same props as: [ReactionsListModal](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Reactions/ReactionsListModal.tsx) */
   ReactionsListModal?: React.ComponentType<ReactionsListModalProps>;
   RecordingPermissionDeniedNotification?: React.ComponentType<RecordingPermissionDeniedNotificationProps>;
+  /** Custom UI component to display the message reminder information in the Message UI, defaults to and accepts same props as: [ReminderNotification](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Message/ReminderNotification.tsx) */
   ReminderNotification?: React.ComponentType<ReminderNotificationProps>;
   /** Custom component to display the search UI, defaults to and accepts same props as: [Search](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Search/Search.tsx) */
   Search?: React.ComponentType<SearchProps>;

--- a/src/i18n/TranslationBuilder/notifications/index.ts
+++ b/src/i18n/TranslationBuilder/notifications/index.ts
@@ -1,1 +1,2 @@
 export { NotificationTranslationTopic } from './NotificationTranslationTopic';
+export * from './types';

--- a/src/i18n/__tests__/TranslationBuilder.test.js
+++ b/src/i18n/__tests__/TranslationBuilder.test.js
@@ -6,17 +6,20 @@ describe('TranslationBuilder and TranslationTopic', () => {
     const manager = new TranslationBuilder(mockI18Next);
     expect(manager.i18next).toEqual(mockI18Next);
   });
+
   it('registers and retrieves the builder', () => {
     const manager = new TranslationBuilder(mockI18Next);
     manager.registerTopic('notification', NotificationTranslationTopic);
     expect(manager.getTopic('notification')).toBeInstanceOf(NotificationTranslationTopic);
   });
+
   it('removes builder', () => {
     const manager = new TranslationBuilder(mockI18Next);
     manager.registerTopic('notification', NotificationTranslationTopic);
     manager.disableTopic('notification');
     expect(manager.getTopic('notification')).toBeUndefined();
   });
+
   it('registers and removes translators', () => {
     const translator = jest.fn();
     const manager = new TranslationBuilder(mockI18Next);
@@ -26,5 +29,60 @@ describe('TranslationBuilder and TranslationTopic', () => {
     expect(notificationBuilder.translators.get('test')).toEqual(translator);
     manager.removeTranslators('notification', ['test']);
     expect(notificationBuilder.translators.get('test')).toBeUndefined();
+  });
+
+  it('stores translators for non-existent topic in a buffer', () => {
+    const manager = new TranslationBuilder(mockI18Next);
+    const translators = { custom1: jest.fn(), custom2: jest.fn() };
+    manager.registerTranslators('notification', translators);
+    expect(manager.topics.size).toEqual(0);
+    expect(manager.translatorRegistrationsBuffer.notification).toEqual(translators);
+  });
+
+  it('removes translators from buffer on translation removal', () => {
+    const manager = new TranslationBuilder(mockI18Next);
+    const translators = { custom1: jest.fn(), custom2: jest.fn() };
+    manager.registerTranslators('notification', translators);
+    manager.removeTranslators('notification', ['custom1']);
+    expect(Object.keys(manager.translatorRegistrationsBuffer.notification).length).toBe(
+      1,
+    );
+    expect(manager.translatorRegistrationsBuffer.notification.custom2).toBeDefined();
+  });
+
+  it('flushes the buffered translators on topic registration', () => {
+    const manager = new TranslationBuilder(mockI18Next);
+    const translators = { custom1: jest.fn(), custom2: jest.fn() };
+    manager.registerTranslators('notification', translators);
+    manager.registerTopic('notification', NotificationTranslationTopic);
+    expect(manager.translatorRegistrationsBuffer.notification).toBeUndefined();
+  });
+
+  it("overrides the topic's translators with buffered translators", () => {
+    const manager = new TranslationBuilder(mockI18Next);
+    const translator = jest.fn().mockImplementation();
+    const translatorName = 'api:attachment:upload:failed';
+    const translators = { [translatorName]: translator };
+    manager.registerTranslators('notification', translators);
+    manager.registerTopic('notification', NotificationTranslationTopic);
+    manager
+      .getTopic('notification')
+      .translate('key', 'value', { notification: { type: translatorName } });
+
+    expect(translator).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the already registered topic on repeated registerTopic calls', () => {
+    const manager = new TranslationBuilder(mockI18Next);
+    class Topic {
+      constructor() {
+        this.id = Math.random().toString();
+      }
+    }
+    manager.registerTopic('custom', Topic);
+    const firstRegistrationId = manager.getTopic('custom').id;
+    manager.registerTopic('custom', Topic);
+    const secondRegistrationId = manager.getTopic('custom').id;
+    expect(firstRegistrationId).toBe(secondRegistrationId);
   });
 });

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,6 +1,6 @@
 export * from './translations';
 export * from './Streami18n';
-export * from './TranslationBuilder/TranslationBuilder';
+export * from './TranslationBuilder';
 export {
   defaultDateTimeParser,
   defaultTranslatorFunction,


### PR DESCRIPTION
### 🎯 Goal

Allow integrators to register translators before i18next initiation

Specifically, we want this translator to be executed if registered as follows (before passing `i18nInstance` to `Chat` component) :

```js
const i18nInstance = new Streami18n();

const customNotificationTranslators: Record<
  string,
  Translator<NotificationTranslatorOptions>
> = {
  'api:message:send:failed': ({ key, value, options: { notification }, t }) => {
    return 'translated';
  },
};

// this registration call was internally ignored due to i18next not being initiated yet

i18nInstance.translationBuilder.registerTranslators(
  'notification',
  customNotificationTranslators,
);
```


