### PR TITLE
feat: add pagination tools to ChannelList context

### DIFF
--- a/src/components/ChannelList/ChannelList.tsx
+++ b/src/components/ChannelList/ChannelList.tsx
@@ -381,7 +381,9 @@ const UnMemoizedChannelList = (props: ChannelListProps) => {
   const showChannelList =
     (!searchActive && !searchIsActive) || additionalChannelSearchProps?.popupResults;
   return (
-    <ChannelListContextProvider value={{ channels, setChannels }}>
+    <ChannelListContextProvider
+      value={{ channels, hasNextPage, loadNextPage, setChannels }}
+    >
       <div className={className} ref={channelListRef}>
         {showChannelSearch &&
           (Search ? (

--- a/src/components/ChannelList/hooks/usePaginatedChannels.ts
+++ b/src/components/ChannelList/hooks/usePaginatedChannels.ts
@@ -135,9 +135,7 @@ export const usePaginatedChannels = (
     queryChannels('reload');
   }, [error, queryChannels, recoveryThrottleInterval]);
 
-  const loadNextPage = () => {
-    queryChannels();
-  };
+  const loadNextPage = () => queryChannels();
 
   useEffect(() => {
     if (client.recoverStateOnReconnect) return;

--- a/src/context/ChannelListContext.tsx
+++ b/src/context/ChannelListContext.tsx
@@ -10,6 +10,14 @@ export type ChannelListContextValue = {
    */
   channels: Channel[];
   /**
+   * Indicator for channel pagination to determine whether more items can be loaded
+   */
+  hasNextPage: boolean;
+  /**
+   * Pagination function to load more channels
+   */
+  loadNextPage(): Promise<void>;
+  /**
    * Sets the list of Channel objects to be rendered by ChannelList component.
    */
   setChannels: Dispatch<SetStateAction<Channel[]>>;


### PR DESCRIPTION
### 🎯 Goal

Allow integrators to recover from failed pagination requests. For example by showing retry button in custom `LoadingErrorIndicator` passed to `ChannelList`. Unfortunately the indicator is not shown along the channel list items. It is items or error. That part is not changed as it would be breaking change.


Example:

```tsx

const ChannelListLoadingIndicator = () => {
  const { hasNextPage, loadNextPage } = useChannelListContext();

  return (
    <div>
      <div>Failed to load channels</div>
      {hasNextPage && <button onClick={loadNextPage}>Retry</button>}
    </div>
  );
};


<ChannelList
  filters={filters}
  LoadingErrorIndicator={ChannelListLoadingIndicator}
  options={options}
  sort={sort}
/>
```

### Todo:

Update docs
