### PR TITLE
fix: change MultipleAnswersField input element to type text

### DIFF
--- a/src/components/Poll/PollCreationDialog/MultipleAnswersField.tsx
+++ b/src/components/Poll/PollCreationDialog/MultipleAnswersField.tsx
@@ -67,7 +67,7 @@ export const MultipleAnswersField = () => {
                 );
               }}
               placeholder={t('Maximum number of votes (from 2 to 10)')}
-              type='number'
+              type='text'
               value={max_votes_allowed}
             />
           </div>


### PR DESCRIPTION
### 🎯 Goal

Characters like `'e', '-' ,'+'` etc are valid chars that do not trigger field value change and thus the validation cannot kick in. Therefore changing back the input type to type `"text"` and rely only on Regex.

