### PR TITLE
fix: distinguish non-submit form buttons

### DIFF
--- a/src/components/Dialog/FormDialog.tsx
+++ b/src/components/Dialog/FormDialog.tsx
@@ -139,6 +139,7 @@ export const FormDialog = <
             <button
               className='str-chat__dialog__controls-button str-chat__dialog__controls-button--cancel'
               onClick={close}
+              type='button'
             >
               {t('Cancel')}
             </button>

--- a/src/components/MessageInput/EditMessageForm.tsx
+++ b/src/components/MessageInput/EditMessageForm.tsx
@@ -58,6 +58,7 @@ export const EditMessageForm = () => {
           className='str-chat__edit-message-cancel'
           data-testid='cancel-button'
           onClick={cancel}
+          type='button'
         >
           {t('Cancel')}
         </button>

--- a/src/components/MessageInput/__tests__/ThreadMessageInput.test.js
+++ b/src/components/MessageInput/__tests__/ThreadMessageInput.test.js
@@ -172,6 +172,11 @@ describe('MessageInput in Thread', () => {
         customClient,
       });
       expect(getDraftSpy).toHaveBeenCalledTimes(1);
+      await act(() => {
+        customClient.setMessageComposerSetupFunction(({ composer }) => {
+          composer.updateConfig({ drafts: { enabled: false } });
+        });
+      });
     });
     it('prevents querying if composition is not empty', async () => {
       const { customChannel, customClient, getDraftSpy } = await setup();
@@ -186,6 +191,11 @@ describe('MessageInput in Thread', () => {
         customClient,
       });
       expect(getDraftSpy).not.toHaveBeenCalled();
+      await act(() => {
+        customClient.setMessageComposerSetupFunction(({ composer }) => {
+          composer.updateConfig({ drafts: { enabled: false } });
+        });
+      });
     });
     it('prevents querying if not rendered inside a thread', async () => {
       const { customChannel, customClient, getDraftSpy } = await setup();
@@ -200,6 +210,11 @@ describe('MessageInput in Thread', () => {
         customClient,
       });
       expect(getDraftSpy).not.toHaveBeenCalled();
+      await act(() => {
+        customClient.setMessageComposerSetupFunction(({ composer }) => {
+          composer.updateConfig({ drafts: { enabled: false } });
+        });
+      });
     });
     it('prevents querying if drafts are disabled (default)', async () => {
       const { customChannel, customClient, getDraftSpy } = await setup();

--- a/src/components/Poll/PollCreationDialog/OptionFieldSet.tsx
+++ b/src/components/Poll/PollCreationDialog/OptionFieldSet.tsx
@@ -65,7 +65,8 @@ export const OptionFieldSet = () => {
                     });
                   }}
                   onKeyUp={(event) => {
-                    if (event.key === 'Enter') {
+                    const isFocusedLastOptionField = i === options.length - 1;
+                    if (event.key === 'Enter' && !isFocusedLastOptionField) {
                       const nextInputId = options[i + 1].id;
                       document.getElementById(nextInputId)?.focus();
                     }

--- a/src/components/Poll/PollCreationDialog/PollCreationDialogControls.tsx
+++ b/src/components/Poll/PollCreationDialog/PollCreationDialogControls.tsx
@@ -22,6 +22,7 @@ export const PollCreationDialogControls = ({
           messageComposer.pollComposer.initState();
           close();
         }}
+        type='button'
       >
         {t('Cancel')}
       </button>


### PR DESCRIPTION
### 🎯 Goal

Fixes REACT-471

All the non-submit buttons should be marked as `type='button'`:
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/submit#using_submit_buttons

This change fixes the behavior where the submit handler is not invoked if the input types are not clearly distinguished.

