### PR TITLE
chore(deps): upgrade react-image-gallery to version 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "nanoid": "^3.3.4",
     "react-dropzone": "^14.2.3",
     "react-fast-compare": "^3.2.2",
-    "react-image-gallery": "1.2.12",
+    "react-image-gallery": "^1.4.0",
     "react-markdown": "^9.0.3",
     "react-player": "2.10.1",
     "react-popper": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10908,10 +10908,10 @@ react-fast-compare@^3.0.1, react-fast-compare@^3.2.2:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
   integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
-react-image-gallery@1.2.12:
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/react-image-gallery/-/react-image-gallery-1.2.12.tgz#b08a633cc336bab2a5afdb96941e023925043c6a"
-  integrity sha512-JIh85lh0Av/yewseGJb/ycg00Y/weQiZEC/BQueC2Z5jnYILGB6mkxnrOevNhsM2NdZJpvcDekCluhy6uzEoTA==
+react-image-gallery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-image-gallery/-/react-image-gallery-1.4.0.tgz#ceb16273b9163831a11579d37d036272a0a38b4b"
+  integrity sha512-m7xLq7+g6/xh+BhVMAxvRU0132sNcEFglYsVsgthrnItl9VtLE7MuVvVWD9pvzcI+WBP5+p9HvnRwIiyhPkBDg==
 
 react-is@^16.13.1:
   version "16.13.1"


### PR DESCRIPTION
### 🎯 Goal

Fixes: #2770 

`react-image-gallery` has the matching React peer deps:

```
"peerDependencies": {
    "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
  }
```