### PR TITLE
fix: regenerate image preview URL on image attachment removal when editing a message

### DIFF
--- a/src/components/Attachment/AttachmentContainer.tsx
+++ b/src/components/Attachment/AttachmentContainer.tsx
@@ -109,19 +109,19 @@ export const GalleryContainer = ({
   >([]);
 
   useLayoutEffect(() => {
-    if (
-      imageElements.current &&
-      imageElements.current.every((element) => !!element) &&
-      imageAttachmentSizeHandler
-    ) {
-      const newConfigurations: ImageAttachmentConfiguration[] = [];
-      imageElements.current.forEach((element, i) => {
-        const config = imageAttachmentSizeHandler(attachment.images[i], element);
-        newConfigurations.push(config);
-      });
-      setAttachmentConfigurations(newConfigurations);
+    if (!imageElements.current || !imageAttachmentSizeHandler) return;
+    const newConfigurations: ImageAttachmentConfiguration[] = [];
+    const nonNullImageElements = imageElements.current.filter((e) => !!e);
+    if (nonNullImageElements.length < imageElements.current.length) {
+      imageElements.current = nonNullImageElements;
     }
-  }, [imageElements, imageAttachmentSizeHandler, attachment]);
+    imageElements.current.forEach((element, i) => {
+      if (!element) return;
+      const config = imageAttachmentSizeHandler(attachment.images[i], element);
+      newConfigurations.push(config);
+    });
+    setAttachmentConfigurations(newConfigurations);
+  }, [imageAttachmentSizeHandler, attachment]);
 
   const images = attachment.images.map((image, i) => ({
     ...image,
@@ -130,7 +130,7 @@ export const GalleryContainer = ({
       attachment.images[i]?.image_url || attachment.images[i]?.thumb_url || '',
     ),
   }));
-
+  console.log(images, imageElements, attachmentConfigurations);
   return (
     <AttachmentWithinContainer attachment={attachment} componentType='gallery'>
       <Gallery images={images || []} innerRefs={imageElements} key='gallery' />


### PR DESCRIPTION
### 🎯 Goal

Fixes #2773 

### 🛠 Implementation details

The effect had a condition that imageElements array could not contain null in order to recalculate preview urls. That lead to the issue in scenario when images at the beginning of the attachment array were removed. The preview URL of removed attachment was assigned based on index to an attachment that moved to the place of the previously removed image.


