### PR TITLE
fix: render markdown link correctly (regression in 13.2.2)

### DIFF
--- a/src/components/Message/renderText/__tests__/__snapshots__/renderText.test.js.snap
+++ b/src/components/Message/renderText/__tests__/__snapshots__/renderText.test.js.snap
@@ -868,6 +868,22 @@ exports[`renderText handles the special case where user name matches to an e-mai
 </div>
 `;
 
+exports[`renderText parses correctly text with markdown links 1`] = `
+<div>
+  <p>
+    a 
+    <a
+      class="str-chat__message-url-link"
+      href="https://www.youtube.com/"
+      rel="nofollow noreferrer noopener"
+      target="_blank"
+    >
+      link
+    </a>
+  </p>
+</div>
+`;
+
 exports[`renderText renders custom mention 1`] = `
 <div>
   <p>

--- a/src/components/Message/renderText/__tests__/renderText.test.js
+++ b/src/components/Message/renderText/__tests__/renderText.test.js
@@ -4,6 +4,7 @@ import { u } from 'unist-builder';
 import { render } from '@testing-library/react';
 import { htmlToTextPlugin, keepLineBreaksPlugin } from '../remarkPlugins';
 import { defaultAllowedTagNames, renderText } from '../renderText';
+import '@testing-library/jest-dom';
 
 const strikeThroughText = '~~xxx~~';
 
@@ -11,6 +12,13 @@ describe(`renderText`, () => {
   it('wraps every link entirely even though the link roots are the same', () => {
     const Markdown = renderText('copilot.com\ncopilot.com/guide\ncopilot.com/about?');
     const { container } = render(Markdown);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('parses correctly text with markdown links', () => {
+    const Markdown = renderText('a [link](https://www.youtube.com/)');
+    const { container } = render(Markdown);
+    expect(container).toHaveTextContent('a link');
     expect(container).toMatchSnapshot();
   });
 

--- a/src/components/Message/renderText/renderText.tsx
+++ b/src/components/Message/renderText/renderText.tsx
@@ -127,7 +127,7 @@ export const renderText = (
         return strippedHref.includes(strippedText) || strippedText.includes(strippedHref);
       });
 
-    if (noParsingNeeded.length > 0 || linkIsInBlock) return;
+    if (noParsingNeeded.length > 0 || linkIsInBlock) continue;
 
     try {
       // special case for mentions:


### PR DESCRIPTION
### 🎯 Goal

fixes #2789 

