### PR TITLE
fix: reset PollComposer state on poll creation form submission

### DIFF
--- a/src/components/Poll/PollCreationDialog/PollCreationDialogControls.tsx
+++ b/src/components/Poll/PollCreationDialog/PollCreationDialogControls.tsx
@@ -33,7 +33,10 @@ export const PollCreationDialogControls = ({
           messageComposer
             .createPoll()
             .then(() => handleSubmitMessage())
-            .then(close)
+            .then(() => {
+              messageComposer.pollComposer.initState();
+              close();
+            })
             .catch(console.error);
         }}
         type='submit'

--- a/src/components/Poll/__tests__/PollCreationDialog.test.js
+++ b/src/components/Poll/__tests__/PollCreationDialog.test.js
@@ -363,6 +363,9 @@ describe('PollCreationDialog', () => {
     const createPollSpy = jest
       .spyOn(client, 'createPoll')
       .mockImplementationOnce(() => Promise.resolve({ poll }));
+    const initPollStateSpy = jest
+      .spyOn(channel.messageComposer.pollComposer, 'initState')
+      .mockImplementation();
 
     await act(async () => {
       await fireEvent.change(getNameInput(), { target: { value: formState.name } });
@@ -407,14 +410,25 @@ describe('PollCreationDialog', () => {
         expect.objectContaining(expectedPollPayload),
       );
       expect(close).toHaveBeenCalledTimes(1);
+      expect(initPollStateSpy).toHaveBeenCalledTimes(1);
     });
   });
 
   it('closes the form on cancel', async () => {
-    await renderComponent();
+    const {
+      channels: [channel],
+      client,
+    } = await initClientWithChannels({ customUser: user });
+    const initPollStateSpy = jest
+      .spyOn(channel.messageComposer.pollComposer, 'initState')
+      .mockImplementation();
+
+    await renderComponent({ channel, client });
+
     act(() => {
       fireEvent.click(screen.getByText(CANCEL_BUTTON_TEXT));
     });
     expect(close).toHaveBeenCalledTimes(1);
+    expect(initPollStateSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### 🎯 Goal

Avoid reopening the form with stale state representing previously submitted / created poll
