### PR TITLE
fix: remove optimization preventing ChannelList re-render on member.updated event

### DIFF
--- a/src/components/ChannelList/hooks/useChannelListShape.ts
+++ b/src/components/ChannelList/hooks/useChannelListShape.ts
@@ -314,11 +314,6 @@ export const useChannelListShapeDefaults = () => {
         const newTargetChannelIndex =
           typeof lastPinnedChannelIndex === 'number' ? lastPinnedChannelIndex + 1 : 0;
 
-        // skip re-render if the position of the channel does not change
-        if (currentChannels[newTargetChannelIndex] === targetChannel) {
-          return currentChannels;
-        }
-
         newChannels.splice(newTargetChannelIndex, 0, targetChannel);
 
         return newChannels;


### PR DESCRIPTION
### 🎯 Goal

Removing lines that prevented the `ChannelList` re-render on `member.updated` if the channel index in the channels array would not change. This, however, prevented running `renderChannels` function that could further change the UI (move the channel from one group to another - unpinned -> pinned channels). 
