### PR TITLE
fix: check the presence of remindMe and saveForLater message actions correctly

### DIFF
--- a/src/components/Message/__tests__/utils.test.js
+++ b/src/components/Message/__tests__/utils.test.js
@@ -109,6 +109,20 @@ describe('Message utils', () => {
       );
     });
 
+    it('should return message actions specified in custom actions array depending on channel config if actions are set to true', () => {
+      const result = getMessageActions(['remindMe'], defaultCapabilities, {
+        user_message_reminders: true,
+      });
+      expect(result).toStrictEqual(['remindMe']);
+    });
+
+    it('should return message actions specified in custom actions array depending on channel config if actions are set to true', () => {
+      const result = getMessageActions(['saveForLater'], defaultCapabilities, {
+        user_message_reminders: true,
+      });
+      expect(result).toStrictEqual(['saveForLater']);
+    });
+
     it('should include reminder actions if enabled in channel config', () => {
       const result = getMessageActions(true, defaultCapabilities, {
         user_message_reminders: true,
@@ -137,9 +151,9 @@ describe('Message utils', () => {
       };
       const result = getMessageActions(actions, capabilities);
       if (capabilityValue) {
-        expect(result).toContain(action);
+        expect(result).toStrictEqual([action]);
       } else {
-        expect(result).not.toContain(action);
+        expect(result).not.toStrictEqual([action]);
       }
     });
   });

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -202,7 +202,7 @@ export const getMessageActions = (
 
   if (
     channelConfig?.['user_message_reminders'] &&
-    messageActions.indexOf(MESSAGE_ACTIONS.remindMe)
+    messageActions.indexOf(MESSAGE_ACTIONS.remindMe) > -1
   ) {
     messageActionsAfterPermission.push(MESSAGE_ACTIONS.remindMe);
   }
@@ -213,7 +213,7 @@ export const getMessageActions = (
 
   if (
     channelConfig?.['user_message_reminders'] &&
-    messageActions.indexOf(MESSAGE_ACTIONS.saveForLater)
+    messageActions.indexOf(MESSAGE_ACTIONS.saveForLater) > -1
   ) {
     messageActionsAfterPermission.push(MESSAGE_ACTIONS.saveForLater);
   }


### PR DESCRIPTION
### 🎯 Goal

The presence of actions using `Array.prototype.indexOf` should be checked against -1 not agains value truthiness.

