### PR TITLE
fix: reflect channel config besides user permissions in AttachmentSelector

### DIFF
--- a/src/components/MessageInput/AttachmentSelector.tsx
+++ b/src/components/MessageInput/AttachmentSelector.tsx
@@ -163,16 +163,22 @@ const useAttachmentSelectorActionsFiltered = (original: AttachmentSelectorAction
   } = useComponentContext();
   const { channelCapabilities } = useChannelStateContext();
   const messageComposer = useMessageComposer();
+  const channelConfig = messageComposer.channel.getConfig();
 
   return original
     .filter((action) => {
-      if (action.type === 'uploadFile') return channelCapabilities['upload-file'];
+      if (action.type === 'uploadFile')
+        return channelCapabilities['upload-file'] && channelConfig?.uploads;
 
       if (action.type === 'createPoll')
-        return channelCapabilities['send-poll'] && !messageComposer.threadId;
+        return (
+          channelCapabilities['send-poll'] &&
+          !messageComposer.threadId &&
+          channelConfig?.polls
+        );
 
       if (action.type === 'addLocation') {
-        return messageComposer.config.location.enabled && !messageComposer.threadId;
+        return channelConfig?.shared_locations && !messageComposer.threadId;
       }
       return true;
     })

--- a/src/mock-builders/generator/channel.ts
+++ b/src/mock-builders/generator/channel.ts
@@ -41,6 +41,7 @@ export const generateChannel = (options?: DeepPartial<ChannelAPIResponse>) => {
         read_events: true,
         replies: true,
         search: true,
+        shared_locations: true,
         typing_events: true,
         updated_at: '2020-04-24T11:36:43.859022903Z',
         uploads: true,


### PR DESCRIPTION
### 🎯 Goal

When displaying the attachment selector menu, the buttons to create a new poll, upload files, share location were displayed based on user permissions only, but we were not checking if the feature as a whole was enabled (`channel.config`)

With this PR we check both permissions and feature enablement.

Fixes REACT-576

