### PR TITLE
fix: enabled headings in message markdown

### DIFF
--- a/src/components/Message/renderText/__tests__/__snapshots__/renderText.test.js.snap
+++ b/src/components/Message/renderText/__tests__/__snapshots__/renderText.test.js.snap
@@ -209,9 +209,11 @@ exports[`keepLineBreaksPlugin absent does not keep line breaks between the items
 </div>
 `;
 
-exports[`keepLineBreaksPlugin absent does not keep line breaks under a heading 1`] = `
+exports[`keepLineBreaksPlugin absent keeps line breaks natively under a heading 1`] = `
 <div>
-  Heading
+  <h2>
+    Heading
+  </h2>
   
 
   <p>
@@ -669,7 +671,9 @@ exports[`keepLineBreaksPlugin present keeps line breaks between the items in an 
 
 exports[`keepLineBreaksPlugin present keeps line breaks under a heading 1`] = `
 <div>
-  Heading
+  <h2>
+    Heading
+  </h2>
   
 
   <br />

--- a/src/components/Message/renderText/__tests__/renderText.test.js
+++ b/src/components/Message/renderText/__tests__/renderText.test.js
@@ -337,7 +337,7 @@ describe('keepLineBreaksPlugin', () => {
       const container = doRenderText(orderedListText, present);
       expect(container).toMatchSnapshot();
     });
-    it(`does not keep line breaks under a heading`, () => {
+    it(`keeps line breaks natively under a heading`, () => {
       const container = doRenderText(headingText, present);
       expect(container).toMatchSnapshot();
     });

--- a/src/components/Message/renderText/renderText.tsx
+++ b/src/components/Message/renderText/renderText.tsx
@@ -45,6 +45,12 @@ export const defaultAllowedTagNames: Array<
   // custom types (tagNames)
   'emoji',
   'mention',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
 ];
 
 function formatUrlForDisplay(url: string) {


### PR DESCRIPTION
### 🎯 Goal

ChannelPreview displays headings but message in message list not. Also other SDKs display headings in messages.
