### PR TITLE
fix: render html as text in ChannelPreview

### DIFF
--- a/src/components/ChannelPreview/utils.tsx
+++ b/src/components/ChannelPreview/utils.tsx
@@ -5,9 +5,19 @@ import type { Channel, PollVote, TranslationLanguages, UserResponse } from 'stre
 
 import type { TranslationContextValue } from '../../context/TranslationContext';
 import type { ChatContextValue } from '../../context';
+import type { PluggableList } from 'unified';
+import { htmlToTextPlugin } from '../Message';
+import remarkGfm from 'remark-gfm';
+
+const remarkPlugins: PluggableList = [
+  htmlToTextPlugin,
+  [remarkGfm, { singleTilde: false }],
+];
 
 export const renderPreviewText = (text: string) => (
-  <ReactMarkdown skipHtml>{text}</ReactMarkdown>
+  <ReactMarkdown remarkPlugins={remarkPlugins} skipHtml>
+    {text}
+  </ReactMarkdown>
 );
 
 const getLatestPollVote = (latestVotesByOption: Record<string, PollVote[]>) => {


### PR DESCRIPTION
### 🎯 Goal

The ChannelPreview did not render any text preview if the latest message represented HTML string. Other SDKs do render the preview as well as the message in message list
