### PR TITLE
feat: add imageToLink Remark plugin for converting image MD links to anchor tags

### DIFF
--- a/src/components/ChannelPreview/utils.tsx
+++ b/src/components/ChannelPreview/utils.tsx
@@ -6,13 +6,14 @@ import type { Channel, PollVote, TranslationLanguages, UserResponse } from 'stre
 import type { TranslationContextValue } from '../../context/TranslationContext';
 import type { ChatContextValue } from '../../context';
 import type { PluggableList } from 'unified';
-import { htmlToTextPlugin, plusPlusToEmphasis } from '../Message';
+import { htmlToTextPlugin, imageToLink, plusPlusToEmphasis } from '../Message';
 import remarkGfm from 'remark-gfm';
 
 const remarkPlugins: PluggableList = [
   htmlToTextPlugin,
   [remarkGfm, { singleTilde: false }],
   plusPlusToEmphasis,
+  imageToLink,
 ];
 
 export const renderPreviewText = (text: string) => (

--- a/src/components/Message/renderText/remarkPlugins/imageToLink.ts
+++ b/src/components/Message/renderText/remarkPlugins/imageToLink.ts
@@ -1,0 +1,43 @@
+import { SKIP, visit, type VisitorResult } from 'unist-util-visit';
+import type { Image, Link, Parent, Text } from 'mdast';
+import type { Node } from 'unist';
+
+type ImgVisitor = (
+  node: Image,
+  index: number | null,
+  parent: Parent | null,
+) => VisitorResult;
+
+export type ImageToLinkPluginOptions = {
+  getTextLabelFrom?: 'alt' | 'title' | 'url';
+};
+
+const text = (value: string): Text => ({ type: 'text', value });
+
+/**
+ * Converts image Markdown links (![Minion](https://octodex.github.com/images/minion.png))
+ * to HTML <a href={url}>{url | title | alt}</a>
+ *
+ * By default, the anchor text content is the image url so that image preview can be generated / enriched on the server.
+ * @param getTextLabelFrom
+ */
+export function imageToLink({ getTextLabelFrom = 'url' }: ImageToLinkPluginOptions = {}) {
+  return (tree: Node) => {
+    const visitor: ImgVisitor = (node, index, parent) => {
+      if (parent == null || index == null) return;
+
+      const label = node[getTextLabelFrom] ?? node.url; // node.alt || node.title || node.url;
+      const link: Link = {
+        children: [text(label)],
+        title: node.title ?? node.alt ?? node.url,
+        type: 'link',
+        url: node.url,
+      };
+
+      parent.children.splice(index, 1, link);
+      return [SKIP, index + 1] as const;
+    };
+
+    visit(tree, 'image', visitor);
+  };
+}

--- a/src/components/Message/renderText/remarkPlugins/index.ts
+++ b/src/components/Message/renderText/remarkPlugins/index.ts
@@ -1,3 +1,4 @@
 export * from './htmlToTextPlugin';
+export * from './imageToLink';
 export * from './keepLineBreaksPlugin';
 export * from './plusPlusToEmphasis';

--- a/src/components/Message/renderText/renderText.tsx
+++ b/src/components/Message/renderText/renderText.tsx
@@ -12,6 +12,7 @@ import { detectHttp, matchMarkdownLinks, messageCodeBlocks } from './regex';
 import { emojiMarkdownPlugin, mentionsMarkdownPlugin } from './rehypePlugins';
 import {
   htmlToTextPlugin,
+  imageToLink,
   keepLineBreaksPlugin,
   plusPlusToEmphasis,
 } from './remarkPlugins';
@@ -175,6 +176,7 @@ export const renderText = (
     keepLineBreaksPlugin,
     [remarkGfm, { singleTilde: false }],
     plusPlusToEmphasis,
+    imageToLink,
   ];
   const rehypePlugins: PluggableList = [emojiMarkdownPlugin];
 


### PR DESCRIPTION
### 🎯 Goal

Recognize Markdown image links.

Message text

`![Minion](https://octodex.github.com/images/minion.png)`

Would result in empty message bubble:

<img width="101" height="41" alt="image" src="https://github.com/user-attachments/assets/96f2242a-4236-49fe-b5ed-1589dd603cb4" />

With this PR the links are recognized and transformed into `<a href={url}>{url | title | alt}</a>`

<img width="392" height="277" alt="image" src="https://github.com/user-attachments/assets/e8d65ebd-4765-4d00-9617-7bac63460b0d" />

This PR also fixes an issue when such embedded image links would lead to `<img/>` rendering in `ChannelPreview` text:

<img width="392" height="814" alt="image" src="https://github.com/user-attachments/assets/6683b605-b991-4bcf-a896-9a8f46b8d803" />


Now:

<img width="392" height="130" alt="image" src="https://github.com/user-attachments/assets/c8a18b6c-d83f-46db-9381-907dba04d6ae" />

