### PR TITLE
fix: add CustomMessageComposerData redeclaration

### DIFF
--- a/src/@types/stream-chat-custom-data.d.ts
+++ b/src/@types/stream-chat-custom-data.d.ts
@@ -6,6 +6,7 @@ import {
   DefaultCommandData,
   DefaultEventData,
   DefaultMemberData,
+  DefaultMessageComposerData,
   DefaultMessageData,
   DefaultPollData,
   DefaultPollOptionData,
@@ -36,4 +37,6 @@ declare module 'stream-chat' {
   interface CustomUserData extends DefaultUserData {}
 
   interface CustomThreadData extends DefaultThreadData {}
+
+  interface CustomMessageComposerData extends DefaultMessageComposerData {}
 }

--- a/src/types/defaultDataInterfaces.ts
+++ b/src/types/defaultDataInterfaces.ts
@@ -24,3 +24,5 @@ export interface DefaultReactionData {}
 export interface DefaultUserData {}
 
 export interface DefaultThreadData {}
+
+export interface DefaultMessageComposerData {}


### PR DESCRIPTION
### 🎯 Goal

Unify the interface declaration. Missed this one when added MessageComposer.