### PR TITLE
fix: check cast-poll-vote permission to show "Suggest an option" poll action

### DIFF
--- a/src/components/Poll/PollActions/PollActions.tsx
+++ b/src/components/Poll/PollActions/PollActions.tsx
@@ -87,6 +87,7 @@ export const PollActions = ({
   } = useStateStore(poll.state, pollStateSelector);
   const [modalOpen, setModalOpen] = useState<ModalName | undefined>();
 
+  const canCastVote = channelCapabilities['cast-poll-vote'] && !is_closed;
   const closeModal = useCallback(() => setModalOpen(undefined), []);
   const onUpdateAnswerClick = useCallback(() => setModalOpen('add-comment'), []);
 
@@ -106,7 +107,7 @@ export const PollActions = ({
         </PollAction>
       )}
 
-      {!is_closed &&
+      {canCastVote &&
         allow_user_suggested_options &&
         options.length < MAX_POLL_OPTIONS && (
           <PollAction

--- a/src/components/Poll/__tests__/PollActions.test.js
+++ b/src/components/Poll/__tests__/PollActions.test.js
@@ -28,7 +28,7 @@ const END_VOTE_ACTION_TEXT = 'End vote';
 const t = (v) => v;
 
 const defaultChannelStateContext = {
-  channelCapabilities: { 'query-poll-votes': true },
+  channelCapabilities: { 'cast-poll-vote': true, 'query-poll-votes': true },
 };
 
 const defaultMessageContext = {
@@ -87,7 +87,20 @@ describe('PollActions', () => {
     expect(screen.queryByText(SEE_ALL_OPTIONS_ACTION_TEXT)).not.toBeInTheDocument();
   });
 
-  it('shows "Suggest an option" action if poll is not closed and suggestions are allowed', async () => {
+  it('does not show "Suggest an option" action if poll is not closed and suggestions are allowed but user does not have permission to cast vote', async () => {
+    const pollData = generatePoll({
+      allow_user_suggested_options: true,
+      is_closed: false,
+    });
+    const poll = new Poll({ client: {}, poll: pollData });
+    await renderComponent({
+      channelStateContext: { channelCapabilities: { 'cast-poll-vote': false } },
+      poll,
+    });
+    expect(screen.queryByText(SUGGEST_OPTION_ACTION_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('shows "Suggest an option" action if poll is not closed and suggestions are allowed and user has permission to cast votes', async () => {
     const pollData = generatePoll({
       allow_user_suggested_options: true,
       is_closed: false,


### PR DESCRIPTION
### 🎯 Goal

The permission has to be checked, because part of the suggest-an-option action is casting vote for a given newly created option.
