### PR TITLE
chore: remove jsdelivr bundle reference from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.node.cjs",
   "module": "dist/index.js",
-  "jsdelivr": "./dist/browser.full-bundle.min.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
### 🎯 Goal

We are not building `./dist/browser.full-bundle.min.js` anymore
