### PR TITLE
fix: add notification translator for notification validation:attachment:upload:in-progress

### DIFF
--- a/src/i18n/TranslationBuilder/notifications/NotificationTranslationTopic.ts
+++ b/src/i18n/TranslationBuilder/notifications/NotificationTranslationTopic.ts
@@ -1,6 +1,7 @@
 import {
   attachmentUploadBlockedNotificationTranslator,
   attachmentUploadFailedNotificationTranslator,
+  attachmentUploadNotTerminatedTranslator,
 } from './attachmentUpload';
 import { TranslationTopic } from '../../TranslationBuilder';
 import type { Notification } from 'stream-chat';
@@ -16,6 +17,7 @@ export const defaultNotificationTranslators: Record<
   'api:attachment:upload:failed': attachmentUploadFailedNotificationTranslator,
   'api:poll:create:failed': pollCreationFailedNotificationTranslator,
   'validation:attachment:upload:blocked': attachmentUploadBlockedNotificationTranslator,
+  'validation:attachment:upload:in-progress': attachmentUploadNotTerminatedTranslator,
   'validation:poll:castVote:limit': pollVoteCountTrespass,
 };
 

--- a/src/i18n/TranslationBuilder/notifications/attachmentUpload.ts
+++ b/src/i18n/TranslationBuilder/notifications/attachmentUpload.ts
@@ -36,3 +36,10 @@ export const attachmentUploadFailedNotificationTranslator: Translator<
   // custom reason string
   return t('Attachment upload failed due to {{reason}}', { reason });
 };
+
+export const attachmentUploadNotTerminatedTranslator: Translator<
+  NotificationTranslatorOptions
+> = ({ options: { notification }, t }) => {
+  if (!notification?.message) return null;
+  return t('Wait until all attachments have uploaded');
+};


### PR DESCRIPTION
### 🎯 Goal

The notification string is not translated unless this translator is added. Its absence results in the following notification text:

<img width="589" height="189" alt="image" src="https://github.com/user-attachments/assets/6373b962-fcf5-4830-b5d8-6f8aaa39680a" />

The translations for the given string already existed, just translator was missing.

