### PR TITLE
fix: add "team" property to the `DefaultChannelData` interface

### DIFF
--- a/src/types/defaultDataInterfaces.ts
+++ b/src/types/defaultDataInterfaces.ts
@@ -3,6 +3,7 @@ export interface DefaultChannelData {
   image?: string;
   name?: string;
   subtitle?: string;
+  team?: string;
 }
 
 export interface DefaultAttachmentData {}


### PR DESCRIPTION
### 🎯 Goal

Ref: https://getstream.slack.com/archives/C02R5UCGN6N/p1759426108993259
