### PR TITLE
fix(useMessageComposer): keep editing message composer with up-to-date edited message reference

### DIFF
--- a/src/components/MessageInput/hooks/useMessageComposer.ts
+++ b/src/components/MessageInput/hooks/useMessageComposer.ts
@@ -40,7 +40,10 @@ export const useMessageComposer = () => {
       const tag = MessageComposer.constructTag(cachedEditedMessage);
 
       const cachedComposer = queueCache.get(tag);
-      if (cachedComposer) return cachedComposer;
+      if (cachedComposer) {
+        cachedComposer.editedMessage = cachedEditedMessage;
+        return cachedComposer;
+      }
 
       return new MessageComposer({
         client,


### PR DESCRIPTION
### 🎯 Goal

fixes #2845 

### 🛠 Implementation details

The cached message composer instance was not given the latest message reference when retrieved.
