### PR TITLE
feat: add prop renderText to VirtualizedMessageList

### DIFF
--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -77,6 +77,7 @@ type PropsDrilledToMessage =
   | 'messageActions'
   | 'openThread'
   | 'reactionDetailsSort'
+  | 'renderText'
   | 'sortReactions'
   | 'sortReactionDetails';
 
@@ -214,6 +215,7 @@ const VirtualizedMessageListWithContext = (
     // TODO: refactor to scrollSeekPlaceHolderConfiguration and components.ScrollSeekPlaceholder, like the Virtuoso Component
     overscan = 0,
     reactionDetailsSort,
+    renderText,
     returnAllReadData = false,
     reviewProcessedMessage,
     scrollSeekPlaceHolder,
@@ -511,6 +513,7 @@ const VirtualizedMessageListWithContext = (
                 ownMessagesReadByOthers,
                 processedMessages,
                 reactionDetailsSort,
+                renderText,
                 returnAllReadData,
                 shouldGroupByUser,
                 sortReactionDetails,

--- a/src/components/MessageList/VirtualizedMessageListComponents.tsx
+++ b/src/components/MessageList/VirtualizedMessageListComponents.tsx
@@ -130,6 +130,7 @@ export const messageRenderer = (
     ownMessagesReadByOthers,
     processedMessages: messageList,
     reactionDetailsSort,
+    renderText,
     returnAllReadData,
     shouldGroupByUser,
     sortReactionDetails,
@@ -217,6 +218,7 @@ export const messageRenderer = (
         openThread={openThread}
         reactionDetailsSort={reactionDetailsSort}
         readBy={ownMessagesReadByOthers[message.id] || []}
+        renderText={renderText}
         returnAllReadData={returnAllReadData}
         sortReactionDetails={sortReactionDetails}
         sortReactions={sortReactions}


### PR DESCRIPTION
### 🎯 Goal

`MessageList` allows to pass `renderText` prop, `VirtualizedMessageList` no. Closing another gap.

Closes REACT-628.

