### PR TITLE
fix: remove stale message status for the last loaded message on returnAllReadData false

### DIFF
--- a/src/components/MessageList/hooks/useLastDeliveredData.ts
+++ b/src/components/MessageList/hooks/useLastDeliveredData.ts
@@ -13,9 +13,9 @@ export const useLastDeliveredData = (
 ): Record<string, UserResponse[]> => {
   const { channel, lastOwnMessage, messages, returnAllReadData } = props;
 
-  const calculate = useCallback(() => {
-    if (returnAllReadData) {
-      return messages.reduce(
+  const calculateForAll = useCallback(
+    () =>
+      messages.reduce(
         (acc, msg) => {
           acc[msg.id] = channel.messageReceiptsTracker.deliveredForMessage({
             msgId: msg.id,
@@ -24,8 +24,11 @@ export const useLastDeliveredData = (
           return acc;
         },
         {} as Record<string, UserResponse[]>,
-      );
-    }
+      ),
+    [channel, messages],
+  );
+
+  const calculateForLastOwn = useCallback(() => {
     if (!lastOwnMessage) return {};
     return {
       [lastOwnMessage.id]: channel.messageReceiptsTracker.deliveredForMessage({
@@ -33,15 +36,25 @@ export const useLastDeliveredData = (
         timestampMs: lastOwnMessage.created_at.getTime(),
       }),
     };
-  }, [channel, lastOwnMessage, messages, returnAllReadData]);
+  }, [channel, lastOwnMessage]);
 
-  const [deliveredTo, setDeliveredTo] =
-    useState<Record<string, UserResponse[]>>(calculate);
-
-  useEffect(
-    () => channel.on('message.delivered', () => setDeliveredTo(calculate)).unsubscribe,
-    [channel, calculate],
+  const [deliveredTo, setDeliveredTo] = useState<Record<string, UserResponse[]>>(
+    returnAllReadData ? calculateForAll : calculateForLastOwn,
   );
+
+  useEffect(() => {
+    if (!returnAllReadData) return;
+    setDeliveredTo(calculateForAll);
+    return channel.on('message.delivered', () => setDeliveredTo(calculateForAll))
+      .unsubscribe;
+  }, [channel, calculateForAll, returnAllReadData]);
+
+  useEffect(() => {
+    if (returnAllReadData) return;
+    else setDeliveredTo(calculateForLastOwn);
+    return channel.on('message.delivered', () => setDeliveredTo(calculateForLastOwn))
+      .unsubscribe;
+  }, [channel, calculateForLastOwn, returnAllReadData]);
 
   return deliveredTo;
 };


### PR DESCRIPTION
### 🎯 Goal

Closes REACT-633

The `deliveredTo` value was not being recalculated when the last own message changed.

