### PR TITLE
fix: prevent closing EditMessageForm on non-sbumit button click

### DIFF
--- a/src/components/Attachment/Geolocation.tsx
+++ b/src/components/Attachment/Geolocation.tsx
@@ -60,6 +60,7 @@ export const Geolocation = ({
               <button
                 className='str-chat__message-attachment-geolocation__stop-sharing-button'
                 onClick={() => channel?.stopLiveLocationSharing(location)}
+                type='button'
               >
                 {t('Stop sharing')}
               </button>

--- a/src/components/Attachment/__tests__/__snapshots__/Card.test.js.snap
+++ b/src/components/Attachment/__tests__/__snapshots__/Card.test.js.snap
@@ -41,6 +41,7 @@ exports[`Card (1) should render card without caption if attachment type is audio
             <button
               class="str-chat__message-attachment-audio-widget--play-button"
               data-testid="play-audio"
+              type="button"
             >
               <svg
                 fill="none"
@@ -258,6 +259,7 @@ exports[`Card (7) should render audio with caption using og_scrape_url and with 
             <button
               class="str-chat__message-attachment-audio-widget--play-button"
               data-testid="play-audio"
+              type="button"
             >
               <svg
                 fill="none"
@@ -470,6 +472,7 @@ exports[`Card (10) should render audio without title if attachment type is audio
             <button
               class="str-chat__message-attachment-audio-widget--play-button"
               data-testid="play-audio"
+              type="button"
             >
               <svg
                 fill="none"
@@ -667,6 +670,7 @@ exports[`Card (13) should render audio without title and with caption using og_s
             <button
               class="str-chat__message-attachment-audio-widget--play-button"
               data-testid="play-audio"
+              type="button"
             >
               <svg
                 fill="none"
@@ -851,6 +855,7 @@ exports[`Card (16) should render audio widget with title & text in Card content 
             <button
               class="str-chat__message-attachment-audio-widget--play-button"
               data-testid="play-audio"
+              type="button"
             >
               <svg
                 fill="none"
@@ -1384,6 +1389,7 @@ exports[`Card (25) should render audio widget with image loaded from thumb_url a
             <button
               class="str-chat__message-attachment-audio-widget--play-button"
               data-testid="play-audio"
+              type="button"
             >
               <svg
                 fill="none"

--- a/src/components/Attachment/components/PlayButton.tsx
+++ b/src/components/Attachment/components/PlayButton.tsx
@@ -11,6 +11,7 @@ export const PlayButton = ({ isPlaying, onClick }: PlayButtonProps) => (
     className='str-chat__message-attachment-audio-widget--play-button'
     data-testid={isPlaying ? 'pause-audio' : 'play-audio'}
     onClick={onClick}
+    type='button'
   >
     {isPlaying ? <PauseIcon /> : <PlayTriangleIcon />}
   </button>

--- a/src/components/Attachment/components/PlaybackRateButton.tsx
+++ b/src/components/Attachment/components/PlaybackRateButton.tsx
@@ -7,6 +7,7 @@ export const PlaybackRateButton = ({ children, onClick }: PlaybackRateButtonProp
     className='str-chat__message_attachment__playback-rate-button'
     data-testid='playback-rate-button'
     onClick={onClick}
+    type='button'
   >
     {children}
   </button>

--- a/src/components/MessageInput/AttachmentPreviewList/FileAttachmentPreview.tsx
+++ b/src/components/MessageInput/AttachmentPreviewList/FileAttachmentPreview.tsx
@@ -43,6 +43,7 @@ export const FileAttachmentPreview = ({
           attachment.localMetadata?.id &&
           removeAttachments([attachment.localMetadata?.id])
         }
+        type='button'
       >
         <CloseIcon />
       </button>

--- a/src/components/MessageInput/AttachmentPreviewList/GeolocationPreview.tsx
+++ b/src/components/MessageInput/AttachmentPreviewList/GeolocationPreview.tsx
@@ -36,6 +36,7 @@ export const GeolocationPreview = ({
           className='str-chat__attachment-preview-delete'
           data-testid='location-preview-item-delete-button'
           onClick={remove}
+          type='button'
         >
           <CloseIcon />
         </button>

--- a/src/components/MessageInput/AttachmentPreviewList/ImageAttachmentPreview.tsx
+++ b/src/components/MessageInput/AttachmentPreviewList/ImageAttachmentPreview.tsx
@@ -36,6 +36,7 @@ export const ImageAttachmentPreview = ({
         data-testid='image-preview-item-delete-button'
         disabled={uploadState === 'uploading'}
         onClick={() => id && removeAttachments([id])}
+        type='button'
       >
         <CloseIcon />
       </button>

--- a/src/components/MessageInput/AttachmentPreviewList/UnsupportedAttachmentPreview.tsx
+++ b/src/components/MessageInput/AttachmentPreviewList/UnsupportedAttachmentPreview.tsx
@@ -40,6 +40,7 @@ export const UnsupportedAttachmentPreview = ({
           attachment.localMetadata?.id &&
           removeAttachments([attachment.localMetadata?.id])
         }
+        type='button'
       >
         <CloseIcon />
       </button>

--- a/src/components/MessageInput/AttachmentPreviewList/VoiceRecordingPreview.tsx
+++ b/src/components/MessageInput/AttachmentPreviewList/VoiceRecordingPreview.tsx
@@ -43,6 +43,7 @@ export const VoiceRecordingPreview = ({
         onClick={() =>
           attachment.localMetadata?.id && removeAttachments([attachment.localMetadata.id])
         }
+        type='button'
       >
         <CloseIcon />
       </button>

--- a/src/components/MessageInput/__tests__/__snapshots__/AttachmentPreviewList.test.js.snap
+++ b/src/components/MessageInput/__tests__/__snapshots__/AttachmentPreviewList.test.js.snap
@@ -25,6 +25,7 @@ exports[`AttachmentPreviewList should render custom BaseImage component 1`] = `
               class="str-chat__attachment-preview-delete"
               data-testid="image-preview-item-delete-button"
               disabled=""
+              type="button"
             >
               <svg
                 data-testid="close-no-outline"
@@ -98,6 +99,7 @@ exports[`AttachmentPreviewList should render custom BaseImage component 1`] = `
               class="str-chat__attachment-preview-delete"
               data-testid="image-preview-item-delete-button"
               disabled=""
+              type="button"
             >
               <svg
                 data-testid="close-no-outline"


### PR DESCRIPTION
### 🎯 Goal

Prevent closing EditMessageForm on non-sbumit button click

Closes REACT-650

### 🛠 Implementation details

Edit form was closed when clicking on the audio play button. Just in case I have added `type='button'` to buttons that remove an attachment in the form.

### 🎨 UI Changes

_Add relevant screenshots_
