### PR TITLE
feat: add ReactionSelector styling + cleanup  

### DIFF
--- a/src/components/Button/styling/Button.scss
+++ b/src/components/Button/styling/Button.scss
@@ -3,7 +3,7 @@
 .str-chat {
   .str-chat__button {
     @include utils.button-reset;
-    position: relative;     /* creates positioning context for pseudo ::after overlay */
+    position: relative; /* creates positioning context for pseudo ::after overlay */
     overflow: hidden;
 
     cursor: pointer;
@@ -90,6 +90,11 @@
         @include utils.focusable;
       }
 
+      &:not(:disabled)[aria-pressed="true"] {
+        // toggled
+        @include utils.overlay-after(0.1);
+      }
+
       &:disabled {
         color: var(--text-disabled);
         cursor: default;
@@ -140,4 +145,3 @@
     }
   }
 }
-

--- a/src/components/Reactions/ReactionSelector.scss
+++ b/src/components/Reactions/ReactionSelector.scss
@@ -1,0 +1,70 @@
+.str-chat__reaction-selector {
+  display: flex;
+  padding-inline-start: var(--spacing-xxs, 0);
+  padding-inline-end: var(--spacing-xs, 0);
+  padding-block: var(--spacing-xxs, 0);
+  align-items: center;
+  gap: var(--spacing-xs);
+
+  border-radius: var(--radius-4xl, 32px);
+  border: 1px solid var(--border-core-surface-subtle, #e2e6ea);
+  background: var(--background-elevation-elevation-2, #fff);
+
+  /* shadow/ios/light/elevation-3 */
+  box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.16);
+
+  .str-chat__reaction-selector__add-button {
+  }
+
+  .str-chat__reaction-selector-list {
+    list-style: none;
+    margin: var(--spacing-none, 0);
+    padding: var(--spacing-none, 0);
+    display: flex;
+    gap: var(--space-2, 2px);
+
+    .str-chat__reaction-selector-list__item {
+      display: flex;
+    }
+
+    .str-chat__reaction-selector-list__item-button {
+      background-color: transparent;
+      border: none;
+      border-radius: var(--radius-max);
+      cursor: pointer;
+
+      display: flex;
+      min-width: 40px;
+      min-height: 40px;
+      padding: var(--spacing-none, 0);
+      justify-content: center;
+      align-items: center;
+      gap: var(--spacing-none, 0);
+
+      &:not(:disabled):hover {
+        background-color: var(--background-core-hover);
+      }
+      &:not(:disabled):active {
+        background-color: var(--background-core-pressed);
+      }
+      &:not(:disabled):focus-visible {
+        outline: 2px solid var(--border-utility-focus);
+        outline-offset: -2px;
+      }
+      &:not(:disabled)[aria-pressed='true'] {
+        background-color: var(--background-core-selected);
+      }
+
+      .str-chat__reaction-icon {
+        font-size: var(--typography-font-size-2xl);
+        line-height: 1;
+        display: flex;
+        padding: var(--spacing-none, 0);
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: var(--spacing-none, 0);
+      }
+    }
+  }
+}

--- a/src/components/Reactions/ReactionSelector.tsx
+++ b/src/components/Reactions/ReactionSelector.tsx
@@ -1,65 +1,31 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useMemo } from 'react';
 import clsx from 'clsx';
 
-import { Avatar as DefaultAvatar } from '../Avatar';
 import { useDialog } from '../Dialog';
 import { defaultReactionOptions } from './reactionOptions';
-import { isMutableRef } from './utils/utils';
-
 import { useComponentContext } from '../../context/ComponentContext';
 import { useMessageContext } from '../../context/MessageContext';
 
-import type { ReactionGroupResponse, ReactionResponse } from 'stream-chat';
-import type { AvatarProps } from '../Avatar';
-
-import type { ReactionOptions } from './reactionOptions';
+import type { ReactionResponse } from 'stream-chat';
 
 export type ReactionSelectorProps = {
-  /** Custom UI component to display user avatar, defaults to and accepts same props as: [Avatar](https://github.com/GetStream/stream-chat-react/blob/master/src/components/Avatar/Avatar.tsx) */
-  Avatar?: React.ElementType<AvatarProps>;
-  /** If true, shows the user's avatar with the reaction */
-  detailedView?: boolean;
   /** Function that adds/removes a reaction on a message (overrides the function stored in `MessageContext`) */
   handleReaction?: (
     reactionType: string,
     event: React.BaseSyntheticEvent,
   ) => Promise<void>;
-  /** An array of the reaction objects to display in the list */
-  latest_reactions?: ReactionResponse[];
   /** An array of the own reaction objects to distinguish own reactions visually */
   own_reactions?: ReactionResponse[];
-  /**
-   * An object that keeps track of the count of each type of reaction on a message
-   * @deprecated This override value is no longer taken into account. Use `reaction_groups` to override reaction counts instead.
-   * */
-  reaction_counts?: Record<string, number>;
-  /** An object containing summary for each reaction type on a message */
-  reaction_groups?: Record<string, ReactionGroupResponse>;
-  /**
-   * @deprecated
-   * A list of the currently supported reactions on a message
-   * */
-  reactionOptions?: ReactionOptions;
-  /** If true, adds a CSS class that reverses the horizontal positioning of the selector */
-  reverse?: boolean;
 };
 
-const UnMemoizedReactionSelector = (props: ReactionSelectorProps) => {
-  const {
-    Avatar: propAvatar,
-    detailedView = true,
-    handleReaction: propHandleReaction,
-    latest_reactions: propLatestReactions,
-    own_reactions: propOwnReactions,
-    reaction_groups: propReactionGroups,
-    reactionOptions: propReactionOptions,
-    reverse = false,
-  } = props;
+const stableOwnReactions: ReactionResponse[] = [];
 
-  const {
-    Avatar: contextAvatar,
-    reactionOptions: contextReactionOptions = defaultReactionOptions,
-  } = useComponentContext('ReactionSelector');
+const UnMemoizedReactionSelector = (props: ReactionSelectorProps) => {
+  const { handleReaction: propHandleReaction, own_reactions: propOwnReactions } = props;
+
+  const { reactionOptions = defaultReactionOptions } =
+    useComponentContext('ReactionSelector');
+
   const {
     closeReactionSelectorOnClick,
     handleReaction: contextHandleReaction,
@@ -67,162 +33,64 @@ const UnMemoizedReactionSelector = (props: ReactionSelectorProps) => {
   } = useMessageContext('ReactionSelector');
   const dialogId = `reaction-selector--${message.id}`;
   const dialog = useDialog({ id: dialogId });
-  const reactionOptions = propReactionOptions ?? contextReactionOptions;
 
-  const Avatar = propAvatar || contextAvatar || DefaultAvatar;
-  const handleReaction = propHandleReaction || contextHandleReaction;
-  const latestReactions = propLatestReactions || message?.latest_reactions || [];
-  const ownReactions = propOwnReactions || message?.own_reactions || [];
-  const reactionGroups = propReactionGroups || message?.reaction_groups || {};
+  const handleReaction = propHandleReaction ?? contextHandleReaction;
+  const ownReactions = propOwnReactions ?? message?.own_reactions ?? stableOwnReactions;
 
-  const [tooltipReactionType, setTooltipReactionType] = useState<string | null>(null);
-  const [tooltipPositions, setTooltipPositions] = useState<{
-    arrow: number;
-    tooltip: number;
-  } | null>(null);
+  const ownReactionByType = useMemo(() => {
+    const map: { [key: string]: ReactionResponse } = {};
 
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const targetRef = useRef<HTMLDivElement | null>(null);
-  const tooltipRef = useRef<HTMLDivElement | null>(null);
+    for (const reaction of ownReactions) {
+      map[reaction.type] ??= reaction;
+    }
 
-  const showTooltip = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>, reactionType: string) => {
-      targetRef.current = event.currentTarget;
-      setTooltipReactionType(reactionType);
-    },
-    [],
-  );
+    return map;
+  }, [ownReactions]);
 
-  const hideTooltip = useCallback(() => {
-    setTooltipReactionType(null);
-    setTooltipPositions(null);
-  }, []);
-
-  useEffect(() => {
-    if (!tooltipReactionType || !rootRef.current) return;
-    const tooltip = tooltipRef.current?.getBoundingClientRect();
-    const target = targetRef.current?.getBoundingClientRect();
-
-    const container = isMutableRef(rootRef)
-      ? rootRef.current?.getBoundingClientRect()
-      : null;
-
-    if (!tooltip || !target || !container) return;
-
-    const tooltipPosition =
-      tooltip.width === container.width || tooltip.x < container.x
-        ? 0
-        : target.left + target.width / 2 - container.left - tooltip.width / 2;
-
-    const arrowPosition = target.x - tooltip.x + target.width / 2 - tooltipPosition;
-
-    setTooltipPositions({
-      arrow: arrowPosition,
-      tooltip: tooltipPosition,
-    });
-  }, [tooltipReactionType, rootRef]);
-
-  const getUsersPerReactionType = (type: string | null) =>
-    latestReactions
-      .map((reaction) => {
-        if (reaction.type === type) {
-          return reaction.user?.name || reaction.user?.id;
-        }
-        return null;
-      })
-      .filter(Boolean);
-
-  const iHaveReactedWithReaction = (reactionType: string) =>
-    ownReactions.find((reaction) => reaction.type === reactionType);
-
-  const getLatestUserForReactionType = (type: string | null) =>
-    latestReactions.find((reaction) => reaction.type === type && !!reaction.user)?.user ||
-    undefined;
+  console.log({ ownReactionByType });
 
   return (
-    <div
-      className={clsx(
-        'str-chat__reaction-selector str-chat__message-reaction-selector str-chat-react__message-reaction-selector',
-        {
-          'str-chat__reaction-selector--reverse': reverse,
-        },
-      )}
-      data-testid='reaction-selector'
-      ref={rootRef}
-    >
-      {!!tooltipReactionType && detailedView && (
-        <div
-          className='str-chat__reaction-selector-tooltip'
-          ref={tooltipRef}
-          style={{
-            left: tooltipPositions?.tooltip,
-            visibility: tooltipPositions ? 'visible' : 'hidden',
-          }}
-        >
-          <div className='arrow' style={{ left: tooltipPositions?.arrow }} />
-          {getUsersPerReactionType(tooltipReactionType)?.map((user, i, users) => (
-            <span className='latest-user-username' key={`key-${i}-${user}`}>
-              {`${user}${i < users.length - 1 ? ', ' : ''}`}
-            </span>
-          ))}
-        </div>
-      )}
-      <ul className='str-chat__message-reactions-list str-chat__message-reactions-options'>
-        {reactionOptions.map(({ Component, name: reactionName, type: reactionType }) => {
-          const latestUser = getLatestUserForReactionType(reactionType);
-          const count = reactionGroups[reactionType]?.count ?? 0;
-          return (
-            <li key={reactionType}>
-              <button
-                aria-label={`Select Reaction: ${reactionName || reactionType}`}
-                className={clsx(
-                  'str-chat__message-reactions-list-item str-chat__message-reactions-option',
-                  {
-                    'str-chat__message-reactions-option-selected':
-                      iHaveReactedWithReaction(reactionType),
-                  },
-                )}
-                data-testid='select-reaction-button'
-                data-text={reactionType}
-                onClick={(event) => {
-                  handleReaction(reactionType, event);
-                  if (closeReactionSelectorOnClick) {
-                    dialog.close();
-                  }
-                }}
-              >
-                {!!count && detailedView && (
-                  <div
-                    className='latest-user str-chat__message-reactions-last-user'
-                    onClick={hideTooltip}
-                    onMouseEnter={(e) => showTooltip(e, reactionType)}
-                    onMouseLeave={hideTooltip}
-                  >
-                    {latestUser ? (
-                      <Avatar
-                        image={latestUser.image}
-                        name={latestUser.name}
-                        size={20}
-                        user={latestUser}
-                      />
-                    ) : (
-                      <div className='latest-user-not-found' />
-                    )}
-                  </div>
-                )}
-                <span className='str-chat__message-reaction-emoji'>
-                  <Component />
-                </span>
-                {Boolean(count) && detailedView && (
-                  <span className='str-chat__message-reactions-list-item__count'>
-                    {count || ''}
-                  </span>
-                )}
-              </button>
-            </li>
-          );
-        })}
+    <div className='str-chat__reaction-selector' data-testid='reaction-selector'>
+      <ul className='str-chat__reaction-selector-list'>
+        {reactionOptions.map(({ Component, name: reactionName, type: reactionType }) => (
+          <li className='str-chat__reaction-list-selector__item' key={reactionType}>
+            <button
+              aria-label={`Select Reaction: ${reactionName || reactionType}`}
+              aria-pressed={typeof ownReactionByType[reactionType] !== 'undefined'}
+              className={clsx('str-chat__reaction-selector-list__item-button')}
+              data-testid='select-reaction-button'
+              data-text={reactionType}
+              onClick={(event) => {
+                handleReaction(reactionType, event);
+                if (closeReactionSelectorOnClick) {
+                  dialog.close();
+                }
+              }}
+            >
+              <span className='str-chat__reaction-icon'>
+                <Component />
+              </span>
+            </button>
+          </li>
+        ))}
       </ul>
+      <button className='str-chat__reaction-selector__add-button str-chat__button str-chat__button--secondary str-chat__button--circular str-chat__button--outline str-chat__button--size-sm'>
+        <svg
+          fill='none'
+          height='20'
+          viewBox='0 0 20 20'
+          width='20'
+          xmlns='http://www.w3.org/2000/svg'
+        >
+          <path
+            d='M10 3.125V10M10 10V16.875M10 10H3.125M10 10H16.875'
+            stroke='#1A1B25'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+            strokeWidth='1.5'
+          />
+        </svg>
+      </button>
     </div>
   );
 };

--- a/src/components/Reactions/StreamEmoji.tsx
+++ b/src/components/Reactions/StreamEmoji.tsx
@@ -18,6 +18,9 @@ type StreamEmojiType = keyof typeof StreamSpriteEmojiPositions;
 
 const STREAM_SPRITE_URL = 'https://getstream.imgix.net/images/emoji-sprite.png';
 
+/**
+ * @deprecated
+ */
 export const StreamEmoji = ({
   fallback,
   type,

--- a/src/components/Reactions/reactionOptions.tsx
+++ b/src/components/Reactions/reactionOptions.tsx
@@ -2,8 +2,6 @@
 
 import React from 'react';
 
-import { StreamEmoji } from './StreamEmoji';
-
 export type ReactionOptions = Array<{
   Component: React.ComponentType;
   type: string;
@@ -13,23 +11,28 @@ export type ReactionOptions = Array<{
 export const defaultReactionOptions: ReactionOptions = [
   {
     type: 'haha',
-    Component: () => <StreamEmoji fallback='😂' type='haha' />,
+    Component: () => <>😂</>,
     name: 'Joy',
   },
   {
     type: 'like',
-    Component: () => <StreamEmoji fallback='👍' type='like' />,
+    Component: () => <>👍</>,
     name: 'Thumbs up',
   },
   {
     type: 'love',
-    Component: () => <StreamEmoji fallback='❤️' type='love' />,
+    Component: () => <>❤️</>,
     name: 'Heart',
   },
-  { type: 'sad', Component: () => <StreamEmoji fallback='😔' type='sad' />, name: 'Sad' },
+  { type: 'sad', Component: () => <>😔</>, name: 'Sad' },
   {
     type: 'wow',
-    Component: () => <StreamEmoji fallback='😲' type='wow' />,
+    Component: () => <>😮</>,
     name: 'Astonished',
+  },
+  {
+    type: 'fire',
+    Component: () => <>🔥</>,
+    name: 'Fire',
   },
 ];

--- a/src/styling/index.scss
+++ b/src/styling/index.scss
@@ -22,6 +22,7 @@
 @use "../components/MediaRecorder/AudioRecorder/styling" as AudioRecorder;
 @use "../components/Message/styling" as Message;
 @use "../components/MessageInput/styling" as MessageComposer;
+@use '../components/Reactions/ReactionSelector' as ReactionSelector;
 
 // Layers have to be kept the last
 @import 'modern-normalize' layer(css-reset);


### PR DESCRIPTION
### 🎯 Goal

Adjust `ReactionSelector` component to match the new design specification. 

BREAKING CHANGE: Props `Avatar`, `detailedView`, `latest_reactions`, `reaction_counts`, `reaction_groups`, `reactionOptions` & `reverse` have been removed from `ReactionSelector` component. The reason is that some of them were deprecated and some of them weren't being used in a way the component was set up by default. The component's class names have also changed, see table. 

| Change Type | Old Class Name                                                                                              | New Class Name                                            |
| ----------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| Changed     | `str-chat__reaction-selector str-chat__message-reaction-selector str-chat-react__message-reaction-selector` | `str-chat__reaction-selector`                             |
| Removed     | `str-chat__reaction-selector--reverse`                                                                      | —                                                         |
| Removed     | `str-chat__reaction-selector-tooltip`                                                                       | —                                                         |
| Removed     | `arrow`                                                                                                     | —                                                         |
| Removed     | `latest-user-username`                                                                                      | —                                                         |
| Changed     | `str-chat__message-reactions-list str-chat__message-reactions-options`                                      | `str-chat__reaction-selector-list`                        |
| Changed     | `str-chat__message-reactions-list-item str-chat__message-reactions-option`                                  | `str-chat__reaction-selector-list__item-button`           |
| Removed     | —                                                                                                           | `str-chat__reaction-list-selector__item`                  |
| Changed     | `str-chat__message-reactions-option-selected`                                                               | `str-chat__reaction-selector-list__item-button--selected` |
| Removed     | `latest-user str-chat__message-reactions-last-user`                                                         | —                                                         |
| Removed     | `latest-user-not-found`                                                                                     | —                                                         |
| Changed     | `str-chat__message-reaction-emoji`                                                                          | `str-chat__reaction-icon`                                 |
| Removed     | `str-chat__message-reactions-list-item__count`                                                              | —                                                         |

