### PR TITLE
fix: add missing suppressAutoscroll prop to MessageListProp

### DIFF
--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -387,6 +387,8 @@ export type MessageListProps = Partial<Pick<MessageProps, PropsDrilledToMessage>
    * is shown only when viewing unread messages.
    */
   showUnreadNotificationAlways?: boolean;
+  /** If true, prevents the message list from auto-scrolling when new messages arrive */
+  suppressAutoscroll?: boolean;
   /** If true, indicates the message list is a thread  */
   threadList?: boolean; // todo: refactor needed - message list should have a state in which among others it would be optionally flagged as thread
 };


### PR DESCRIPTION
### 🎯 Goal

- The prop was already supported in VirtualizedMessageListProps but was missing from MessageListProps, causing TypeScript errors when using `<MessageList suppressAutoscroll={true} />`

### 🛠 Implementation details

- Add missing type `suppressAutoscroll?: boolean` to `MessageList`

### 🎨 UI Changes

_Add relevant screenshots_
