### PR TITLE
feat: new GroupAvatar component design & adjustments 

### DIFF
--- a/src/components/Avatar/ChannelAvatar.tsx
+++ b/src/components/Avatar/ChannelAvatar.tsx
@@ -3,7 +3,9 @@ import React from 'react';
 import { Avatar, GroupAvatar } from './';
 import type { AvatarProps, GroupAvatarProps } from './';
 
-export type ChannelAvatarProps = Partial<GroupAvatarProps> & AvatarProps;
+export type ChannelAvatarProps = Partial<Omit<GroupAvatarProps & AvatarProps, 'size'>> & {
+  size: GroupAvatarProps['size'];
+};
 
 export const ChannelAvatar = ({
   groupChannelDisplayInfo,
@@ -14,7 +16,11 @@ export const ChannelAvatar = ({
 }: ChannelAvatarProps) => {
   if (groupChannelDisplayInfo) {
     return (
-      <GroupAvatar groupChannelDisplayInfo={groupChannelDisplayInfo} {...sharedProps} />
+      <GroupAvatar
+        groupChannelDisplayInfo={groupChannelDisplayInfo}
+        size={size}
+        {...sharedProps}
+      />
     );
   }
   return <Avatar imageUrl={imageUrl} size={size} userName={userName} {...sharedProps} />;

--- a/src/components/Avatar/GroupAvatar.tsx
+++ b/src/components/Avatar/GroupAvatar.tsx
@@ -1,38 +1,72 @@
 import clsx from 'clsx';
 import React, { type ComponentPropsWithoutRef } from 'react';
-import { Avatar } from './Avatar';
+import { Avatar, type AvatarProps } from './Avatar';
 import type { GroupChannelDisplayInfo } from '../ChannelPreview';
 
 export type GroupAvatarProps = ComponentPropsWithoutRef<'div'> & {
   /** Mapping of image URLs to names which initials will be used as fallbacks in case image assets fail to load. */
   groupChannelDisplayInfo: GroupChannelDisplayInfo;
+  size: 'xl' | 'lg' | null;
+  isOnline?: boolean;
 };
 
+/**
+ * Avatar component to display multiple users' avatars in a group channel, with a maximum of 4 avatars shown.
+ * Renders a single Avatar if only one user is provided.
+ */
+// TODO: rename to AvatarGroup
 export const GroupAvatar = ({
   className,
   groupChannelDisplayInfo,
+  isOnline,
+  size,
   ...rest
-}: GroupAvatarProps) => (
-  <div
-    className={clsx(
-      `str-chat__avatar-group`,
-      { 'str-chat__avatar-group--three-part': groupChannelDisplayInfo.length === 3 },
-      className,
-    )}
-    data-testid='group-avatar'
-    role='button'
-    {...rest}
-  >
-    {groupChannelDisplayInfo.slice(0, 4).map(({ image, name }, i) => (
+}: GroupAvatarProps) => {
+  if (!groupChannelDisplayInfo || groupChannelDisplayInfo.length < 2) {
+    const [firstUser] = groupChannelDisplayInfo || [];
+
+    return (
       <Avatar
-        className={clsx({
-          'str-chat__avatar--single': groupChannelDisplayInfo.length === 3 && i === 0,
-        })}
-        imageUrl={image}
-        key={`${name}-${image}-${i}`}
-        size='md'
-        userName={name}
+        imageUrl={firstUser?.imageUrl}
+        isOnline={isOnline}
+        size={size}
+        userName={firstUser?.userName}
+        {...rest}
       />
-    ))}
-  </div>
-);
+    );
+  }
+
+  let avatarSize: AvatarProps['size'] = null;
+
+  if (size === 'xl') {
+    avatarSize = 'lg';
+  } else if (size === 'lg') {
+    avatarSize = 'sm';
+  }
+
+  return (
+    <div
+      className={clsx(
+        'str-chat__avatar-group',
+        {
+          'str-chat__avatar-group--offline': typeof isOnline === 'boolean' && !isOnline,
+          'str-chat__avatar-group--online': typeof isOnline === 'boolean' && isOnline,
+          [`str-chat__avatar-group--size-${size}`]: typeof size === 'string',
+        },
+        className,
+      )}
+      data-testid='group-avatar'
+      role='button'
+      {...rest}
+    >
+      {groupChannelDisplayInfo.slice(0, 4).map(({ imageUrl, userName }, index) => (
+        <Avatar
+          imageUrl={imageUrl}
+          key={`${userName}-${imageUrl}-${index}`}
+          size={avatarSize}
+          userName={userName}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/Avatar/styling/GroupAvatar.scss
+++ b/src/components/Avatar/styling/GroupAvatar.scss
@@ -1,0 +1,106 @@
+.str-chat__avatar-group {
+  width: var(--avatar-group-size);
+  height: var(--avatar-group-size);
+  position: relative;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  &--size-xl {
+    --avatar-group-size: var(--size-64);
+    --avatar-group-badge-size: var(--size-16);
+  }
+
+  &--size-lg {
+    --avatar-group-size: var(--size-40);
+    --avatar-group-badge-size: 14px;
+  }
+
+  &.str-chat__avatar-group--online::after,
+  &.str-chat__avatar-group--offline::after {
+    aspect-ratio: 1/1;
+    content: '';
+    position: absolute;
+    width: var(--avatar-group-badge-size);
+
+    right: -2px;
+    top: -2px;
+
+    border-radius: var(--radius-max, 9999px);
+    border-style: solid;
+    border-color: var(--presence-border, #fff);
+    border-width: 2px;
+  }
+
+  &.str-chat__avatar-group--online::after {
+    background: var(--presence-bg-online, #00c384);
+  }
+
+  &.str-chat__avatar-group--offline::after {
+    background: var(--presence-bg-offline, #687385);
+  }
+
+  // TODO: discuss
+
+  // & > .str-chat__avatar::before {
+  //   content: '';
+  //   border-radius: var(--radius-max);
+  //   width: 100%;
+  //   height: 100%;
+  //   border: 2px solid var(--border-core-on-accent);
+  //   background: transparent;
+  //   position: absolute;
+  //   box-sizing: content-box;
+  // }
+
+  & > .str-chat__avatar {
+    position: absolute;
+    border: 2px solid var(--border-core-on-accent);
+  }
+
+  &:has(> :last-child:nth-child(4)) {
+    & > :nth-child(1) {
+      top: 0;
+      left: 0;
+    }
+    & > :nth-child(2) {
+      top: 0;
+      right: 0;
+    }
+    & > :nth-child(3) {
+      bottom: 0;
+      left: 0;
+    }
+    & > :nth-child(4) {
+      bottom: 0;
+      right: 0;
+    }
+  }
+
+  &:has(> :last-child:nth-child(3)) {
+    & > :nth-child(1) {
+      top: 0;
+    }
+    & > :nth-child(2) {
+      bottom: 0;
+      left: 0;
+    }
+    & > :nth-child(3) {
+      bottom: 0;
+      right: 0;
+    }
+  }
+
+  &:has(> :last-child:nth-child(2)) {
+    & > :nth-child(1) {
+      top: 0;
+      left: 0;
+    }
+    & > :nth-child(2) {
+      bottom: 0;
+      right: 0;
+    }
+  }
+}

--- a/src/components/ChannelHeader/ChannelHeader.tsx
+++ b/src/components/ChannelHeader/ChannelHeader.tsx
@@ -57,7 +57,7 @@ export const ChannelHeader = (props: ChannelHeaderProps) => {
         className='str-chat__avatar--channel-header'
         groupChannelDisplayInfo={groupChannelDisplayInfo}
         imageUrl={displayImage}
-        size='md'
+        size='lg'
         userName={displayTitle}
       />
       <div className='str-chat__channel-header-end'>

--- a/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
+++ b/src/components/ChannelPreview/ChannelPreviewMessenger.tsx
@@ -63,7 +63,7 @@ const UnMemoizedChannelPreviewMessenger = (props: ChannelPreviewUIComponentProps
             className='str-chat__avatar--channel-preview'
             groupChannelDisplayInfo={groupChannelDisplayInfo}
             imageUrl={displayImage}
-            size='md'
+            size='lg'
             userName={avatarName}
           />
         </div>

--- a/src/components/ChannelPreview/utils.tsx
+++ b/src/components/ChannelPreview/utils.tsx
@@ -107,7 +107,7 @@ export const getLatestMessagePreview = (
   return t('Empty message...');
 };
 
-export type GroupChannelDisplayInfo = { image?: string; name?: string }[];
+export type GroupChannelDisplayInfo = { imageUrl?: string; userName?: string }[];
 
 export const getGroupChannelDisplayInfo = (
   channel: Channel,
@@ -115,14 +115,14 @@ export const getGroupChannelDisplayInfo = (
   const members = Object.values(channel.state.members);
   if (members.length <= 2) return;
 
-  const info: GroupChannelDisplayInfo = [];
-  for (let i = 0; i < members.length; i++) {
-    const { user } = members[i];
+  const data: GroupChannelDisplayInfo = [];
+  for (const member of members) {
+    const { user } = member;
     if (!user?.name && !user?.image) continue;
-    info.push({ image: user.image, name: user.name });
-    if (info.length === 4) break;
+    data.push({ imageUrl: user.image, userName: user.name });
+    if (data.length === 4) break;
   }
-  return info;
+  return data;
 };
 
 const getChannelDisplayInfo = (

--- a/src/styling/index.scss
+++ b/src/styling/index.scss
@@ -22,6 +22,7 @@
 @use '../components/Attachment/styling' as Attachment;
 @use '../components/AudioPlayback/styling' as AudioPlayback;
 @use '../components/Avatar/styling/Avatar' as Avatar;
+@use '../components/Avatar/styling/GroupAvatar' as GroupAvatar;
 @use '../components/MediaRecorder/AudioRecorder/styling' as AudioRecorder;
 @use '../components/Message/styling' as Message;
 @use '../components/MessageActions/styling' as MessageActions;


### PR DESCRIPTION
### 🎯 Goal

<img width="539" height="182" alt="localhost_5175__user_id=mark (3)" src="https://github.com/user-attachments/assets/ed3a9d0e-3808-4009-9674-0177b6b8825b" />
<img width="539" height="182" alt="localhost_5175__user_id=mark (2)" src="https://github.com/user-attachments/assets/3fd57d7b-f416-456b-9543-b89ba0465540" />

### TODO:

- [ ] adjust ChannelAvatar behavior?
- [ ] rename GroupAvatar to AvatarGroup
- [ ] discuss GroupAvatar behavior when only one user-info object is available

BREAKING CHANGE: `GroupAvatar` component now renders a singular `Avatar` component without any wrappers if the `groupChannelDisplayInfo` contains only a single entry. Some class names have been removed, see the table bellow:
| Change Type | Old Class Name                       | New Class Name |
| ----------- | ------------------------------------ | -------------- |
| Removed     | `str-chat__avatar--single`           | -              |
| Removed     | `str-chat__avatar-group--three-part` | -              |

