### PR TITLE
fix(dialog): keep DialogManagerProvider mounted on first render and stabilize manager identity

### DIFF
--- a/src/components/ChannelList/hooks/useSelectedChannelState.ts
+++ b/src/components/ChannelList/hooks/useSelectedChannelState.ts
@@ -45,5 +45,5 @@ export function useSelectedChannelState<O>({
     return selector(channel);
   }, [channel, selector]);
 
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/src/components/Dialog/__tests__/DialogManagerContext.test.tsx
+++ b/src/components/Dialog/__tests__/DialogManagerContext.test.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { vi } from 'vitest';
 import {
   DialogManagerProvider,
   useDialogManager,
 } from '../../../context/DialogManagerContext';
 
 import { useDialogIsOpen, useOpenedDialogCount } from '../hooks';
+
+vi.mock('../../../components/Dialog/service/DialogPortal', () => ({
+  DialogPortalDestination: () => null,
+}));
 
 const TEST_IDS = {
   CLOSE_DIALOG: 'close-dialog',
@@ -87,6 +93,16 @@ describe('DialogManagerContext', () => {
         TEST_MANAGER_ID,
       );
       expect(screen.getByTestId(TEST_IDS.DIALOG_COUNT).textContent).toBe('0');
+    });
+
+    it('renders children during SSR when id is provided', () => {
+      const html = renderToStaticMarkup(
+        <DialogManagerProvider id={TEST_MANAGER_ID}>
+          <div>server-rendered-child</div>
+        </DialogManagerProvider>,
+      );
+
+      expect(html).toContain('server-rendered-child');
     });
 
     it('provides dialog manager to non-child components', () => {

--- a/src/context/DialogManagerContext.tsx
+++ b/src/context/DialogManagerContext.tsx
@@ -15,26 +15,11 @@ type DialogManagerId = string;
 
 type DialogManagersState = Record<DialogManagerId, DialogManager | undefined>;
 const dialogManagersRegistry: StateStore<DialogManagersState> = new StateStore({});
+const pendingDialogManagersById: Partial<Record<DialogManagerId, DialogManager>> = {};
+const dialogManagerMountCountsById: Partial<Record<DialogManagerId, number>> = {};
 
 const getDialogManager = (id: string): DialogManager | undefined =>
   dialogManagersRegistry.getLatestValue()[id];
-
-const getOrCreateDialogManager = ({
-  closeOnClickOutside,
-  id,
-}: {
-  closeOnClickOutside?: boolean;
-  id: string;
-}) => {
-  let manager = getDialogManager(id);
-  if (!manager) {
-    manager = new DialogManager({ closeOnClickOutside, id });
-    dialogManagersRegistry.partialNext({ [id]: manager });
-  } else if (typeof closeOnClickOutside === 'boolean') {
-    manager.closeOnClickOutside = closeOnClickOutside;
-  }
-  return manager;
-};
 
 const removeDialogManager = (id: string) => {
   if (!getDialogManager(id)) return;
@@ -67,22 +52,49 @@ export const DialogManagerProvider = ({
   closeOnClickOutside,
   id,
 }: DialogManagerProviderProps) => {
-  const [dialogManager, setDialogManager] = useState<DialogManager | null>(() => {
-    if (id) return getDialogManager(id) ?? null;
+  const [dialogManager, setDialogManager] = useState<DialogManager>(() => {
+    if (id) {
+      const manager =
+        getDialogManager(id) ??
+        pendingDialogManagersById[id] ??
+        new DialogManager({ closeOnClickOutside, id });
+
+      pendingDialogManagersById[id] = manager;
+      return manager;
+    }
     return new DialogManager({ closeOnClickOutside }); // will not be included in the registry
   });
 
   useEffect(() => {
     if (!id) return;
-    setDialogManager(getOrCreateDialogManager({ closeOnClickOutside, id }));
+    const manager =
+      getDialogManager(id) ??
+      pendingDialogManagersById[id] ??
+      new DialogManager({ closeOnClickOutside, id });
+
+    if (typeof closeOnClickOutside === 'boolean') {
+      manager.closeOnClickOutside = closeOnClickOutside;
+    }
+
+    if (!getDialogManager(id)) {
+      dialogManagersRegistry.partialNext({ [id]: manager });
+    }
+    delete pendingDialogManagersById[id];
+
+    setDialogManager((prev) => (prev === manager ? prev : manager));
+    dialogManagerMountCountsById[id] = (dialogManagerMountCountsById[id] ?? 0) + 1;
+
     return () => {
+      const nextMountCount = (dialogManagerMountCountsById[id] ?? 1) - 1;
+      if (nextMountCount > 0) {
+        dialogManagerMountCountsById[id] = nextMountCount;
+        return;
+      }
+
+      delete dialogManagerMountCountsById[id];
       removeDialogManager(id);
-      setDialogManager(null);
     };
   }, [closeOnClickOutside, id]);
-
-  // temporarily do not render until a new dialog manager is created
-  if (!dialogManager) return null;
 
   return (
     <DialogManagerProviderContext.Provider value={{ dialogManager }}>
@@ -172,7 +184,7 @@ export const useDialogManager = ({
 
         if (!managerInPrevState || managerInNewState?.id !== managerInPrevState.id) {
           setDialogManagerContext((prevState) => {
-            if (prevState?.dialogManager.id === managerInNewState?.id) return prevState;
+            if (prevState?.dialogManager === managerInNewState) return prevState;
             // fixme: need to handle the possibility that the dialogManager is undefined
             return {
               dialogManager:

--- a/src/store/hooks/useStateStore.ts
+++ b/src/store/hooks/useStateStore.ts
@@ -59,7 +59,11 @@ export function useStateStore<
     };
   }, [store, selector]);
 
-  const state = useSyncExternalStore(wrappedSubscription, wrappedSnapshot);
+  const state = useSyncExternalStore(
+    wrappedSubscription,
+    wrappedSnapshot,
+    wrappedSnapshot,
+  );
 
   return state;
 }


### PR DESCRIPTION
## 🎯 Goal

This PR fixes an initial-render bug in `DialogManagerProvider` that could cause `Chat` children to be skipped on first render (notably affecting SSR), and also fixes manager identity mismatches that could break anchored dialog UIs (for example channel action context menus).

## Problem

`DialogManagerProvider` previously initialized with `null` for `id`-based managers until `useEffect` ran.  
That introduced two issues:

1. First render could return `null`, so children were not rendered in SSR/initial pass.
2. Manager lifecycle/lookup could diverge when multiple providers with the same `id` were involved, causing dialog open state and portal destination to use different manager instances.

## Changes

- Removed first-pass `null` gating behavior for `DialogManagerProvider`.
- Added pending manager cache to ensure same-id providers can share a stable manager during first render.
- Added mount ref counting to avoid removing a shared manager while other providers with the same `id` are still mounted.
- Switched manager equality checks from id-based comparison to object identity (`===`) where needed to prevent stale instance reuse.

## Tests

Added regression coverage in both branches to verify SSR behavior:

- Assert children are included in server-rendered markup when `DialogManagerProvider` is used with an `id`.
- Mock `DialogPortalDestination` in the SSR-specific test to keep the assertion focused on provider rendering behavior.

## Validation

- Master dialog context suite passes locally:
  - `yarn test src/components/Dialog/__tests__/DialogManagerContext.test.tsx`
- Context menu behavior was rechecked in the local app repro URL and now opens after toggle.

## Impact

- Prevents initial child drop on first render.
- Restores stable dialog/context-menu behavior for shared manager scenarios.
- Keeps behavior aligned between `master` and `release-v13` implementations where APIs differ.
