### PR TITLE
fix(dialog): prevent outside-click from other dialog managers closing active dialogs

### DIFF
--- a/src/components/Dialog/__tests__/DialogPortal.test.tsx
+++ b/src/components/Dialog/__tests__/DialogPortal.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useDialogOnNearestManager } from '../hooks';
+import { DialogAnchor } from '../service';
+import { DialogManagerProvider } from '../../../context';
+
+const DialogFixture = ({ dialogId, testId }: { dialogId: string; testId: string }) => {
+  const { dialog } = useDialogOnNearestManager({ id: dialogId });
+
+  return (
+    <>
+      <button data-testid={`open-${dialogId}`} onClick={() => dialog.open()}>
+        Open
+      </button>
+      <DialogAnchor id={dialogId}>
+        <button data-testid={testId}>Dialog content</button>
+      </DialogAnchor>
+    </>
+  );
+};
+
+describe('DialogPortal', () => {
+  it('does not close dialogs from another manager when clicking in a different manager overlay', async () => {
+    render(
+      <DialogManagerProvider id='manager-a'>
+        <DialogFixture dialogId='dialog-a' testId='dialog-a-content' />
+        <DialogManagerProvider id='manager-b'>
+          <DialogFixture dialogId='dialog-b' testId='dialog-b-content' />
+        </DialogManagerProvider>
+      </DialogManagerProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('open-dialog-a'));
+      fireEvent.click(screen.getByTestId('open-dialog-b'));
+    });
+
+    expect(screen.getByTestId('dialog-a-content')).toBeInTheDocument();
+    expect(screen.getByTestId('dialog-b-content')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('dialog-b-content'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dialog-a-content')).toBeInTheDocument();
+      expect(screen.getByTestId('dialog-b-content')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Dialog/service/DialogPortal.tsx
+++ b/src/components/Dialog/service/DialogPortal.tsx
@@ -25,6 +25,10 @@ export const DialogPortalDestination = () => {
 
     const handleDocumentClick = (event: MouseEvent) => {
       const target = event.target as Node;
+      const clickedOverlay = (target as HTMLElement).closest?.(
+        '[data-str-chat__portal-id]',
+      );
+      if (clickedOverlay && clickedOverlay !== destinationRoot) return;
       if (target !== destinationRoot && destinationRoot.contains(target)) return;
       // Defer so target onClick handlers (e.g. context-menu toggle buttons) can run first.
       setTimeout(() => {


### PR DESCRIPTION
### 🎯 Goal

This PR fixes a dialog dismissal bug where clicks inside one dialog manager could close dialogs in another manager.

### Root cause
`DialogPortal` was treating clicks outside its own overlay as outside-click dismissals, even when the click happened inside a different dialog manager overlay.

### Fix
- Updated outside-click handling in `DialogPortal` to ignore clicks that originate inside another dialog overlay (`[data-str-chat__portal-id]`), unless the click belongs to the current manager overlay.

### Why this matters
- Prevents unintended cross-manager dialog closures.
- Fixes cases where nested/parallel dialog flows (e.g. context menu + modal) become unstable after overlay interactions.

