### PR TITLE
feat: hide quick message actions on small screens

### DIFF
--- a/src/components/Dialog/components/ContextMenu.tsx
+++ b/src/components/Dialog/components/ContextMenu.tsx
@@ -413,6 +413,7 @@ export type ContextMenuItemProps = ComponentProps<'button'>;
 export type ContextMenuItemComponent = ComponentType<ContextMenuItemProps>;
 
 type ContextMenuContextValue = {
+  anchorReferenceElement?: HTMLElement | null;
   closeMenu: () => void;
   openSubmenu: (params: ContextMenuOpenSubmenuParams) => void;
   returnToParentMenu: () => void;
@@ -464,6 +465,7 @@ type ContextMenuAnchorProps = Partial<
 export type ContextMenuProps = ContextMenuBaseProps & ContextMenuAnchorProps;
 
 export type ContextMenuContentProps = ContextMenuBaseProps & {
+  anchorReferenceElement?: HTMLElement | null;
   transitionDirection?: 'forward' | 'backward';
 };
 
@@ -475,6 +477,7 @@ export type ContextMenuContentProps = ContextMenuBaseProps & {
  * handling from `ContextMenu`.
  */
 export function ContextMenuContent({
+  anchorReferenceElement,
   backLabel = 'Back',
   children,
   className,
@@ -547,7 +550,9 @@ export function ContextMenuContent({
   }, [transitionDirection, menuStack.length]);
 
   return (
-    <ContextMenuContext.Provider value={{ closeMenu, openSubmenu, returnToParentMenu }}>
+    <ContextMenuContext.Provider
+      value={{ anchorReferenceElement, closeMenu, openSubmenu, returnToParentMenu }}
+    >
       <ContextMenuRoot
         className={clsx(className, activeMenu.menuClassName)}
         data-str-chat-enable-animations={enableAnimations}
@@ -705,6 +710,7 @@ export const ContextMenu = (props: ContextMenuProps) => {
 
   const content = (
     <ContextMenuContentComponent
+      anchorReferenceElement={isAnchored ? referenceElement : undefined}
       {...menuProps}
       key={`context-menu-content-${contentResetToken}`}
       onMenuLevelChange={handleMenuLevelChange}

--- a/src/components/Message/styling/Message.scss
+++ b/src/components/Message/styling/Message.scss
@@ -81,6 +81,10 @@
   --str-chat-message-options-size: calc(3 * var(--str-chat__message-options-button-size));
   padding-inline: var(--str-chat__message-composer-padding);
 
+  @media (max-width: 767px) {
+    --str-chat-message-options-size: var(--str-chat__message-options-button-size);
+  }
+
   .str-chat__message-bubble {
     width: min(100%, var(--str-chat__message-max-width));
     max-width: var(--str-chat__message-max-width);

--- a/src/components/MessageActions/MessageActions.defaults.tsx
+++ b/src/components/MessageActions/MessageActions.defaults.tsx
@@ -82,9 +82,6 @@ const DefaultMessageActionComponents = {
       const { dialog, dialogManager } = useDialogOnNearestManager({
         id: dialogId,
       });
-      const { dialog: extendedDialog } = useDialogOnNearestManager({
-        id: `${dialogId}-extended`,
-      });
       const dialogIsOpen = useDialogIsOpen(dialogId, dialogManager?.id);
 
       return (
@@ -98,7 +95,7 @@ const DefaultMessageActionComponents = {
             trapFocus
             updatePositionOnContentResize
           >
-            <ReactionSelector dialogId={dialogId} referenceElement={referenceElement} />
+            <ReactionSelector dialogId={dialogId} />
           </DialogAnchor>
           <ContextMenuButton
             aria-expanded={dialogIsOpen}
@@ -111,7 +108,6 @@ const DefaultMessageActionComponents = {
             Icon={IconEmoji}
             onClick={(event) => {
               if (dialogIsOpen) {
-                extendedDialog.close();
                 dialog.close();
                 return;
               }
@@ -661,10 +657,6 @@ const DefaultMessageActionComponents = {
       const { dialog: dropdownReactionSelectorDialog } = useDialogOnNearestManager({
         id: `${reactionSelectorDialogId}-dropdown`,
       });
-      const { dialog: dropdownReactionSelectorExtendedDialog } =
-        useDialogOnNearestManager({
-          id: `${reactionSelectorDialogId}-dropdown-extended`,
-        });
 
       return (
         <QuickMessageActionsButton
@@ -677,7 +669,6 @@ const DefaultMessageActionComponents = {
             // Close dropdown-anchored reaction selectors before toggling actions menu
             // to avoid stale selector re-anchoring.
             dropdownReactionSelectorDialog?.close();
-            dropdownReactionSelectorExtendedDialog?.close();
             dialog?.toggle();
           }}
           ref={ref}

--- a/src/components/MessageActions/MessageActions.defaults.tsx
+++ b/src/components/MessageActions/MessageActions.defaults.tsx
@@ -30,6 +30,7 @@ import { useMessageComposerController } from '../MessageComposer/hooks/useMessag
 import { savePreEditSnapshot } from '../MessageComposer/preEditSnapshot';
 import { useNotificationApi } from '../Notifications';
 import { useMessageReminder } from '../Message/hooks/useMessageReminder';
+import { ReactionSelector as DefaultReactionSelector } from '../Reactions';
 import { ReactionSelectorWithButton } from '../Reactions/ReactionSelectorWithButton';
 import {
   useChatContext,
@@ -40,6 +41,7 @@ import {
 import { RemindMeSubmenu, RemindMeSubmenuHeader } from './RemindMeSubmenu';
 import {
   ContextMenuButton,
+  DialogAnchor,
   useContextMenuContext,
   useDialogIsOpen,
   useDialogOnNearestManager,
@@ -67,6 +69,65 @@ const getNotificationError = (error: unknown): Error | undefined => {
 
 const DefaultMessageActionComponents = {
   dropdown: {
+    React() {
+      const { ReactionSelector = DefaultReactionSelector } = useComponentContext();
+      const { anchorReferenceElement } = useContextMenuContext();
+      const { isMyMessage, message, threadList } = useMessageContext();
+      const { t } = useTranslationContext();
+      const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null);
+      const dialogId = `${DefaultReactionSelector.getDialogId({
+        messageId: message.id,
+        threadList,
+      })}-dropdown`;
+      const { dialog, dialogManager } = useDialogOnNearestManager({
+        id: dialogId,
+      });
+      const { dialog: extendedDialog } = useDialogOnNearestManager({
+        id: `${dialogId}-extended`,
+      });
+      const dialogIsOpen = useDialogIsOpen(dialogId, dialogManager?.id);
+
+      return (
+        <>
+          <DialogAnchor
+            dialogManagerId={dialogManager?.id}
+            id={dialogId}
+            offset={8}
+            placement={isMyMessage() ? 'top-end' : 'top-start'}
+            referenceElement={referenceElement}
+            trapFocus
+            updatePositionOnContentResize
+          >
+            <ReactionSelector dialogId={dialogId} referenceElement={referenceElement} />
+          </DialogAnchor>
+          <ContextMenuButton
+            aria-expanded={dialogIsOpen}
+            aria-label={t('aria/Open Reaction Selector')}
+            className={clsx(
+              msgActionsBoxButtonClassName,
+              'str-chat__message-actions-list-item-button--react',
+            )}
+            data-testid='dropdown-react-action'
+            Icon={IconEmoji}
+            onClick={(event) => {
+              if (dialogIsOpen) {
+                extendedDialog.close();
+                dialog.close();
+                return;
+              }
+              setReferenceElement(
+                anchorReferenceElement instanceof HTMLElement
+                  ? anchorReferenceElement
+                  : event.currentTarget,
+              );
+              dialog.open();
+            }}
+          >
+            {t('Add reaction')}
+          </ContextMenuButton>
+        </>
+      );
+    },
     ThreadReply() {
       const { closeMenu } = useContextMenuContext();
       const { handleOpenThread } = useMessageContext();
@@ -586,13 +647,24 @@ const DefaultMessageActionComponents = {
     // eslint-disable-next-line react/display-name
     DropdownToggle: forwardRef<HTMLButtonElement>((_, ref) => {
       const { t } = useTranslationContext();
-      const { message } = useMessageContext();
+      const { message, threadList } = useMessageContext();
       const dropdownDialogIsOpen = useDialogIsOpen(
         MessageActions.getDialogId({ messageId: message.id }),
       );
       const { dialog } = useDialogOnNearestManager({
         id: MessageActions.getDialogId({ messageId: message.id }),
       });
+      const reactionSelectorDialogId = DefaultReactionSelector.getDialogId({
+        messageId: message.id,
+        threadList,
+      });
+      const { dialog: dropdownReactionSelectorDialog } = useDialogOnNearestManager({
+        id: `${reactionSelectorDialogId}-dropdown`,
+      });
+      const { dialog: dropdownReactionSelectorExtendedDialog } =
+        useDialogOnNearestManager({
+          id: `${reactionSelectorDialogId}-dropdown-extended`,
+        });
 
       return (
         <QuickMessageActionsButton
@@ -602,6 +674,10 @@ const DefaultMessageActionComponents = {
           className='str-chat__message-actions-box-button'
           data-testid='message-actions-toggle-button'
           onClick={() => {
+            // Close dropdown-anchored reaction selectors before toggling actions menu
+            // to avoid stale selector re-anchoring.
+            dropdownReactionSelectorDialog?.close();
+            dropdownReactionSelectorExtendedDialog?.close();
             dialog?.toggle();
           }}
           ref={ref}
@@ -644,6 +720,11 @@ export const defaultMessageActionSet: MessageActionSetItem[] = [
   {
     Component: DefaultMessageActionComponents.quick.React,
     placement: 'quick',
+    type: 'react',
+  },
+  {
+    Component: DefaultMessageActionComponents.dropdown.React,
+    placement: 'dropdown',
     type: 'react',
   },
   {

--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -82,7 +82,6 @@ export const MessageActions: MessageActionsInterface = ({
     threadList,
   });
   const dropdownReactionSelectorDialogId = `${reactionSelectorDialogId}-dropdown`;
-  const dropdownReactionSelectorExtendedDialogId = `${dropdownReactionSelectorDialogId}-extended`;
   const { dialog, dialogManager } = useDialogOnNearestManager({
     id: messageActionsDialogId,
   });
@@ -98,10 +97,6 @@ export const MessageActions: MessageActionsInterface = ({
     dropdownReactionSelectorDialogId,
     dialogManager?.id,
   );
-  const dropdownReactionSelectorExtendedDialogIsOpen = useDialogIsOpen(
-    dropdownReactionSelectorExtendedDialogId,
-    dialogManager?.id,
-  );
 
   // do not render anything if total action count is zero
   if (dropdownActionSet.length + quickActionSet.length === 0) {
@@ -114,8 +109,7 @@ export const MessageActions: MessageActionsInterface = ({
         'str-chat__message-options--active':
           messageActionsDialogIsOpen ||
           reactionSelectorDialogIsOpen ||
-          dropdownReactionSelectorDialogIsOpen ||
-          dropdownReactionSelectorExtendedDialogIsOpen,
+          dropdownReactionSelectorDialogIsOpen,
       })}
     >
       {quickDropdownToggleAction && dropdownActionSet.length > 0 && (
@@ -126,7 +120,6 @@ export const MessageActions: MessageActionsInterface = ({
             backLabel={t('Back')}
             className={clsx('str-chat__message-actions-box', {
               'str-chat__message-actions-box--hidden':
-                dropdownReactionSelectorExtendedDialogIsOpen ||
                 dropdownReactionSelectorDialogIsOpen,
               'str-chat__message-actions-box--open': messageActionsDialogIsOpen,
             })}

--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -81,6 +81,8 @@ export const MessageActions: MessageActionsInterface = ({
     messageId: message.id,
     threadList,
   });
+  const dropdownReactionSelectorDialogId = `${reactionSelectorDialogId}-dropdown`;
+  const dropdownReactionSelectorExtendedDialogId = `${dropdownReactionSelectorDialogId}-extended`;
   const { dialog, dialogManager } = useDialogOnNearestManager({
     id: messageActionsDialogId,
   });
@@ -90,6 +92,14 @@ export const MessageActions: MessageActionsInterface = ({
   );
   const reactionSelectorDialogIsOpen = useDialogIsOpen(
     reactionSelectorDialogId,
+    dialogManager?.id,
+  );
+  const dropdownReactionSelectorDialogIsOpen = useDialogIsOpen(
+    dropdownReactionSelectorDialogId,
+    dialogManager?.id,
+  );
+  const dropdownReactionSelectorExtendedDialogIsOpen = useDialogIsOpen(
+    dropdownReactionSelectorExtendedDialogId,
     dialogManager?.id,
   );
 
@@ -102,7 +112,10 @@ export const MessageActions: MessageActionsInterface = ({
     <div
       className={clsx('str-chat__message-options', {
         'str-chat__message-options--active':
-          messageActionsDialogIsOpen || reactionSelectorDialogIsOpen,
+          messageActionsDialogIsOpen ||
+          reactionSelectorDialogIsOpen ||
+          dropdownReactionSelectorDialogIsOpen ||
+          dropdownReactionSelectorExtendedDialogIsOpen,
       })}
     >
       {quickDropdownToggleAction && dropdownActionSet.length > 0 && (
@@ -112,6 +125,9 @@ export const MessageActions: MessageActionsInterface = ({
           <ContextMenuComponent
             backLabel={t('Back')}
             className={clsx('str-chat__message-actions-box', {
+              'str-chat__message-actions-box--hidden':
+                dropdownReactionSelectorExtendedDialogIsOpen ||
+                dropdownReactionSelectorDialogIsOpen,
               'str-chat__message-actions-box--open': messageActionsDialogIsOpen,
             })}
             dialogManagerId={dialogManager?.id}

--- a/src/components/MessageActions/__tests__/MessageActions.test.tsx
+++ b/src/components/MessageActions/__tests__/MessageActions.test.tsx
@@ -49,6 +49,7 @@ const MESSAGE_ACTIONS_HOST_TEST_ID = 'message-actions-host';
 const dialogOverlayTestId = 'str-chat__dialog-overlay';
 const threadActionTestId = 'thread-action';
 const reactionActionTestId = 'message-reaction-action';
+const dropdownReactionActionTestId = 'dropdown-react-action';
 const reactionSelectorTestId = 'reaction-selector';
 
 const defaultMessageContextValue = {
@@ -557,6 +558,22 @@ describe('<MessageActions />', () => {
 
       expect(queryByTestId(reactionActionTestId)).not.toBeInTheDocument();
     });
+
+    it('should display reaction action at the top of dropdown list', async () => {
+      const { container } = await renderMessageActions({
+        channelStateOpts: {
+          channelCapabilities: { 'send-reaction': true },
+        },
+      });
+      await toggleOpenMessageActions();
+
+      const contextMenuButtons = container.querySelectorAll(
+        '.str-chat__context-menu__button',
+      );
+
+      expect(contextMenuButtons[0]).toHaveTextContent('Add reaction');
+      expect(screen.getByTestId(dropdownReactionActionTestId)).toBeInTheDocument();
+    });
   });
 
   describe('Reaction selector', () => {
@@ -633,6 +650,75 @@ describe('<MessageActions />', () => {
       });
 
       expect(actionsHost).toHaveClass('str-chat__message-options--active');
+    });
+
+    it('should render ReactionSelector when dropdown reaction action is clicked', async () => {
+      await renderMessageActions({
+        channelStateOpts: {
+          channelCapabilities: { 'send-reaction': true },
+        },
+      });
+      await toggleOpenMessageActions();
+
+      await act(async () => {
+        await fireEvent.click(screen.getByTestId(dropdownReactionActionTestId));
+      });
+
+      const reactionSelector = screen.getByTestId(reactionSelectorTestId);
+      expect(reactionSelector).toBeInTheDocument();
+      expect(reactionSelector.closest('.str-chat__context-menu')).toBeNull();
+      const messageActionsMenu = document.querySelector('.str-chat__message-actions-box');
+      expect(messageActionsMenu).toBeInTheDocument();
+      expect(messageActionsMenu).toHaveClass('str-chat__message-actions-box--hidden');
+    });
+
+    it('should close ReactionSelector when dropdown reaction action is clicked while selector is open', async () => {
+      await renderMessageActions({
+        channelStateOpts: {
+          channelCapabilities: { 'send-reaction': true },
+        },
+      });
+      await toggleOpenMessageActions();
+
+      await act(async () => {
+        await fireEvent.click(screen.getByTestId(dropdownReactionActionTestId));
+      });
+
+      expect(screen.getByTestId(reactionSelectorTestId)).toBeInTheDocument();
+
+      await act(async () => {
+        await fireEvent.click(screen.getByTestId(dropdownReactionActionTestId));
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(reactionSelectorTestId)).not.toBeInTheDocument();
+      });
+
+      const messageActionsMenu = document.querySelector('.str-chat__message-actions-box');
+      expect(messageActionsMenu).not.toHaveClass('str-chat__message-actions-box--hidden');
+    });
+
+    it('should close ReactionSelector when message actions toggle is clicked while dropdown selector is open', async () => {
+      await renderMessageActions({
+        channelStateOpts: {
+          channelCapabilities: { 'send-reaction': true },
+        },
+      });
+      await toggleOpenMessageActions();
+
+      await act(async () => {
+        await fireEvent.click(screen.getByTestId(dropdownReactionActionTestId));
+      });
+
+      expect(screen.getByTestId(reactionSelectorTestId)).toBeInTheDocument();
+
+      await act(async () => {
+        await fireEvent.click(screen.getByTestId(TOGGLE_ACTIONS_BUTTON_TEST_ID));
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(reactionSelectorTestId)).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/src/components/MessageActions/styling/MessageActions.scss
+++ b/src/components/MessageActions/styling/MessageActions.scss
@@ -2,6 +2,11 @@
 
 .str-chat__message-actions-box {
   min-width: 180px;
+
+  &.str-chat__message-actions-box--hidden {
+    visibility: hidden;
+    pointer-events: none;
+  }
 }
 
 .str-chat__message-options {
@@ -39,5 +44,24 @@
 
   .str-chat__message-actions-box-button {
     position: relative;
+  }
+}
+
+.str-chat
+  .str-chat__message-actions-list-item-button.str-chat__message-actions-list-item-button--react {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .str-chat .str-chat__message-options {
+    .str-chat__button.str-chat__message-reactions-button,
+    .str-chat__button.str-chat__message-reply-in-thread-button {
+      display: none;
+    }
+  }
+
+  .str-chat
+    .str-chat__message-actions-list-item-button.str-chat__message-actions-list-item-button--react {
+    display: flex;
   }
 }

--- a/src/components/Reactions/ReactionSelector.tsx
+++ b/src/components/Reactions/ReactionSelector.tsx
@@ -1,7 +1,7 @@
-import React, { type ReactNode, useMemo, useState } from 'react';
+import React, { type ReactNode, useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
 
-import { useDialogOnNearestManager } from '../Dialog';
+import { DialogAnchor, useDialogIsOpen, useDialogOnNearestManager } from '../Dialog';
 import { defaultReactionOptions } from './reactionOptions';
 import { useComponentContext } from '../../context/ComponentContext';
 import { useMessageContext } from '../../context/MessageContext';
@@ -11,6 +11,10 @@ import { IconPlus } from '../Icons';
 import type { ReactionResponse } from 'stream-chat';
 
 export type ReactionSelectorProps = {
+  /** Override dialog id used by the selector popover. */
+  dialogId?: string;
+  /** Optional anchor for selector dialogs; when provided, extended selector uses this anchor as well. */
+  referenceElement?: HTMLElement | null;
   /** Function that adds/removes a reaction on a message (overrides the function stored in `MessageContext`) */
   handleReaction?: (
     reactionType: string,
@@ -30,8 +34,14 @@ interface ReactionSelectorInterface {
 const stableOwnReactions: ReactionResponse[] = [];
 
 export const ReactionSelector: ReactionSelectorInterface = (props) => {
-  const { handleReaction: propHandleReaction, own_reactions: propOwnReactions } = props;
-  const [extendedListOpen, setExtendedListOpen] = useState(false);
+  const {
+    dialogId: propDialogId,
+    handleReaction: propHandleReaction,
+    own_reactions: propOwnReactions,
+    referenceElement: propReferenceElement,
+  } = props;
+  const [extendedReferenceElement, setExtendedReferenceElement] =
+    useState<HTMLElement | null>(null);
 
   const {
     reactionOptions = defaultReactionOptions,
@@ -41,14 +51,34 @@ export const ReactionSelector: ReactionSelectorInterface = (props) => {
   const {
     closeReactionSelectorOnClick,
     handleReaction: contextHandleReaction,
+    isMyMessage,
     message,
     threadList,
   } = useMessageContext('ReactionSelector');
-  const dialogId = ReactionSelector.getDialogId({
-    messageId: message.id,
-    threadList,
-  });
+  const dialogId =
+    propDialogId ??
+    ReactionSelector.getDialogId({
+      messageId: message.id,
+      threadList,
+    });
   const { dialog } = useDialogOnNearestManager({ id: dialogId });
+  const extendedDialogId = `${dialogId}-extended`;
+  const { dialog: extendedDialog, dialogManager: extendedDialogManager } =
+    useDialogOnNearestManager({ id: extendedDialogId });
+  const extendedDialogIsOpen = useDialogIsOpen(
+    extendedDialogId,
+    extendedDialogManager?.id,
+  );
+
+  useEffect(() => {
+    if (extendedDialogIsOpen) return;
+    setExtendedReferenceElement(null);
+  }, [extendedDialogIsOpen]);
+
+  useEffect(() => {
+    if (!extendedReferenceElement || extendedDialogIsOpen) return;
+    extendedDialog.open();
+  }, [extendedDialog, extendedDialogIsOpen, extendedReferenceElement]);
 
   const handleReaction = propHandleReaction ?? contextHandleReaction;
   const ownReactions = propOwnReactions ?? message?.own_reactions ?? stableOwnReactions;
@@ -77,9 +107,32 @@ export const ReactionSelector: ReactionSelectorInterface = (props) => {
   }, [reactionOptions]);
 
   return (
-    <div className='str-chat__reaction-selector' data-testid='reaction-selector'>
-      {!extendedListOpen && (
-        <>
+    <>
+      <DialogAnchor
+        dialogManagerId={extendedDialogManager?.id}
+        id={extendedDialogId}
+        offset={8}
+        placement={
+          typeof isMyMessage === 'function' && isMyMessage() ? 'top-end' : 'top-start'
+        }
+        referenceElement={propReferenceElement ?? extendedReferenceElement}
+        trapFocus
+      >
+        <div className='str-chat__reaction-selector'>
+          <ReactionSelectorExtendedList
+            {...props}
+            dialogId={extendedDialogId}
+            handleReaction={async (reactionType, event) => {
+              await handleReaction(reactionType, event);
+              if (closeReactionSelectorOnClick) {
+                dialog.close();
+              }
+            }}
+          />
+        </div>
+      </DialogAnchor>
+      {!extendedDialogIsOpen && (
+        <div className='str-chat__reaction-selector' data-testid='reaction-selector'>
           <ul
             className='str-chat__reaction-selector-list'
             data-testid='reaction-selector-list'
@@ -113,18 +166,21 @@ export const ReactionSelector: ReactionSelectorInterface = (props) => {
             circular
             className='str-chat__reaction-selector__add-button'
             data-testid='reaction-selector-add-button'
-            onClick={() => setExtendedListOpen(true)}
+            onClick={(event) => {
+              if (propReferenceElement) {
+                extendedDialog.open();
+                return;
+              }
+              setExtendedReferenceElement(event.currentTarget);
+            }}
             size='sm'
             variant='secondary'
           >
             <IconPlus />
           </Button>
-        </>
+        </div>
       )}
-      {extendedListOpen && (
-        <ReactionSelectorExtendedList {...props} dialogId={dialogId} />
-      )}
-    </div>
+    </>
   );
 };
 

--- a/src/components/Reactions/ReactionSelector.tsx
+++ b/src/components/Reactions/ReactionSelector.tsx
@@ -1,7 +1,7 @@
-import React, { type ReactNode, useEffect, useMemo, useState } from 'react';
+import React, { type ReactNode, useMemo, useState } from 'react';
 import clsx from 'clsx';
 
-import { DialogAnchor, useDialogIsOpen, useDialogOnNearestManager } from '../Dialog';
+import { useDialogOnNearestManager } from '../Dialog';
 import { defaultReactionOptions } from './reactionOptions';
 import { useComponentContext } from '../../context/ComponentContext';
 import { useMessageContext } from '../../context/MessageContext';
@@ -13,8 +13,6 @@ import type { ReactionResponse } from 'stream-chat';
 export type ReactionSelectorProps = {
   /** Override dialog id used by the selector popover. */
   dialogId?: string;
-  /** Optional anchor for selector dialogs; when provided, extended selector uses this anchor as well. */
-  referenceElement?: HTMLElement | null;
   /** Function that adds/removes a reaction on a message (overrides the function stored in `MessageContext`) */
   handleReaction?: (
     reactionType: string,
@@ -38,10 +36,8 @@ export const ReactionSelector: ReactionSelectorInterface = (props) => {
     dialogId: propDialogId,
     handleReaction: propHandleReaction,
     own_reactions: propOwnReactions,
-    referenceElement: propReferenceElement,
   } = props;
-  const [extendedReferenceElement, setExtendedReferenceElement] =
-    useState<HTMLElement | null>(null);
+  const [extendedListOpen, setExtendedListOpen] = useState(false);
 
   const {
     reactionOptions = defaultReactionOptions,
@@ -51,7 +47,6 @@ export const ReactionSelector: ReactionSelectorInterface = (props) => {
   const {
     closeReactionSelectorOnClick,
     handleReaction: contextHandleReaction,
-    isMyMessage,
     message,
     threadList,
   } = useMessageContext('ReactionSelector');
@@ -62,23 +57,6 @@ export const ReactionSelector: ReactionSelectorInterface = (props) => {
       threadList,
     });
   const { dialog } = useDialogOnNearestManager({ id: dialogId });
-  const extendedDialogId = `${dialogId}-extended`;
-  const { dialog: extendedDialog, dialogManager: extendedDialogManager } =
-    useDialogOnNearestManager({ id: extendedDialogId });
-  const extendedDialogIsOpen = useDialogIsOpen(
-    extendedDialogId,
-    extendedDialogManager?.id,
-  );
-
-  useEffect(() => {
-    if (extendedDialogIsOpen) return;
-    setExtendedReferenceElement(null);
-  }, [extendedDialogIsOpen]);
-
-  useEffect(() => {
-    if (!extendedReferenceElement || extendedDialogIsOpen) return;
-    extendedDialog.open();
-  }, [extendedDialog, extendedDialogIsOpen, extendedReferenceElement]);
 
   const handleReaction = propHandleReaction ?? contextHandleReaction;
   const ownReactions = propOwnReactions ?? message?.own_reactions ?? stableOwnReactions;
@@ -107,32 +85,9 @@ export const ReactionSelector: ReactionSelectorInterface = (props) => {
   }, [reactionOptions]);
 
   return (
-    <>
-      <DialogAnchor
-        dialogManagerId={extendedDialogManager?.id}
-        id={extendedDialogId}
-        offset={8}
-        placement={
-          typeof isMyMessage === 'function' && isMyMessage() ? 'top-end' : 'top-start'
-        }
-        referenceElement={propReferenceElement ?? extendedReferenceElement}
-        trapFocus
-      >
-        <div className='str-chat__reaction-selector'>
-          <ReactionSelectorExtendedList
-            {...props}
-            dialogId={extendedDialogId}
-            handleReaction={async (reactionType, event) => {
-              await handleReaction(reactionType, event);
-              if (closeReactionSelectorOnClick) {
-                dialog.close();
-              }
-            }}
-          />
-        </div>
-      </DialogAnchor>
-      {!extendedDialogIsOpen && (
-        <div className='str-chat__reaction-selector' data-testid='reaction-selector'>
+    <div className='str-chat__reaction-selector' data-testid='reaction-selector'>
+      {!extendedListOpen ? (
+        <>
           <ul
             className='str-chat__reaction-selector-list'
             data-testid='reaction-selector-list'
@@ -166,21 +121,28 @@ export const ReactionSelector: ReactionSelectorInterface = (props) => {
             circular
             className='str-chat__reaction-selector__add-button'
             data-testid='reaction-selector-add-button'
-            onClick={(event) => {
-              if (propReferenceElement) {
-                extendedDialog.open();
-                return;
-              }
-              setExtendedReferenceElement(event.currentTarget);
+            onClick={() => {
+              setExtendedListOpen(true);
             }}
             size='sm'
             variant='secondary'
           >
             <IconPlus />
           </Button>
-        </div>
+        </>
+      ) : (
+        <ReactionSelectorExtendedList
+          {...props}
+          dialogId={dialogId}
+          handleReaction={async (reactionType, event) => {
+            await handleReaction(reactionType, event);
+            if (closeReactionSelectorOnClick) {
+              dialog.close();
+            }
+          }}
+        />
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/Reactions/ReactionSelectorWithButton.tsx
+++ b/src/components/Reactions/ReactionSelectorWithButton.tsx
@@ -45,7 +45,7 @@ export const ReactionSelectorWithButton = ({
         trapFocus
         updatePositionOnContentResize
       >
-        <ReactionSelector />
+        <ReactionSelector referenceElement={buttonRef.current} />
       </DialogAnchor>
       <QuickMessageActionsButton
         aria-expanded={dialogIsOpen}

--- a/src/components/Reactions/ReactionSelectorWithButton.tsx
+++ b/src/components/Reactions/ReactionSelectorWithButton.tsx
@@ -45,7 +45,7 @@ export const ReactionSelectorWithButton = ({
         trapFocus
         updatePositionOnContentResize
       >
-        <ReactionSelector referenceElement={buttonRef.current} />
+        <ReactionSelector />
       </DialogAnchor>
       <QuickMessageActionsButton
         aria-expanded={dialogIsOpen}

--- a/src/components/Reactions/__tests__/ReactionSelector.test.tsx
+++ b/src/components/Reactions/__tests__/ReactionSelector.test.tsx
@@ -157,7 +157,7 @@ describe('ReactionSelector', () => {
 
     expect(getByTestId('reaction-selector-extended-list')).toBeInTheDocument();
 
-    // Quick list should be hidden when extended list is open
+    // Quick list should be unmounted when extended list is open
     expect(queryByTestId('reaction-selector-list')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
### 🎯 Goal

Provide more space to message bubbles on small screens and thus make them readable.

Relevant designs:

https://www.figma.com/design/Us73erK1xFNcB5EH3hyq6Y/Chat-SDK-Design-System?node-id=16826-236477&m=dev

### What changed

1. Added react action to dropdown at the top of defaultMessageActionSet, using IconEmoji and label “Add reaction”.
2. Kept dropdown action open/close toggle behavior on repeated click.
3. Opened reaction selector from dropdown as a standalone dialog (not submenu) and anchored it via context-menu reference (no fragile DOM class query).

### 🎨 UI Changes

[HzF6.webm](https://github.com/user-attachments/assets/33d81921-8e40-4c36-9ab4-23d771e73c81)


