### PR TITLE
chore(release): enable stable releases for v14

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,10 +1,8 @@
 {
   "branches": [
-    "release-v13",
     {
       "name": "master",
-      "channel": "beta",
-      "prerelease": "beta"
+      "channel": "latest"
     }
   ],
   "plugins": [


### PR DESCRIPTION
### 🎯 Goal

Updates the semantic-release config, so releases made from the `master` branch are delivered to the `latest` (stable) release channel on NPM.
