### PR TITLE
chore(release): publish to `release-v13` channel

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,8 @@
   "branches": [
     {
       "name": "release-v13",
-      "channel": "latest"
+      "channel": "v13",
+      "range": "13.x"
     }
   ],
   "plugins": [

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,10 @@
 {
   "branches": [
     {
+      "name": "master",
+      "channel": "latest"
+    },
+    {
       "name": "release-v13",
       "channel": "v13",
       "range": "13.x"


### PR DESCRIPTION
### 🎯 Goal

Update the semantic-release configuration, so releases from the `release-v13` are distributed on the `release-v13` channel on NPM.