### PR TITLE
docs: track react v14 message action follow-up

### DIFF
--- a/ai-docs/breaking-changes.md
+++ b/ai-docs/breaking-changes.md
@@ -1,6 +1,6 @@
 # React v14 Breaking Changes
 
-Last updated: 2026-04-14
+Last updated: 2026-04-16
 
 ## Scope
 
@@ -13,8 +13,8 @@ This file tracks confirmed v13 to v14 breaking changes for `stream-chat-react`.
 ## Audit Reference
 
 - Baseline tag: `v13.14.2`
-- Current audited SDK head: `78934929a2b1b6d82f09736aada08c57c194d45e` (`78934929a`, `2026-04-14`, `chore(release): 14.0.0-beta.7 [skip ci]`)
-- Future mining starting point: diff `78934929a2b1b6d82f09736aada08c57c194d45e..HEAD` first, then compare any newly confirmed changes back to the original v13 baseline before adding them here
+- Current audited SDK head: `a41311edd9caf6f828bdaf1d8fb071c44d0ca0f1` (`a41311edd`, `2026-04-16`, `chore(release): enable stable releases for v14 (#3121)`)
+- Future mining starting point: diff `a41311edd9caf6f828bdaf1d8fb071c44d0ca0f1..HEAD` first, then compare any newly confirmed changes back to the original v13 baseline before adding them here
 
 Only confirmed items should move from this file into the migration guide.
 
@@ -590,6 +590,7 @@ Only confirmed items should move from this file into the migration guide.
   - `customMessageActions`-style customization is no longer supported through the old list/wrapper APIs
   - `MessageListProps`, `VirtualizedMessageListProps`, `MessageProps`, and `SharedMessageProps` no longer expose `customMessageActions`
   - the default action order and action set are different in v14, so integrations that merge with `defaultMessageActionSet` can render a different menu even without custom code changes
+  - current v14 `defaultMessageActionSet` now includes a built-in `download` action for downloadable attachments, so custom filters that assume the older built-in action set can drop or misplace the new entry
 - Old API:
   - `v13.14.2:src/components/MessageActions/index.ts:2` exported `MessageActionsBox`
   - `v13.14.2:src/components/MessageActions/index.ts:3` exported `CustomMessageActionsList`
@@ -602,6 +603,7 @@ Only confirmed items should move from this file into the migration guide.
   - `src/components/MessageActions/MessageActions.tsx:35` types `MessageActionsProps` as `disableBaseMessageActionSetFilter?` and `messageActionSet?`
   - `src/components/MessageActions/defaults.tsx:383` exports `defaultMessageActionSet`
   - `src/components/MessageActions/hooks/useBaseMessageActionSetFilter.ts:19` and `useSplitMessageActionSet.ts:9` provide the new customization hooks
+  - `src/components/Message/utils.tsx:54` through `:66` add `download` to the public `MESSAGE_ACTIONS` set and to `getMessageActions(true)`
   - `src/components/Message/types.ts:16` no longer includes `customMessageActions` in `MessageProps`
   - `src/components/MessageList/MessageList.tsx` and `src/components/MessageList/VirtualizedMessageList.tsx` no longer accept or route `customMessageActions`
 - Replacement:
@@ -609,12 +611,13 @@ Only confirmed items should move from this file into the migration guide.
   - stop relying on `MessageActionsBox`, `MessageActionsWrapper`, or `CustomMessageActionsList`
   - route any custom edit/delete/etc. logic through the new action-set items and the current message/composer context
   - if your UX depends on action ordering, define your own `messageActionSet` explicitly instead of relying on the SDK defaults
+  - if you filter `defaultMessageActionSet`, decide explicitly whether the built-in `download` action should stay available for downloadable attachments
 - Evidence:
   - current root export comparison removes `MessageActionsBox`, `MessageActionsWrapper`, and `CustomMessageActionsList`
   - current `MessageActions` implementation renders quick actions plus a `ContextMenu`, not the old wrapper/box pair
   - current `MessageActionsProps` no longer exposes the old prop-driven customization surface
   - current public `MessageList` / `VirtualizedMessageList` / `Message` prop types no longer expose `customMessageActions`
-  - current `defaultMessageActionSet` adds entries like `ThreadReply`, `CopyMessageText`, `Resend`, and `BlockUser`, and reorders destructive actions compared with the v13 baseline
+  - current `defaultMessageActionSet` adds entries like `ThreadReply`, `CopyMessageText`, `Resend`, `BlockUser`, and `Download`, and reorders destructive actions compared with the v13 baseline
 - Docs impact:
   - migration guide
   - `docs/data/docs/chat-sdk/react/v14/05-experimental-features/01-message-actions.md`
@@ -2222,6 +2225,14 @@ Only confirmed items should move from this file into the migration guide.
 - extended reaction-list surface (`b2848025d`): investigated; `ReactionSelectorExtendedList` was added to `ComponentContext`, `MessageReactionsDetail` gained an add-reaction step, and `reactionDetailsSort` forwarding was fixed, but these are additive/current-behavior changes rather than a distinct v13-to-v14 migration bucket. Track the missing docs separately.
 - EmojiPicker stylesheet addition (`b4ed46455`): investigated; `stream-chat-react/dist/css/emoji-picker.css` is a new additive stylesheet entrypoint, not a removed or renamed v13 API. Track it as docs-alignment work only.
 - assorted post-beta UI fixes (`443b9a8a9`, `be8ed265f`, `6605f6361`): investigated; message padding, jump-to-message scroll behavior, and broader UI glitch fixes change runtime polish but do not remove or rename a public API.
+- download attachment message action (`2f86376d4`, `d6b103248`): investigated; current source adds `download` to `MESSAGE_ACTIONS`, `getMessageActions(true)`, and the default dropdown action set, but this is additive current-v14 behavior rather than a removed or renamed v13 API. Track the missing docs separately.
+- quick message actions on small screens (`fb8e99ba1`): investigated; current source hides inline reaction and thread-reply quick actions on small screens and moves the reaction entry into the dropdown menu, but this is responsive default behavior rather than a removed or renamed public API.
+- Tooltip redesign (`d0cbaaddb`): investigated; current `Tooltip` and `PopperTooltip` add `className` merging and visual/styling cleanup, but this is additive surface area rather than a removed or renamed v13 API.
+- floating date separator sticky behavior (`397fadd70`): investigated; current message-list hooks keep the floating date synced with the first visible date section instead of hiding it whenever an in-flow separator is visible, but this is current default behavior rather than a distinct v13-to-v14 migration bucket.
+- deleted-message normalization (`20b402261`, `f95f287b4`): investigated; current source centralizes deleted-message checks under `isMessageDeleted(message)` so `deleted_at`, `type === 'deleted'`, and `deleted_for_me` render consistently, but this is docs-alignment/current-behavior work rather than a new removed-or-renamed v13 API.
+- dialog-manager outside-click isolation (`233ec8920`): investigated; current `DialogPortal` avoids cross-manager outside clicks closing the active dialog, but this is runtime hardening rather than a removed or renamed public API.
+- poll and styling polish (`d7870bb8b`, `bb05c20ee`, `3702caaa0`, `f131a6a2a`): investigated; these commits refine visuals, tokens, and pinned-message styling, but they do not remove or rename a documented public API.
+- demo/docs/release follow-ups (`3ec3671a2`, `5f9ee0def`, `4d357b837`, `a41311edd`): investigated; example-app changes, tracker updates, and release commits do not add new migration items on their own.
 
 ## Notes For Migration Guide Drafting
 

--- a/ai-docs/docs-plan.md
+++ b/ai-docs/docs-plan.md
@@ -1,6 +1,6 @@
 # React v14 Docs Plan
 
-Last updated: 2026-04-14
+Last updated: 2026-04-16
 
 ## Goal
 
@@ -8,16 +8,16 @@ Produce a reliable v13 to v14 migration guide for `stream-chat-react` and keep t
 
 ## Current Phase
 
-- Phase: post-snapshot docs maintenance against audited head `78934929a2b1b6d82f09736aada08c57c194d45e`
+- Phase: post-snapshot docs maintenance against audited head `a41311edd9caf6f828bdaf1d8fb071c44d0ca0f1`
 - Constraint: keep `breaking-changes.md` as the source of truth for confirmed migration items, but treat this file as the execution tracker for the remaining v14 docs work
 - Migration-guide and sidebar work is already in flight on `docs-content#1080`; keep the guide aligned with new SDK changes until that PR is merged
-- New SDK changes after the audited head should be mined from `78934929a2b1b6d82f09736aada08c57c194d45e..HEAD`, then folded back into both trackers before related docs edits are made
+- New SDK changes after the audited head should be mined from `a41311edd9caf6f828bdaf1d8fb071c44d0ca0f1..HEAD`, then folded back into both trackers before related docs edits are made
 
 ## Working Baseline
 
 - Code baseline for analysis: `stream-chat-react` `v13.14.2..master`
-- Current audited SDK head: `78934929a2b1b6d82f09736aada08c57c194d45e` (`78934929a`, `2026-04-14`, `chore(release): 14.0.0-beta.7 [skip ci]`)
-- Future mining starting point: review `stream-chat-react` diff `78934929a2b1b6d82f09736aada08c57c194d45e..HEAD`, then map any confirmed changes back to `v13.14.2` before updating `breaking-changes.md` and this file
+- Current audited SDK head: `a41311edd9caf6f828bdaf1d8fb071c44d0ca0f1` (`a41311edd`, `2026-04-16`, `chore(release): enable stable releases for v14 (#3121)`)
+- Future mining starting point: review `stream-chat-react` diff `a41311edd9caf6f828bdaf1d8fb071c44d0ca0f1..HEAD`, then map any confirmed changes back to `v13.14.2` before updating `breaking-changes.md` and this file
 - Docs content repo: `/docs/data/docs`
 - Docs content branch: `react-chat-v14`
 - Active migration-guide PR: `docs-content#1080` (`docs/react-v14-migration-guide` -> `react-chat-v14`)
@@ -250,13 +250,13 @@ Completed WS5 pages:
 
 ## Active Batch: Verification
 
-Objective: run docs verification and fix any markdown/build issues that surface from the updated post-`78934929` v14 content set.
+Objective: run docs verification and fix any markdown/build issues that surface from the updated post-`a41311ed` v14 content set.
 
 Post-snapshot maintenance currently in scope:
 
-- confirmed breaking changes from `dc16bb584..78934929` are now tracked in `BC-061` and `BC-062`
-- the matching public-docs follow-up is complete for this window
-- the next docs pass should start from `78934929..HEAD`, then rerun the docs verification commands after those pages are updated
+- the `78934929..a41311ed` follow-up window is now folded into the public docs
+- `BC-017` now captures the built-in `download` action addition inside the current `MessageActions` surface
+- the next maintenance pass should start from `a41311ed..HEAD`, then rerun docs verification after any new docs edits
 
 ## Confirmed Docs Issues
 
@@ -1026,6 +1026,34 @@ Post-snapshot maintenance currently in scope:
   - `data/docs/chat-sdk/react/v14/02-ui-components/09-message-composer/06-emoji-picker.md` and `03-ui-cookbook/07-emoji_picker.md` still explain setup without the dedicated stylesheet import
 - Expected fix: completed; the emoji-picker reference and cookbook pages now include the standalone stylesheet setup
 
+### 80. v14 message-actions docs do not mention the built-in download action or the current small-screen quick-action behavior
+
+- Status: resolved
+- Evidence:
+  - current `src/components/Message/utils.tsx` adds `download` to `MESSAGE_ACTIONS` and includes it in `getMessageActions(true)`
+  - current `src/components/MessageActions/MessageActions.defaults.tsx` adds a built-in dropdown `Download` action to `defaultMessageActionSet`
+  - current `src/components/MessageActions/styling/MessageActions.scss` hides inline reaction and thread-reply quick actions on screens up to `767px` and exposes the dropdown react item instead
+  - `data/docs/chat-sdk/react/v14/05-experimental-features/01-message-actions.md` and `03-ui-cookbook/04-message/04-message_actions.md` do not yet mention the built-in `download` action or the mobile quick-action collapse
+- Expected fix: completed; the message-actions reference and cookbook now document the built-in `download` action, the new `download` action type in filtered sets, and the current small-screen behavior where inline quick actions collapse into the dropdown
+
+### 81. v14 custom message UI cookbook still checks only `message.deleted_at`
+
+- Status: resolved
+- Evidence:
+  - current `src/components/Message/utils.tsx` exports `isMessageDeleted(message)` and treats `deleted_at`, `type === 'deleted'`, and `deleted_for_me` as deleted-message states
+  - current `src/components/Message/MessageUI.tsx` now uses `isMessageDeleted(message)` consistently for `MessageDeleted`, `MessageDeletedBubble`, and attachment/reaction visibility
+  - `data/docs/chat-sdk/react/v14/03-ui-cookbook/04-message/01-message_ui.md` still tells readers to check `message.deleted_at` and still branches on `message.deleted_at` in the sample code
+- Expected fix: completed; the custom message UI cookbook now uses broader deleted-message checks instead of `message.deleted_at` only
+
+### 82. v14 message-list and date-separator docs still lag the current sticky floating-date behavior
+
+- Status: resolved
+- Evidence:
+  - current `src/components/MessageList/hooks/MessageList/useFloatingDateSeparatorMessageList.ts` now keeps the floating date synced with the separator pinned at the top boundary instead of hiding it whenever an in-flow separator is visible
+  - current `src/components/MessageList/hooks/VirtualizedMessageList/useFloatingDateSeparator.ts` now follows the first visible item/date section instead of hiding the floating label whenever a visible separator exists
+  - `data/docs/chat-sdk/react/v14/02-ui-components/07-message-list/01-message_list.md`, `02-virtualized_list.md`, and `08-message/13-date_separator.md` do not yet explain the current sticky floating-date behavior
+- Expected fix: completed; the message-list, virtualized-list, and date-separator pages now describe the floating date as the current-section label that follows the first visible date group
+
 ## Docs Update Checklist
 
 - [x] Freeze the initial breaking-change inventory against audited snapshot `6ea7a78e4184fce6066f7318f9ebd57a5ff1474a`
@@ -1041,6 +1069,7 @@ Post-snapshot maintenance currently in scope:
 - [x] Fold the post-snapshot avatar overflow/internalization follow-up from `241209e8059ce767fe5bc3500466aa73f53618e3..6c7cd42afffb6d341b7a3b4bf5cc5a9bcd3f98ee` back into the public v14 docs
 - [x] Fold the post-snapshot deprecated-API purge and sidebar-state externalization from `6c7cd42afffb6d341b7a3b4bf5cc5a9bcd3f98ee..dc16bb584675f48d5f67cf5d5d355ba012cf81d2` back into the public v14 docs
 - [x] Fold the post-snapshot notifications/actions cleanup, sender-only-edit removal, reactions-detail additions, upload-progress indicators, and emoji-picker stylesheet changes from `dc16bb584675f48d5f67cf5d5d355ba012cf81d2..78934929a2b1b6d82f09736aada08c57c194d45e` back into the public v14 docs
+- [x] Fold the post-snapshot message-actions, deleted-message, floating-date, and tooltip/current-behavior follow-up window from `78934929a2b1b6d82f09736aada08c57c194d45e..a41311edd9caf6f828bdaf1d8fb071c44d0ca0f1` back into the trackers and public v14 docs
 - [x] Convert `ai-docs/docs-plan.md` from inventory mode into execution workstreams
 - [x] Draft the v13 to v14 migration guide content
 - [x] Prepare the v14 release-guide rename and sidebar update in `docs-content#1080`
@@ -1052,7 +1081,7 @@ Post-snapshot maintenance currently in scope:
 - [x] Update Channel docs for current `MessageActions`
 - [x] Update ComponentContext docs for `MessageAlsoSentInChannelIndicator`
 - [x] Sweep v14 docs for stale `MessageOptions`, `experimental/MessageActions`, renamed exports, and `Channel X={...}` examples
-- [ ] Run docs verification commands for the current post-`78934929` doc set
+- [ ] Run docs verification commands for the current post-`a41311ed` doc set
 
 ## Page Tracker
 
@@ -1060,6 +1089,12 @@ Post-snapshot maintenance currently in scope:
 | -------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | in PR    | `data/docs/chat-sdk/react/v14/06-release-guides/01-upgrade-to-v14.md`                              | v13 to v14 migration guide drafted in `docs-content#1080`; keep aligned with post-snapshot changes such as Search, MessageEditedIndicator, current Giphy/composer behavior, the `ChannelListUI` migration, the latest action-set/error/unread changes, the latest channel-list hook cleanup, the stylesheet import-path cleanup, the latest reactions/icon follow-up work, the avatar-overflow follow-up from `49d576e4`, the latest deprecated-API purge plus sidebar-state externalization, and the current notification/editability/reactions/composer follow-up window until merged |
 | in PR    | `data/docs/_sidebars/[chat-sdk][react][v14-rc].json`                                               | Nav label and migration guide metadata are updated in `docs-content#1080`; merge pending                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| resolved | `data/docs/chat-sdk/react/v14/05-experimental-features/01-message-actions.md`                      | Now documents the built-in `download` action and the current small-screen behavior where inline quick actions collapse into the dropdown                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| resolved | `data/docs/chat-sdk/react/v14/03-ui-cookbook/04-message/04-message_actions.md`                     | Cookbook examples now mention the built-in `download` action and the current small-screen quick-action behavior                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| resolved | `data/docs/chat-sdk/react/v14/03-ui-cookbook/04-message/01-message_ui.md`                          | Deleted-message examples now use broader deleted-message checks instead of `message.deleted_at` only                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| resolved | `data/docs/chat-sdk/react/v14/02-ui-components/07-message-list/01-message_list.md`                 | Now describes the current sticky floating-date behavior as a current-section label                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| resolved | `data/docs/chat-sdk/react/v14/02-ui-components/07-message-list/02-virtualized_list.md`             | Now describes the current sticky floating-date behavior as a current-section label                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| resolved | `data/docs/chat-sdk/react/v14/02-ui-components/08-message/13-date_separator.md`                    | Now explains the floating separator as the current-section label that follows the first visible date group                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | resolved | `data/docs/chat-sdk/react/v14/06-release-guides/01-upgrade-to-v14.md`                              | Now covers `onlySenderCanEdit` removal, the legacy notification-callback / `ConnectionStatus` removal, and the current emoji-picker stylesheet setup for this post-`dc16bb584` window                                                                                                                                                                                                                                                                                                                                                                                                   |
 | resolved | `data/docs/chat-sdk/react/v14/02-ui-components/03-chat/01-chat.md`                                 | Now treats sidebar state as app-owned and no longer documents removed `initialNavOpen` or `navOpen`-based SDK state                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | resolved | `data/docs/chat-sdk/react/v14/02-ui-components/03-chat/02-chat_context.md`                         | Now reflects the current `ChatContext` shape without removed nav-state fields                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |


### PR DESCRIPTION
### 🎯 Goal

Keep the internal React v14 trackers aligned with the latest `master` window and the paired public docs follow-up.

### 🛠 Implementation details

- bump the audited SDK head to `a41311edd9caf6f828bdaf1d8fb071c44d0ca0f1`
- extend `BC-017` with the additive built-in `download` action note
- record the rest of the window as ruled-out current-behavior work
- reopen and then resolve the matching docs issues for message actions, deleted-message handling, and sticky floating-date behavior
- paired docs PR: https://github.com/GetStream/docs-content/pull/1205

### 🎨 UI Changes

None.
