### PR TITLE
fix: allow flipping message actions context menu

### DIFF
--- a/src/components/MessageActions/MessageActions.tsx
+++ b/src/components/MessageActions/MessageActions.tsx
@@ -116,9 +116,7 @@ export const MessageActions: MessageActionsInterface = ({
         <>
           <quickDropdownToggleAction.Component ref={setActionsBoxButtonElement} />
 
-          {/* Stacked submenu changes height; without this, flip() can swap top↔bottom on updateKey. */}
           <ContextMenuComponent
-            allowFlip={false}
             backLabel={t('Back')}
             className={clsx('str-chat__message-actions-box', {
               'str-chat__message-actions-box--hidden':

--- a/src/components/Reactions/ReactionSelectorWithButton.tsx
+++ b/src/components/Reactions/ReactionSelectorWithButton.tsx
@@ -40,6 +40,7 @@ export const ReactionSelectorWithButton = ({
       <DialogAnchor
         dialogManagerId={dialogManager?.id}
         id={dialogId}
+        offset={8}
         placement={isMyMessage() ? 'top-end' : 'top-start'}
         referenceElement={buttonRef.current}
         trapFocus


### PR DESCRIPTION
### 🎯 Goal

Remove regression where flipping message actions context menu was disabled.

