### PR TITLE
fix: recognize async moderated shadow blocked messages as blocked

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "react-dom": "^19.0.0",
     "sass": "^1.97.2",
     "semantic-release": "^25.0.2",
-    "stream-chat": "^9.41.0",
+    "stream-chat": "^9.41.1",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.17.0",
     "vite": "^7.3.1",

--- a/src/components/Message/__tests__/utils.test.ts
+++ b/src/components/Message/__tests__/utils.test.ts
@@ -1,7 +1,12 @@
 import { generateMessage, generateReaction, generateUser } from 'mock-builders';
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { TFunction } from 'i18next';
-import type { ChannelConfigWithInfo, MessageResponse, Mute } from 'stream-chat';
+import type {
+  ChannelConfigWithInfo,
+  LocalMessage,
+  MessageResponse,
+  Mute,
+} from 'stream-chat';
 import type { StreamChat } from 'stream-chat';
 import {
   countReactions,
@@ -15,6 +20,7 @@ import {
   getMessageActions,
   getNonImageAttachments,
   getReadByTooltipText,
+  isMessageBlocked,
   isUserMuted,
   mapToUserNameOrId,
   MESSAGE_ACTIONS,
@@ -541,6 +547,33 @@ describe('Message utils', () => {
       ).toThrow(
         'getReadByTooltipText was called, but tooltipUserNameMapper function is not available',
       );
+    });
+  });
+
+  describe('isMessageBlocked function', () => {
+    it('returns true when message.shadowed is true', () => {
+      const message = fromPartial<LocalMessage>({
+        shadowed: true,
+        type: 'regular',
+      });
+      expect(isMessageBlocked(message)).toBe(true);
+    });
+
+    it('returns true for moderation remove error messages when not shadowed', () => {
+      const message = fromPartial<LocalMessage>({
+        moderation: { action: 'remove' },
+        shadowed: false,
+        type: 'error',
+      });
+      expect(isMessageBlocked(message)).toBe(true);
+    });
+
+    it('returns false when message is not shadowed and not a moderation remove error', () => {
+      const message = fromPartial<LocalMessage>({
+        shadowed: false,
+        type: 'regular',
+      });
+      expect(isMessageBlocked(message)).toBe(false);
     });
   });
 });

--- a/src/components/Message/utils.tsx
+++ b/src/components/Message/utils.tsx
@@ -399,11 +399,12 @@ export const isMessageBounced = (
     message.moderation?.action === 'bounce');
 
 export const isMessageBlocked = (
-  message: Pick<LocalMessage, 'type' | 'moderation' | 'moderation_details'>,
+  message: Pick<LocalMessage, 'type' | 'moderation' | 'moderation_details' | 'shadowed'>,
 ) =>
-  message.type === 'error' &&
-  (message.moderation_details?.action === 'MESSAGE_RESPONSE_ACTION_REMOVE' ||
-    message.moderation?.action === 'remove');
+  message.shadowed ||
+  (message.type === 'error' &&
+    (message.moderation_details?.action === 'MESSAGE_RESPONSE_ACTION_REMOVE' ||
+      message.moderation?.action === 'remove'));
 
 export const isMessageDeleted = (message: LocalMessage): boolean =>
   Boolean(message.deleted_at || message.type === 'deleted' || message.deleted_for_me);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7753,10 +7753,10 @@ stdin-discarder@^0.2.2:
   resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.2.2.tgz#390037f44c4ae1a1ae535c5fe38dc3aba8d997be"
   integrity sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==
 
-stream-chat@^9.41.0:
-  version "9.41.0"
-  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.41.0.tgz#ad88d7919aaf1d3c35b4a431a8cd464cb640f146"
-  integrity sha512-Rgp3vULGKYxHZ/aCeundly6ngdBGttTPz+YknmWhbqvNlEhPB/RM61CpQPHgPyfkSm+osJT3tEV9fKd+I/S77g==
+stream-chat@^9.41.1:
+  version "9.41.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-9.41.1.tgz#a877c8aa800d78b497eec2fad636345d4422309c"
+  integrity sha512-W8zjfINYol2UtdRMz2t/NN2GyjDrvb4pJgKmhtuRYzCY1u0Cjezcsu5OCNgyAM0QsenlY6tRqnvAU8Qam5R49Q==
   dependencies:
     "@types/jsonwebtoken" "^9.0.8"
     "@types/ws" "^8.5.14"


### PR DESCRIPTION
### 🎯 Goal
https://linear.app/stream/issue/REACT-945/handle-shadow-blocked-images-in-react-chat-sdk

`isMessageBlocked` method decides if we should display the `MessageBlocked` placeholder for a message. This method didn't categorize `shadowed` messages as blocked (probably because these messages are not displayed in message list, except when they change from `shadowed: false` to `shadowed: true`)

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

_Add relevant screenshots_
