### PR TITLE
docs: clarify AI migration composer hook usage

### DIFF
--- a/ai-docs/ai-migration.md
+++ b/ai-docs/ai-migration.md
@@ -236,6 +236,10 @@ Removed override keys (no rename; redesign the surface): `EditMessageInput`, `Ed
 
 After the `MessageInput*` → `MessageComposer*` rename (Phase 1):
 
+- Use `useMessageComposerContext()` for component-level bindings exposed by the rendered composer UI, such as `handleSubmit`, paste handling, recording state, and refs.
+- Use `useMessageComposerController()` when the integration needs the underlying `MessageComposer` controller, such as `initState()`, `clear()`, `textComposer`, `attachmentManager`, `pollComposer`, or `linkPreviewsManager`.
+- Prefer dedicated state hooks for simple reads instead of reaching into the controller directly.
+
 ### `handleSubmit` signature
 
 ```tsx


### PR DESCRIPTION
### 🎯 Goal

Clarify the AI migration guide so coding agents know when to use `useMessageComposerContext()` versus `useMessageComposerController()` during React v14 migrations.

### 🛠 Implementation details

- document `useMessageComposerContext()` as the hook for rendered composer UI bindings
- document `useMessageComposerController()` as the hook for the underlying `MessageComposer` controller and managers
- recommend dedicated state hooks for simple reads before reaching into the controller directly

### 🎨 UI Changes

None.
