### PR TITLE
fix: prevent cutting off button outlines in ContextMenu components

### DIFF
--- a/src/components/Dialog/styling/ContextMenu.scss
+++ b/src/components/Dialog/styling/ContextMenu.scss
@@ -135,10 +135,10 @@
       display: flex;
       flex-direction: column;
       gap: var(--str-chat__spacing-xxxs);
-      overflow-x: hidden;
     }
 
     .str-chat__context-menu__body.str-chat__context-menu__body--submenu-forward {
+      overflow-x: hidden;
       animation-duration: 280ms;
       animation-name: var(
         --str-chat__context-menu-submenu-forward-animation,
@@ -152,6 +152,7 @@
     }
 
     .str-chat__context-menu__body.str-chat__context-menu__body--submenu-backward {
+      overflow-x: hidden;
       animation-duration: 400ms;
       animation-name: var(
         --str-chat__context-menu-submenu-backward-animation,


### PR DESCRIPTION
### 🎯 Goal

Closes REACT-962


