### PR TITLE
fix: make search results scrollable

### DIFF
--- a/src/components/ChannelList/styling/ChannelList.scss
+++ b/src/components/ChannelList/styling/ChannelList.scss
@@ -46,15 +46,16 @@
   border-inline-end: 1px solid var(--str-chat__border-core-default);
 
   .str-chat__channel-list-inner {
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
-    padding-bottom: calc(var(--str-chat__space-8) + var(--str-chat__space-2));
 
     .str-chat__channel-list-inner__main {
       height: 100%;
       overflow-y: auto;
       scrollbar-gutter: stable both-edges;
       scrollbar-width: thin;
+      padding-bottom: calc(var(--str-chat__space-8) + var(--str-chat__space-2));
 
       .str-chat__channel-list-empty {
         height: 100%;

--- a/src/components/Location/styling/ShareLocationDialog.scss
+++ b/src/components/Location/styling/ShareLocationDialog.scss
@@ -6,10 +6,6 @@ $duration-selector-min-width: 120px;
   width: 100%;
   max-width: 520px;
 
-  .str-chat__prompt__body {
-    height: 65px;
-  }
-
   .str-chat__live-location-activation {
     display: flex;
     flex-direction: column;

--- a/src/components/Search/styling/Search.scss
+++ b/src/components/Search/styling/Search.scss
@@ -4,6 +4,11 @@
   gap: var(--str-chat__spacing-sm);
   padding-block: var(--str-chat__spacing-xs);
   justify-content: center;
+
+  &.str-chat__search--active {
+    flex: 1;
+    min-height: 0;
+  }
 }
 
 .str-chat__search-bar {
@@ -58,6 +63,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--str-chat__spacing-sm);
+  flex: 1;
+  min-height: 0;
 
   .str-chat__search-results-header {
     overflow-x: auto;
@@ -75,7 +82,26 @@
   }
 }
 
+.str-chat__search-source-results {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
 .str-chat__search-source-result-list {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+
+  .str-chat__infinite-scroll-paginator {
+    flex: 1;
+    min-height: 0;
+    scrollbar-gutter: stable both-edges;
+    scrollbar-width: thin;
+  }
+
   .str-chat__search-result-container {
     padding: var(--str-chat__spacing-xxs);
     border-bottom: 1px solid var(--str-chat__border-core-subtle);


### PR DESCRIPTION
### 🎯 Goal

Closes REACT-963

Search results container was not limited to the viewport boundaries and thus not scrollable

Also added a fix for ShareLocationDialog, where the grey area around the switch field was cut of due to the limit of the height on the parent container in the dialog.
