### PR TITLE
fix: limit reactions host width (segmented/bottom)

### DIFF
--- a/src/components/Message/styling/Message.scss
+++ b/src/components/Message/styling/Message.scss
@@ -280,6 +280,10 @@ $message-bubble-padding: var(--str-chat__spacing-xs);
       display: flex;
       grid-area: reactions;
 
+      &:has(.str-chat__message-reactions--segmented.str-chat__message-reactions--bottom) {
+        max-width: var(--str-chat__message-max-width);
+      }
+
       &:has(.str-chat__message-reactions--top) {
         margin-bottom: calc(var(--str-chat__spacing-xxs) * -1);
       }


### PR DESCRIPTION
### 🎯 Goal

Limit the width of the reactions host element to the max width of the message for message reactions of type segmented and bottom-positioned.

### 🎨 UI Changes


before/after

<img width="694" height="554" alt="Screenshot 2026-04-29 at 6 00 05 PM" src="https://github.com/user-attachments/assets/afeacc61-59f8-4dbb-8c4d-aa90d207179a" />

<img width="694" height="554" alt="Screenshot 2026-04-29 at 5 59 42 PM" src="https://github.com/user-attachments/assets/fc1e54d3-8f16-4a95-844e-42dd786acc85" />
