### PR TITLE
chore(ci): update GitHub Actions and source Node version from .nvmrc

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,19 +1,13 @@
 name: Setup
 description: Sets up Node and installs dependencies
 
-inputs:
-  node-version:
-    description: 'Specify Node version'
-    required: false
-    default: '24'
-
 runs:
   using: 'composite'
   steps:
     - name: Setup Node
       uses: actions/setup-node@v6
       with:
-        node-version: ${{ inputs.node-version }}
+        node-version-file: '.nvmrc'
 
     - name: Set NODE_VERSION env
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: yarn coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -16,10 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
       - uses: preactjs/compressed-size-action@v2
         env:
           NODE_OPTIONS: --max_old_space_size=4096
-          YARN_IGNORE_ENGINES: 'true' # skip validation for node20 requirement
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           pattern: './dist/**/*.{?(c|m)js,css,json}'


### PR DESCRIPTION
### 🎯 Goal

Keep our CI pipeline current and remove drift between the Node version we develop against and the one CI runs. Specifically:

- The `codecov/codecov-action` was on `v5`; `v6` (Mar 2026) is the first major with Node 24 support, matching the rest of our toolchain.
- Node was hardcoded as `'24'` in two places (the composite `setup-node` action and the size workflow), so a future Node bump would require touching multiple files in lockstep with `.nvmrc`. Single source of truth is safer.
- The size workflow ran under whatever Node the `preactjs/compressed-size-action` defaults to (Node 20), forcing us to set `YARN_IGNORE_ENGINES: 'true'` to bypass our `engines` requirement. That's a workaround that masks the actual problem — the job wasn't running on Node 24.

### 🛠 Implementation details

**`.github/actions/setup-node/action.yml`**
- Removed the `node-version` input (no caller was overriding it) and switched `actions/setup-node@v6` to `node-version-file: '.nvmrc'`. `.nvmrc` is now the single source of truth for the Node version across all workflows that use this composite action.

**`.github/workflows/ci.yml`**
- Bumped `codecov/codecov-action` from `v5` → `v6`.

**`.github/workflows/size.yml`**
- Added an explicit `actions/setup-node@v6` step (also using `node-version-file: '.nvmrc'`) before `preactjs/compressed-size-action@v2`, so the job's shell commands run under Node 24.
- Removed the `YARN_IGNORE_ENGINES: 'true'` env override now that the engines requirement is satisfied.

**Audit notes (no changes needed)**
- All other actions are already at the latest major: `actions/checkout@v6`, `actions/setup-node@v6`, `actions/cache@v5`, `preactjs/compressed-size-action@v2`.
- No published GitHub security advisories on any action we use.

### 🎨 UI Changes

N/A — CI/build configuration only, no runtime or visual changes.