### PR TITLE
chore(demo): add channel preview overlay

### DIFF
--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -291,11 +291,18 @@ const App = () => {
         { type: 'public' },
         // public example channels
         {
-          cid: {
-            $in: ['random', 'general', 'music', 'jokes'].map(
-              (channelId) => `messaging:${channelId}`,
-            ),
-          },
+          $and: [
+            {
+              cid: {
+                $in: ['random', 'general', 'music', 'jokes'].map(
+                  (channelId) => `messaging:${channelId}`,
+                ),
+              },
+            },
+            {
+              members: { $in: [userId] },
+            },
+          ],
         },
       ],
     }),

--- a/examples/vite/src/ChatLayout/Panels.tsx
+++ b/examples/vite/src/ChatLayout/Panels.tsx
@@ -1,11 +1,6 @@
 import clsx from 'clsx';
-import type {
-  ChannelFilters,
-  ChannelMemberResponse,
-  ChannelOptions,
-  ChannelSort,
-} from 'stream-chat';
-import { useCallback, useEffect, useRef } from 'react';
+import type { ChannelFilters, ChannelOptions, ChannelSort } from 'stream-chat';
+import { useEffect, useRef } from 'react';
 import {
   AIStateIndicator,
   Channel,
@@ -26,8 +21,6 @@ import {
   useChatContext,
   type ChatViewSelectorEntry,
   useThreadsViewContext,
-  Button,
-  useChannelMembersState,
 } from 'stream-chat-react';
 
 import { useAppSettingsSelector } from '../AppSettings/state';
@@ -108,34 +101,6 @@ const ResponsiveChannelPanels = () => {
   );
 };
 
-const HeaderStartContent = () => {
-  const { client } = useChatContext();
-  const { channel } = useChannelStateContext();
-  const members = useChannelMembersState(channel);
-  const membership = members[client.userID!] as ChannelMemberResponse | undefined;
-
-  const isMember = typeof membership?.channel_role === 'string';
-  const canJoin = channel.data?.own_capabilities?.includes('join-channel');
-
-  const handleClick = useCallback(() => {
-    if (isMember) {
-      channel.removeMembers([client.userID!]).then(() => {
-        channel.watch();
-      });
-    } else {
-      channel.addMembers([client.userID!]);
-    }
-  }, [isMember]);
-
-  if (!canJoin) return null;
-
-  return (
-    <Button onClick={handleClick} variant='secondary' appearance='outline' size='sm'>
-      {isMember ? 'Leave' : 'Join'}
-    </Button>
-  );
-};
-
 export const ChannelsPanels = ({
   filters,
   iconOnly,
@@ -197,7 +162,7 @@ export const ChannelsPanels = ({
           </WithComponents>
         </div>
         <SidebarResizeHandle layoutRef={channelsLayoutRef} />
-        <WithComponents overrides={{ TypingIndicator, HeaderStartContent }}>
+        <WithComponents overrides={{ TypingIndicator }}>
           <Channel>
             <ResponsiveChannelPanels />
           </Channel>

--- a/examples/vite/src/ChatLayout/Panels.tsx
+++ b/examples/vite/src/ChatLayout/Panels.tsx
@@ -83,22 +83,24 @@ const ResponsiveChannelPanels = () => {
       <WithDragAndDropUpload className='app-chat-view__channel-main'>
         <Window>
           <ChannelHeader Avatar={ChannelAvatar} />
-          {messageListType === 'virtualized' ? (
-            <VirtualizedMessageList returnAllReadData shouldGroupByUser />
-          ) : (
-            <MessageList returnAllReadData />
-          )}
-          <ReturnToSkipNavigation />
-          <AIStateIndicator />
-          <MessageComposer
-            additionalTextareaProps={{
-              id: CHANNEL_MESSAGE_COMPOSER_TEXTAREA_TARGET_ID,
-            }}
-            audioRecordingEnabled
-            maxRows={10}
-            asyncMessagesMultiSendEnabled
-          />
-          <PublicChannelOverlay />
+          <div className='app-chat-view__channel-body'>
+            {messageListType === 'virtualized' ? (
+              <VirtualizedMessageList returnAllReadData shouldGroupByUser />
+            ) : (
+              <MessageList returnAllReadData />
+            )}
+            <ReturnToSkipNavigation />
+            <AIStateIndicator />
+            <MessageComposer
+              additionalTextareaProps={{
+                id: CHANNEL_MESSAGE_COMPOSER_TEXTAREA_TARGET_ID,
+              }}
+              audioRecordingEnabled
+              maxRows={10}
+              asyncMessagesMultiSendEnabled
+            />
+            <PublicChannelOverlay />
+          </div>
         </Window>
       </WithDragAndDropUpload>
       <ChannelThreadPanel />

--- a/examples/vite/src/ChatLayout/Panels.tsx
+++ b/examples/vite/src/ChatLayout/Panels.tsx
@@ -34,6 +34,7 @@ import { useAppSettingsSelector } from '../AppSettings/state';
 import { DESKTOP_LAYOUT_BREAKPOINT } from './constants.ts';
 import { SidebarResizeHandle, ThreadResizeHandle } from './Resize.tsx';
 import { ReturnToSkipNavigation } from '../AccessibilityNavigation/ReturnToSkipNavigation.tsx';
+import { PublicChannelOverlay } from '../PublicChannelOverlay/PublicChannelOverlay.tsx';
 import { useSidebar } from './SidebarContext.tsx';
 import { ThreadStateSync } from './Sync.tsx';
 
@@ -97,6 +98,7 @@ const ResponsiveChannelPanels = () => {
             maxRows={10}
             asyncMessagesMultiSendEnabled
           />
+          <PublicChannelOverlay />
         </Window>
       </WithDragAndDropUpload>
       <ChannelThreadPanel />

--- a/examples/vite/src/ChatLayout/Panels.tsx
+++ b/examples/vite/src/ChatLayout/Panels.tsx
@@ -27,7 +27,11 @@ import { useAppSettingsSelector } from '../AppSettings/state';
 import { DESKTOP_LAYOUT_BREAKPOINT } from './constants.ts';
 import { SidebarResizeHandle, ThreadResizeHandle } from './Resize.tsx';
 import { ReturnToSkipNavigation } from '../AccessibilityNavigation/ReturnToSkipNavigation.tsx';
-import { PublicChannelOverlay } from '../PublicChannelOverlay/PublicChannelOverlay.tsx';
+import {
+  PublicChannelComposerBanner,
+  PublicChannelOverlay,
+  usePublicChannelState,
+} from '../PublicChannelOverlay/PublicChannelOverlay.tsx';
 import { useSidebar } from './SidebarContext.tsx';
 import { ThreadStateSync } from './Sync.tsx';
 
@@ -62,6 +66,23 @@ const ChannelThreadPanel = () => {
   );
 };
 
+const MessageComposerOrBanner = () => {
+  const { canJoin, isMember } = usePublicChannelState();
+
+  if (!isMember && !canJoin) return <PublicChannelComposerBanner />;
+
+  return (
+    <MessageComposer
+      additionalTextareaProps={{
+        id: CHANNEL_MESSAGE_COMPOSER_TEXTAREA_TARGET_ID,
+      }}
+      audioRecordingEnabled
+      maxRows={10}
+      asyncMessagesMultiSendEnabled
+    />
+  );
+};
+
 const ResponsiveChannelPanels = () => {
   const { thread } = useChannelStateContext('ResponsiveChannelPanels');
   const isThreadOpen = !!thread;
@@ -84,14 +105,7 @@ const ResponsiveChannelPanels = () => {
             )}
             <ReturnToSkipNavigation />
             <AIStateIndicator />
-            <MessageComposer
-              additionalTextareaProps={{
-                id: CHANNEL_MESSAGE_COMPOSER_TEXTAREA_TARGET_ID,
-              }}
-              audioRecordingEnabled
-              maxRows={10}
-              asyncMessagesMultiSendEnabled
-            />
+            <MessageComposerOrBanner />
             <PublicChannelOverlay />
           </div>
         </Window>

--- a/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.scss
+++ b/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.scss
@@ -1,7 +1,7 @@
 .app-public-channel-overlay {
   position: absolute;
   inset: 0;
-  z-index: 1;
+  z-index: 3;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -84,4 +84,21 @@
     height: 20px;
     width: 20px;
   }
+}
+
+.app-public-channel-composer-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 56px;
+  padding: 16px;
+  border-top: 1px solid var(--str-chat__border-color);
+}
+
+.app-public-channel-composer-banner__text {
+  margin: 0;
+  font: var(--str-chat__font-caption-default);
+  color: var(--str-chat__text-secondary);
+  text-align: center;
 }

--- a/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.scss
+++ b/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.scss
@@ -15,10 +15,36 @@
 }
 
 .app-public-channel-overlay__content {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 40px 16px;
+  padding: 40px 48px;
+  overscroll-behavior: contain;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: -120px;
+    border-radius: 50%;
+    background: radial-gradient(
+      circle,
+      rgba(255, 255, 255, 0.9) 0%,
+      rgba(255, 255, 255, 0.85) 40%,
+      rgba(255, 255, 255, 0) 70%
+    );
+    filter: blur(20px);
+    z-index: -1;
+
+    .str-chat__theme-dark & {
+      background: radial-gradient(
+        circle,
+        rgba(0, 0, 0, 0.6) 0%,
+        rgba(0, 0, 0, 0.55) 40%,
+        rgba(0, 0, 0, 0) 70%
+      );
+    }
+  }
 
   .str-chat__icon {
     width: 32px;
@@ -49,4 +75,13 @@
   font: var(--str-chat__font-caption-default);
   color: var(--str-chat__text-secondary);
   max-width: 200px;
+}
+
+.app-public-channel-overlay__join-button {
+  width: 106px;
+
+  .str-chat__loading-indicator {
+    height: 20px;
+    width: 20px;
+  }
 }

--- a/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.scss
+++ b/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.scss
@@ -1,0 +1,52 @@
+.app-public-channel-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(5px);
+  background: rgba(255, 255, 255, 0.75);
+  padding: 12px 0;
+
+  .str-chat__theme-dark & {
+    background: rgba(0, 0, 0, 0.75);
+  }
+}
+
+.app-public-channel-overlay__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 16px;
+
+  .str-chat__icon {
+    width: 32px;
+    height: 32px;
+    color: var(--str-chat__text-tertiary);
+  }
+}
+
+.app-public-channel-overlay__text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--str-chat__spacing-xxs);
+  margin-block: var(--str-chat__spacing-sm) var(--str-chat__spacing-xl);
+
+  p {
+    margin: 0;
+  }
+}
+
+.app-public-channel-overlay__title {
+  font: var(--str-chat__font-heading-xs);
+  color: var(--str-chat__text-color);
+}
+
+.app-public-channel-overlay__description {
+  font: var(--str-chat__font-caption-default);
+  color: var(--str-chat__text-secondary);
+  max-width: 200px;
+}

--- a/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.tsx
+++ b/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.tsx
@@ -12,16 +12,22 @@ import {
 
 import './PublicChannelOverlay.scss';
 
-export const PublicChannelOverlay = () => {
+export const usePublicChannelState = () => {
   const { client } = useChatContext();
   const { channel } = useChannelStateContext();
   const members = useChannelMembersState(channel);
   const membership = members[client.userID!] as ChannelMemberResponse | undefined;
-  const { addNotification } = useNotificationApi();
-  const [joining, setJoining] = useState(false);
 
   const isMember = typeof membership?.channel_role === 'string';
   const canJoin = channel.data?.own_capabilities?.includes('join-channel');
+
+  return { canJoin, channel, client, isMember };
+};
+
+export const PublicChannelOverlay = () => {
+  const { canJoin, channel, client, isMember } = usePublicChannelState();
+  const { addNotification } = useNotificationApi();
+  const [joining, setJoining] = useState(false);
 
   const handleJoin = useCallback(async () => {
     setJoining(true);
@@ -69,6 +75,20 @@ export const PublicChannelOverlay = () => {
           {joining ? <LoadingIndicator /> : 'Join Group'}
         </Button>
       </div>
+    </div>
+  );
+};
+
+export const PublicChannelComposerBanner = () => {
+  const { canJoin, isMember } = usePublicChannelState();
+
+  if (isMember || canJoin) return null;
+
+  return (
+    <div className='app-public-channel-composer-banner'>
+      <p className='app-public-channel-composer-banner__text'>
+        You can only view this conversation
+      </p>
     </div>
   );
 };

--- a/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.tsx
+++ b/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.tsx
@@ -1,11 +1,13 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import type { ChannelMemberResponse } from 'stream-chat';
 import {
   Button,
   IconMessageBubbles,
+  LoadingIndicator,
   useChannelMembersState,
   useChannelStateContext,
   useChatContext,
+  useNotificationApi,
 } from 'stream-chat-react';
 
 import './PublicChannelOverlay.scss';
@@ -15,14 +17,34 @@ export const PublicChannelOverlay = () => {
   const { channel } = useChannelStateContext();
   const members = useChannelMembersState(channel);
   const membership = members[client.userID!] as ChannelMemberResponse | undefined;
+  const { addNotification } = useNotificationApi();
+  const [joining, setJoining] = useState(false);
 
   const isMember = typeof membership?.channel_role === 'string';
+  const canJoin = channel.data?.own_capabilities?.includes('join-channel');
 
-  const handleJoin = useCallback(() => {
-    channel.addMembers([client.userID!]);
-  }, [channel, client.userID]);
+  const handleJoin = useCallback(async () => {
+    setJoining(true);
+    try {
+      await channel.addMembers([client.userID!]);
+    } catch (error) {
+      addNotification({
+        emitter: 'PublicChannelOverlay',
+        incident: {
+          domain: 'api',
+          entity: 'channel',
+          operation: 'join',
+        },
+        message: 'Failed to join the group',
+        severity: 'error',
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+    } finally {
+      setJoining(false);
+    }
+  }, [addNotification, channel, client.userID]);
 
-  if (isMember) return null;
+  if (isMember || !canJoin) return null;
 
   return (
     <div className='app-public-channel-overlay'>
@@ -39,11 +61,12 @@ export const PublicChannelOverlay = () => {
         <Button
           appearance='solid'
           className='app-public-channel-overlay__join-button'
+          disabled={joining}
           onClick={handleJoin}
           size='md'
           variant='primary'
         >
-          Join Group
+          {joining ? <LoadingIndicator /> : 'Join Group'}
         </Button>
       </div>
     </div>

--- a/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.tsx
+++ b/examples/vite/src/PublicChannelOverlay/PublicChannelOverlay.tsx
@@ -1,0 +1,51 @@
+import { useCallback } from 'react';
+import type { ChannelMemberResponse } from 'stream-chat';
+import {
+  Button,
+  IconMessageBubbles,
+  useChannelMembersState,
+  useChannelStateContext,
+  useChatContext,
+} from 'stream-chat-react';
+
+import './PublicChannelOverlay.scss';
+
+export const PublicChannelOverlay = () => {
+  const { client } = useChatContext();
+  const { channel } = useChannelStateContext();
+  const members = useChannelMembersState(channel);
+  const membership = members[client.userID!] as ChannelMemberResponse | undefined;
+
+  const isMember = typeof membership?.channel_role === 'string';
+
+  const handleJoin = useCallback(() => {
+    channel.addMembers([client.userID!]);
+  }, [channel, client.userID]);
+
+  if (isMember) return null;
+
+  return (
+    <div className='app-public-channel-overlay'>
+      <div className='app-public-channel-overlay__content'>
+        <IconMessageBubbles />
+        <div className='app-public-channel-overlay__text'>
+          <p className='app-public-channel-overlay__title'>
+            You're previewing this group
+          </p>
+          <p className='app-public-channel-overlay__description'>
+            Join to send messages and follow the conversation
+          </p>
+        </div>
+        <Button
+          appearance='solid'
+          className='app-public-channel-overlay__join-button'
+          onClick={handleJoin}
+          size='md'
+          variant='primary'
+        >
+          Join Group
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/examples/vite/src/index.scss
+++ b/examples/vite/src/index.scss
@@ -225,7 +225,12 @@ body {
   }
 
   .str-chat__tooltip {
-    z-index: 10;
+    z-index: 2;
+  }
+
+  .str-chat__notification-list,
+  .str-chat__dialog-overlay {
+    z-index: 4;
   }
 
   @media (max-width: 767px) {

--- a/examples/vite/src/index.scss
+++ b/examples/vite/src/index.scss
@@ -138,6 +138,14 @@ body {
     height: 100%;
   }
 
+  .app-chat-view__channel-body {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
   .app-chat-view__threads-main > * {
     flex: 1 1 auto;
     min-width: 0;


### PR DESCRIPTION
### 🎯 Goal

Replace the join / leave channel button in the ChannelHeader with join overlay over channels which the user is not member of. This will return back the option to expand the sidebar, when collapsed as that button was replaced with join / leave channel in the ChannelHeader.

### Observed server issues:

WS events related to acquiring channel membership are not delivered reliably - many times not delivered and thus the UI is not updated (from non-member -> to member).

### 🎨 UI Changes

<img width="1062" height="818" alt="image" src="https://github.com/user-attachments/assets/6f4ee089-357d-4b2f-b2be-7abc2bbc72ce" />

<img width="1062" height="818" alt="image" src="https://github.com/user-attachments/assets/a9a52f27-b88e-443b-9983-a4ebe8ce3c44" />

<img width="1062" height="818" alt="image" src="https://github.com/user-attachments/assets/1aabc515-f675-44bc-bf5c-9a44fcea7db9" />

If a user does not have permission to join the channel, we change the copy and hide the join button (even though it could be frustrating to receive channels, that a user cannot join):

<img width="944" height="825" alt="image" src="https://github.com/user-attachments/assets/ed8e0472-0aa5-4807-aa4d-2a6b8f1772a8" />


