### PR TITLE
fix: export AttachmentSelectorContext from the SDK

### DIFF
--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,3 +1,4 @@
+export * from './AttachmentSelectorContext';
 export * from './ChannelActionContext';
 export * from './ChannelListContext';
 export * from './ChannelStateContext';


### PR DESCRIPTION
### 🎯 Goal

Fix the omission of export of the AttachmentSelectorContext. It is documented in our docs, but not exported
