### PR TITLE
fix: prevent overriding active channel UI on ChannelList pagination error

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -192,7 +192,7 @@ const UnMemoizedChannel = (props: PropsWithChildren<ChannelProps>) => {
     );
   }
 
-  if (channelsQueryState.error && LoadingErrorIndicator) {
+  if (channelsQueryState.error && !channel && LoadingErrorIndicator) {
     return (
       <ChannelContainer>
         <LoadingErrorIndicator error={channelsQueryState.error} />
@@ -200,7 +200,7 @@ const UnMemoizedChannel = (props: PropsWithChildren<ChannelProps>) => {
     );
   }
 
-  if (channelsQueryState.error) {
+  if (channelsQueryState.error && !channel) {
     return <ChannelContainer />;
   }
 

--- a/src/components/Channel/__tests__/Channel.test.tsx
+++ b/src/components/Channel/__tests__/Channel.test.tsx
@@ -380,7 +380,7 @@ describe('Channel', () => {
     await waitFor(() => expect(asFragment()).toMatchSnapshot());
   });
 
-  it('should render empty channel container if channels query failed', async () => {
+  it('should render empty channel container if channels query failed and no channel is available', async () => {
     const childrenContent = 'Channel children';
     const { asFragment } = render(
       <ChatProvider
@@ -397,6 +397,58 @@ describe('Channel', () => {
       </ChatProvider>,
     );
     await waitFor(() => expect(asFragment()).toMatchSnapshot());
+  });
+
+  it('should render channel content if channels query failed but channel is available', async () => {
+    const childrenContent = 'Channel children';
+    await channel.watch();
+    render(
+      <ChatProvider
+        value={fromPartial<ChatContextValue>({
+          channelsQueryState: {
+            error: new Error('pagination failed'),
+            queryInProgress: null,
+            setError: vi.fn(),
+            setQueryInProgress: vi.fn(),
+          },
+          client: chatClient,
+          searchController: new SearchController(),
+        })}
+      >
+        <Channel channel={channel}>{childrenContent}</Channel>
+      </ChatProvider>,
+    );
+    await waitFor(() => expect(screen.getByText(childrenContent)).toBeInTheDocument());
+  });
+
+  it('should render channel content if channels query failed and channel is available even if LoadingErrorIndicator is provided', async () => {
+    const errMsg = 'Channels query failed';
+    const childrenContent = 'Channel children';
+    await channel.watch();
+    render(
+      <ChatProvider
+        value={fromPartial<ChatContextValue>({
+          channelsQueryState: {
+            error: new Error(errMsg),
+            queryInProgress: null,
+            setError: vi.fn(),
+            setQueryInProgress: vi.fn(),
+          },
+          client: chatClient,
+          searchController: new SearchController(),
+        })}
+      >
+        <WithComponents
+          overrides={{
+            LoadingErrorIndicator: ({ error }) => <div>{error.message}</div>,
+          }}
+        >
+          <Channel channel={channel}>{childrenContent}</Channel>
+        </WithComponents>
+      </ChatProvider>,
+    );
+    await waitFor(() => expect(screen.getByText(childrenContent)).toBeInTheDocument());
+    expect(screen.queryByText(errMsg)).not.toBeInTheDocument();
   });
 
   it('should render provided loading indicator if channels query is in progress', async () => {

--- a/src/components/Channel/__tests__/__snapshots__/Channel.test.tsx.snap
+++ b/src/components/Channel/__tests__/__snapshots__/Channel.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`Channel > should render empty channel container if channel does not hav
 </DocumentFragment>
 `;
 
-exports[`Channel > should render empty channel container if channels query failed 1`] = `
+exports[`Channel > should render empty channel container if channels query failed and no channel is available 1`] = `
 <DocumentFragment>
   <div
     class="str-chat str-chat__channel"


### PR DESCRIPTION
### 🎯 Goal

Developers, who worked on `Channel.tsx` implemented the logic of what is displayed in `Channel` component coupled to what happens in the `ChannelList` pagination (not SDK development, but app development pattern). This PR prevents overriding `Channel` UI just because during the channel pagination an error occurred. It is rather unexpected from the app user point of view to loose the all the information in the chat just because the one page of items could not be solved in the channel list sidebar.

