### PR TITLE
fix: allow content overflow in generic Button

### DIFF
--- a/src/components/Button/styling/Button.scss
+++ b/src/components/Button/styling/Button.scss
@@ -4,7 +4,6 @@
   .str-chat__button {
     @include utils.button-reset;
     position: relative; /* creates positioning context for pseudo ::after overlay */
-    overflow: hidden;
     white-space: nowrap;
     cursor: pointer;
 


### PR DESCRIPTION
### 🎯 Goal

Closes REACT-884

The `overflow: hidden` unnecessarily cuts of the content. The Button should not be taking care of handling overflow, it should be rather its children that will prevent overflow with ellipsis etc.

### 🎨 UI Changes

<img width="76" height="141" alt="image" src="https://github.com/user-attachments/assets/c2948b1f-cf7f-4218-8353-c9b7f0829489" />
