### PR TITLE
fix(Avatar): fall back to initials when imageUrl is an empty string

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -66,7 +66,7 @@ export const Avatar = ({
     return initials;
   }, [nameString, size]);
 
-  const showImage = typeof imageUrl === 'string' && !error;
+  const showImage = typeof imageUrl === 'string' && imageUrl && !error;
 
   return (
     <div

--- a/src/components/Avatar/__tests__/Avatar.test.tsx
+++ b/src/components/Avatar/__tests__/Avatar.test.tsx
@@ -57,6 +57,14 @@ describe('Avatar', () => {
     expect(queryByTestId(AVATAR_IMG_TEST_ID)).not.toBeInTheDocument();
   });
 
+  it('should render fallback when imageUrl is an empty string', () => {
+    const { getByTestId, queryByTestId } = render(
+      <Avatar imageUrl='' size='md' userName='frank N. Stein' />,
+    );
+    expect(queryByTestId(AVATAR_IMG_TEST_ID)).not.toBeInTheDocument();
+    expect(getByTestId(AVATAR_FALLBACK_TEST_ID)).toHaveTextContent('fS');
+  });
+
   it('should call onClick prop on user click', () => {
     const onClick = vi.fn();
 


### PR DESCRIPTION
### 🎯 Goal

Prevent the `Avatar` component from rendering an `<img>` element with an empty `src` when `imageUrl` is an empty string. An empty `src` makes the browser attempt to load the current document URL as an image, which both wastes a request and triggers an unintended `onError` (which would then flip the avatar into the error fallback for the wrong reason).

### 🛠 Implementation details

`showImage` previously only checked that `imageUrl` was a string. An empty string passes `typeof imageUrl === 'string'`, so the `<img>` was rendered with `src=""`. Added a truthy check so an empty string now falls through to the initials/icon fallback path. Added a regression test for the empty-string case.

### 🎨 UI Changes

No visual changes for valid image URLs. When `imageUrl=""`, the avatar now renders the username initials (or `IconUser` fallback) instead of a broken `<img>`.