### PR TITLE
fix(ContextMenu): show focus outline for auto-focused context menu items

### DIFF
--- a/src/components/Dialog/styling/ContextMenu.scss
+++ b/src/components/Dialog/styling/ContextMenu.scss
@@ -117,6 +117,10 @@
         background-color: var(--str-chat__background-utility-pressed);
       }
 
+      &:focus:not(:disabled) {
+        @include utils.focusable;
+      }
+
       &:focus-visible:not(:disabled) {
         background-color: transparent;
       }


### PR DESCRIPTION
### 🎯 Goal

The first item in context menus was not receiving focus visual indicators even though it was focused. The reason was that the styles applied only to items with `:focus-visible`. This rule is applied only if the element is focused using keyboard.
