### PR TITLE
feat(Notifications): swap snackbar notifications after minDisplayMs dwell 

### DIFF
--- a/src/components/Notifications/NotificationList.tsx
+++ b/src/components/Notifications/NotificationList.tsx
@@ -19,12 +19,21 @@ export type NotificationListVerticalAlignment = 'bottom' | 'top';
  * different notification triggers a swap (immediate or after `minDisplayMs`, see the
  * scheduling effect); returning `null` triggers the empty-slot exit.
  *
- * Default: `defaultPickNext` — applies persistent-wins, same-type-refresh and FIFO rules
- * from the design spec. Pass your own selector to opt out of any of those policies.
- * The library also exports `pickOldest` (FIFO) and `pickNewest` (LIFO) as low-level
- * building blocks you can compose.
+ * Default: `createDefaultPickNext(pickOldest)` — applies persistent-wins,
+ * same-type-refresh and FIFO queue rules from the design spec. Pass
+ * `pickNext={createDefaultPickNext(pickNewest)}` to swap FIFO for LIFO without
+ * reimplementing those rules, or your own `pickNext` to opt out entirely.
  */
 export type PickNextNotification = (
+  notifications: Notification[],
+  displayed: Notification | null,
+) => Notification | null;
+
+/**
+ * Picks the next queued notification when no higher-priority rule applies (persistent
+ * wins, same-type refresh). Used by `createDefaultPickNext`.
+ */
+export type PickFromQueue = (
   notifications: Notification[],
   displayed: Notification | null,
 ) => Notification | null;
@@ -53,8 +62,7 @@ export type NotificationListProps = {
   /**
    * Override the candidate-selection policy. The function decides which notification
    * should be displayed given the store and the currently displayed one. Defaults to
-   * `defaultPickNext`, which applies the persistent-wins / same-type-refresh / FIFO rules
-   * documented on `PickNextNotification`.
+   * `createDefaultPickNext(pickOldest)`. Pass `createDefaultPickNext(pickNewest)` for LIFO.
    */
   pickNext?: PickNextNotification;
   /** Panel target consumed by this list. */
@@ -101,8 +109,8 @@ const isPersistent = (notification: Notification) => !notification.duration;
 const haveSameType = (a: Notification | null, b: Notification | null) =>
   !!a?.type && !!b?.type && a.type === b.type;
 
-/** FIFO selector — oldest `createdAt` other than `displayed` wins. */
-export const pickOldest: PickNextNotification = (notifications, displayed) => {
+/** FIFO queue selector — oldest `createdAt` other than `displayed` wins. */
+export const pickOldest: PickFromQueue = (notifications, displayed) => {
   const excludeId = displayed?.id ?? null;
   let oldest: Notification | null = null;
   for (const notification of notifications) {
@@ -114,8 +122,8 @@ export const pickOldest: PickNextNotification = (notifications, displayed) => {
   return oldest;
 };
 
-/** LIFO selector — newest `createdAt` other than `displayed` wins. */
-export const pickNewest: PickNextNotification = (notifications, displayed) => {
+/** LIFO queue selector — newest `createdAt` other than `displayed` wins. */
+export const pickNewest: PickFromQueue = (notifications, displayed) => {
   const excludeId = displayed?.id ?? null;
   let newest: Notification | null = null;
   for (const notification of notifications) {
@@ -160,9 +168,9 @@ const pickNewestOfType = (
 };
 
 /**
- * Default `PickNextNotification` selector. Encodes the snackbar concurrency rules from
- * the design spec — the scheduling effect only decides *when* to swap, this function
- * decides *what* to swap to.
+ * Builds the default `PickNextNotification` selector with a configurable queue fallback.
+ * Encodes the snackbar concurrency rules from the design spec — the scheduling effect
+ * only decides *when* to swap, the returned function decides *what* to swap to.
  *
  * Rules, in order of precedence:
  *   1. **Persistent wins.** Persistent variants (no `duration`) jump ahead of any
@@ -173,52 +181,56 @@ const pickNewestOfType = (
  *      same `type` collapses to its latest occurrence. (The scheduling effect detects
  *      this via `haveSameType` and bypasses the dwell window so the refresh feels
  *      instant; this function just makes sure the latest same-type is returned.)
- *   4. **FIFO fallback.** Otherwise, the oldest queued notification (other than the
- *      displayed one) is shown next, so every notification is guaranteed at least
- *      `minDisplayMs` of visibility — nothing is silently dropped.
+ *   4. **Queue fallback.** Otherwise, `pickFromQueue` selects the next notification
+ *      (default: `pickOldest` / FIFO).
  *
  * Exported so callers that want to layer behavior on top of the design rules can wrap
- * this function instead of rewriting it.
+ * the result instead of rewriting it.
  */
-export const defaultPickNext: PickNextNotification = (notifications, displayed) => {
-  if (notifications.length === 0) return null;
+export const createDefaultPickNext =
+  (pickFromQueue: PickFromQueue = pickOldest): PickNextNotification =>
+  (notifications, displayed) => {
+    if (notifications.length === 0) return null;
 
-  const newestPersistent = pickNewestPersistent(notifications, null);
+    const newestPersistent = pickNewestPersistent(notifications, null);
 
-  if (!displayed) {
-    return newestPersistent ?? pickOldest(notifications, null);
-  }
-
-  const displayedInStore = notifications.some(({ id }) => id === displayed.id);
-  if (!displayedInStore) {
-    return newestPersistent ?? pickOldest(notifications, null);
-  }
-
-  if (isPersistent(displayed)) {
-    // Currently showing a persistent: only a newer persistent can replace it. Reuse the
-    // earlier lookup when it already points at a different persistent.
-    const newerPersistent =
-      newestPersistent && newestPersistent.id !== displayed.id
-        ? newestPersistent
-        : pickNewestPersistent(notifications, displayed.id);
-    if (newerPersistent && newerPersistent.createdAt > displayed.createdAt) {
-      return newerPersistent;
+    if (!displayed) {
+      return newestPersistent ?? pickFromQueue(notifications, null);
     }
-    return displayed;
-  }
 
-  // Currently showing a transient.
-  // 1. Same-type "refresh of current" wins immediately — a repeated trigger of the
-  //    displayed snackbar collapses to the latest occurrence of that type.
-  const sameTypeNewest = pickNewestOfType(notifications, displayed.type, displayed.id);
-  if (sameTypeNewest) return sameTypeNewest;
+    const displayedInStore = notifications.some(({ id }) => id === displayed.id);
+    if (!displayedInStore) {
+      return newestPersistent ?? pickFromQueue(notifications, null);
+    }
 
-  // 2. Any queued persistent jumps ahead of the queue.
-  if (newestPersistent) return newestPersistent;
+    if (isPersistent(displayed)) {
+      // Currently showing a persistent: only a newer persistent can replace it. Reuse the
+      // earlier lookup when it already points at a different persistent.
+      const newerPersistent =
+        newestPersistent && newestPersistent.id !== displayed.id
+          ? newestPersistent
+          : pickNewestPersistent(notifications, displayed.id);
+      if (newerPersistent && newerPersistent.createdAt > displayed.createdAt) {
+        return newerPersistent;
+      }
+      return displayed;
+    }
 
-  // 3. FIFO fallback.
-  return pickOldest(notifications, displayed) ?? displayed;
-};
+    // Currently showing a transient.
+    // 1. Same-type "refresh of current" wins immediately — a repeated trigger of the
+    //    displayed snackbar collapses to the latest occurrence of that type.
+    const sameTypeNewest = pickNewestOfType(notifications, displayed.type, displayed.id);
+    if (sameTypeNewest) return sameTypeNewest;
+
+    // 2. Any queued persistent jumps ahead of the queue.
+    if (newestPersistent) return newestPersistent;
+
+    // 3. Queue fallback.
+    return pickFromQueue(notifications, displayed) ?? displayed;
+  };
+
+/** Default selector — design-spec rules with FIFO queue fallback (`pickOldest`). */
+const defaultPickNext = createDefaultPickNext(pickOldest);
 
 export const NotificationList = ({
   className,
@@ -316,7 +328,7 @@ export const NotificationList = ({
   }, [displayedNotification, notifications, pickNext]);
 
   // Main scheduling effect — owns *when* swaps happen. The *what* is delegated entirely
-  // to `pickNext` (default: `defaultPickNext`).
+  // to `pickNext` (default: `createDefaultPickNext(pickOldest)`).
   //
   // Runs on every change to `displayedNotification`, `notifications`, `pickNext`, or
   // `transitionState`, and decides one of four outcomes:

--- a/src/components/Notifications/NotificationList.tsx
+++ b/src/components/Notifications/NotificationList.tsx
@@ -12,6 +12,22 @@ import type { NotificationTargetPanel } from './notificationTarget';
 export type NotificationListFilter = (notification: Notification) => boolean;
 export type NotificationListEnterFrom = 'bottom' | 'left' | 'right' | 'top';
 export type NotificationListVerticalAlignment = 'bottom' | 'top';
+/**
+ * Selects the candidate notification to display. Receives the current store contents and
+ * the currently displayed notification (or `null` when nothing is mounted). Returning
+ * `displayed` (or any notification with the same id) means "no swap"; returning a
+ * different notification triggers a swap (immediate or after `minDisplayMs`, see the
+ * scheduling effect); returning `null` triggers the empty-slot exit.
+ *
+ * Default: `defaultPickNext` — applies persistent-wins, same-type-refresh and FIFO rules
+ * from the design spec. Pass your own selector to opt out of any of those policies.
+ * The library also exports `pickOldest` (FIFO) and `pickNewest` (LIFO) as low-level
+ * building blocks you can compose.
+ */
+export type PickNextNotification = (
+  notifications: Notification[],
+  displayed: Notification | null,
+) => Notification | null;
 
 export type NotificationListProps = {
   /** Optional class name for the list container */
@@ -26,6 +42,21 @@ export type NotificationListProps = {
    * Use to declare which notifications this list consumes (e.g. by origin.emitter, origin.context.channelId, or metadata).
    */
   filter?: NotificationListFilter;
+  /**
+   * Minimum time in milliseconds the active notification stays visible before a queued one
+   * can replace it. Replacements scheduled while the dwell window is open wait until it has
+   * elapsed; arrivals after that window replace the active notification immediately.
+   * Same-type repeated triggers and external dismissals bypass this dwell.
+   * Defaults to 1000ms.
+   */
+  minDisplayMs?: number;
+  /**
+   * Override the candidate-selection policy. The function decides which notification
+   * should be displayed given the store and the currently displayed one. Defaults to
+   * `defaultPickNext`, which applies the persistent-wins / same-type-refresh / FIFO rules
+   * documented on `PickNextNotification`.
+   */
+  pickNext?: PickNextNotification;
   /** Panel target consumed by this list. */
   panel?: NotificationTargetPanel;
   /** Fallback panel when emitted notifications do not include origin.context.panel. */
@@ -45,6 +76,7 @@ const ENTER_TRANSLATION: Record<NotificationListEnterFrom, { x: string; y: strin
 };
 
 const EXIT_ANIMATION_MS = 340;
+const DEFAULT_MIN_DISPLAY_MS = 1000;
 
 const isEnterFrom = (value: unknown): value is NotificationListEnterFrom =>
   value === 'bottom' || value === 'left' || value === 'right' || value === 'top';
@@ -64,20 +96,156 @@ const getNotificationEnterFrom = (
   return fallbackEnterFrom;
 };
 
+const isPersistent = (notification: Notification) => !notification.duration;
+
+const haveSameType = (a: Notification | null, b: Notification | null) =>
+  !!a?.type && !!b?.type && a.type === b.type;
+
+/** FIFO selector — oldest `createdAt` other than `displayed` wins. */
+export const pickOldest: PickNextNotification = (notifications, displayed) => {
+  const excludeId = displayed?.id ?? null;
+  let oldest: Notification | null = null;
+  for (const notification of notifications) {
+    if (notification.id === excludeId) continue;
+    if (!oldest || notification.createdAt < oldest.createdAt) {
+      oldest = notification;
+    }
+  }
+  return oldest;
+};
+
+/** LIFO selector — newest `createdAt` other than `displayed` wins. */
+export const pickNewest: PickNextNotification = (notifications, displayed) => {
+  const excludeId = displayed?.id ?? null;
+  let newest: Notification | null = null;
+  for (const notification of notifications) {
+    if (notification.id === excludeId) continue;
+    if (!newest || notification.createdAt > newest.createdAt) {
+      newest = notification;
+    }
+  }
+  return newest;
+};
+
+const pickNewestPersistent = (
+  notifications: Notification[],
+  excludeId: string | null,
+): Notification | null => {
+  let newest: Notification | null = null;
+  for (const notification of notifications) {
+    if (notification.id === excludeId) continue;
+    if (!isPersistent(notification)) continue;
+    if (!newest || notification.createdAt > newest.createdAt) {
+      newest = notification;
+    }
+  }
+  return newest;
+};
+
+const pickNewestOfType = (
+  notifications: Notification[],
+  type: string | undefined | null,
+  excludeId: string | null,
+): Notification | null => {
+  if (!type) return null;
+  let newest: Notification | null = null;
+  for (const notification of notifications) {
+    if (notification.id === excludeId) continue;
+    if (notification.type !== type) continue;
+    if (!newest || notification.createdAt > newest.createdAt) {
+      newest = notification;
+    }
+  }
+  return newest;
+};
+
+/**
+ * Default `PickNextNotification` selector. Encodes the snackbar concurrency rules from
+ * the design spec — the scheduling effect only decides *when* to swap, this function
+ * decides *what* to swap to.
+ *
+ * Rules, in order of precedence:
+ *   1. **Persistent wins.** Persistent variants (no `duration`) jump ahead of any
+ *      queued transient because they carry an action the user must acknowledge.
+ *   2. **Persistent ↛ replaced by transient.** While a persistent is displayed it stays
+ *      put until dismissed externally or a *newer* persistent arrives.
+ *   3. **Same-type refresh.** While a transient is displayed, a repeated trigger of the
+ *      same `type` collapses to its latest occurrence. (The scheduling effect detects
+ *      this via `haveSameType` and bypasses the dwell window so the refresh feels
+ *      instant; this function just makes sure the latest same-type is returned.)
+ *   4. **FIFO fallback.** Otherwise, the oldest queued notification (other than the
+ *      displayed one) is shown next, so every notification is guaranteed at least
+ *      `minDisplayMs` of visibility — nothing is silently dropped.
+ *
+ * Exported so callers that want to layer behavior on top of the design rules can wrap
+ * this function instead of rewriting it.
+ */
+export const defaultPickNext: PickNextNotification = (notifications, displayed) => {
+  if (notifications.length === 0) return null;
+
+  const newestPersistent = pickNewestPersistent(notifications, null);
+
+  if (!displayed) {
+    return newestPersistent ?? pickOldest(notifications, null);
+  }
+
+  const displayedInStore = notifications.some(({ id }) => id === displayed.id);
+  if (!displayedInStore) {
+    return newestPersistent ?? pickOldest(notifications, null);
+  }
+
+  if (isPersistent(displayed)) {
+    // Currently showing a persistent: only a newer persistent can replace it. Reuse the
+    // earlier lookup when it already points at a different persistent.
+    const newerPersistent =
+      newestPersistent && newestPersistent.id !== displayed.id
+        ? newestPersistent
+        : pickNewestPersistent(notifications, displayed.id);
+    if (newerPersistent && newerPersistent.createdAt > displayed.createdAt) {
+      return newerPersistent;
+    }
+    return displayed;
+  }
+
+  // Currently showing a transient.
+  // 1. Same-type "refresh of current" wins immediately — a repeated trigger of the
+  //    displayed snackbar collapses to the latest occurrence of that type.
+  const sameTypeNewest = pickNewestOfType(notifications, displayed.type, displayed.id);
+  if (sameTypeNewest) return sameTypeNewest;
+
+  // 2. Any queued persistent jumps ahead of the queue.
+  if (newestPersistent) return newestPersistent;
+
+  // 3. FIFO fallback.
+  return pickOldest(notifications, displayed) ?? displayed;
+};
+
 export const NotificationList = ({
   className,
   enterFrom = 'bottom',
   fallbackPanel,
   filter,
+  minDisplayMs = DEFAULT_MIN_DISPLAY_MS,
   panel,
+  pickNext = defaultPickNext,
   verticalAlignment = 'bottom',
 }: NotificationListProps) => {
   const { Notification: NotificationComponent = DefaultNotification } =
     useComponentContext();
   const { t } = useTranslationContext();
   const { removeNotification, startNotificationTimeout } = useNotificationApi();
+  // Holds the timer that runs the exit animation. Set when we flip `transitionState` to
+  // `'exit'`; when it fires, the previously displayed notification is removed and either the
+  // next candidate is mounted (entering) or the list collapses to empty. Only one exit
+  // animation can be in flight at a time.
   const exitTimeoutRef = useRef<number | null>(null);
-  const latestNotificationRef = useRef<Notification | null>(null);
+  // Holds the dwell timer that defers a swap until `minDisplayMs` has elapsed since the
+  // active notification became visible. It only exists while we're waiting out the dwell
+  // window; same-type triggers, external dismissals and arrivals after the dwell window
+  // bypass it and trigger the exit animation directly.
+  const replacementTimeoutRef = useRef<number | null>(null);
+  const candidateRef = useRef<Notification | null>(null);
+  const displayedAtRef = useRef<number | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const observedElementRef = useRef<HTMLDivElement | null>(null);
   const startedTimeoutIdsRef = useRef<Set<string> | null>(null);
@@ -102,7 +270,6 @@ export const NotificationList = ({
     filter: combinedFilter,
     panel,
   });
-  const nextNotification = notifications[0] ?? null;
 
   const dismiss = useCallback(
     (id: string) => {
@@ -112,6 +279,7 @@ export const NotificationList = ({
     [removeNotification],
   );
 
+  // Drop any stale entries from the started-timeouts set whenever the store changes.
   useEffect(() => {
     const notificationIds = new Set(notifications.map(({ id }) => id));
 
@@ -122,38 +290,178 @@ export const NotificationList = ({
     });
   }, [notifications]);
 
-  useEffect(() => {
-    latestNotificationRef.current = nextNotification;
-  }, [nextNotification]);
+  const clearReplacementTimeout = useCallback(() => {
+    if (replacementTimeoutRef.current !== null) {
+      window.clearTimeout(replacementTimeoutRef.current);
+      replacementTimeoutRef.current = null;
+    }
+  }, []);
 
+  // Cleanup pending timers on unmount.
   useEffect(
     () => () => {
-      if (exitTimeoutRef.current) {
+      clearReplacementTimeout();
+      if (exitTimeoutRef.current !== null) {
         window.clearTimeout(exitTimeoutRef.current);
+        exitTimeoutRef.current = null;
       }
     },
-    [],
+    [clearReplacementTimeout],
   );
 
+  // Keep the freshest candidate around so swap completion can read the latest value, even
+  // when a new notification arrives mid-exit-animation.
   useEffect(() => {
-    if (!displayedNotification) {
-      if (!nextNotification) return;
+    candidateRef.current = pickNext(notifications, displayedNotification);
+  }, [displayedNotification, notifications, pickNext]);
 
-      setDisplayedNotification(nextNotification);
-      setTransitionState('enter');
+  // Main scheduling effect — owns *when* swaps happen. The *what* is delegated entirely
+  // to `pickNext` (default: `defaultPickNext`).
+  //
+  // Runs on every change to `displayedNotification`, `notifications`, `pickNext`, or
+  // `transitionState`, and decides one of four outcomes:
+  //   1. Do nothing (the right notification is already on screen, or an exit animation
+  //      is mid-flight and will re-trigger this effect when it finishes).
+  //   2. Mount the first notification (no `displayedNotification` yet).
+  //   3. Unmount the current one (`pickNext` returned `null`, the store became empty).
+  //   4. Swap the displayed one for the new candidate — either immediately or after the
+  //      `minDisplayMs` dwell window has elapsed.
+  //
+  // Timing rules applied here (independent of selection policy):
+  //   - **Dwell window.** When `pickNext` returns a different candidate, hold the active
+  //     notification on screen until at least `minDisplayMs` has passed since it became
+  //     visible. Replacements that arrive after that window swap immediately.
+  //   - **Same-type bypass.** If the candidate has the same `type` as the displayed
+  //     notification, swap immediately (no dwell) — this is the "repeated trigger
+  //     refreshes the snackbar and resets the auto-dismiss timer" behavior. The timer
+  //     reset is achieved by removing the previously displayed notification on swap
+  //     (which clears its `NotificationManager` timer) so the new one starts its own
+  //     when it next intersects the slot.
+  //   - **External-dismiss bypass.** If the displayed notification is no longer in the
+  //     store (user clicked the close button, `NotificationManager` auto-removed it,
+  //     etc.), swap immediately — we should not stall an empty slot for the dwell.
+  useEffect(() => {
+    // An exit animation is already in flight. Once its timer fires it sets new state
+    // (either the next notification or `null`), which will re-run this effect from a
+    // clean baseline.
+    if (transitionState === 'exit') return;
+
+    // No notification is mounted yet — pick whatever the candidate logic prefers and
+    // mount it directly with an enter animation. No swap required.
+    if (!displayedNotification) {
+      const candidate = pickNext(notifications, null);
+      if (candidate) {
+        displayedAtRef.current = Date.now();
+        setDisplayedNotification(candidate);
+        setTransitionState('enter');
+      }
       return;
     }
 
-    if (displayedNotification.id === nextNotification?.id) return;
-    if (transitionState === 'exit') return;
+    const candidate = pickNext(notifications, displayedNotification);
 
-    setTransitionState('exit');
-    exitTimeoutRef.current = window.setTimeout(() => {
-      setDisplayedNotification(latestNotificationRef.current);
-      setTransitionState('enter');
-      exitTimeoutRef.current = null;
-    }, EXIT_ANIMATION_MS);
-  }, [displayedNotification, nextNotification, transitionState]);
+    // The store has been drained while a notification was visible. Play the exit
+    // animation, then unmount.
+    if (!candidate) {
+      clearReplacementTimeout();
+      setTransitionState('exit');
+      exitTimeoutRef.current = window.setTimeout(() => {
+        exitTimeoutRef.current = null;
+        displayedAtRef.current = null;
+        setDisplayedNotification(null);
+        setTransitionState('enter');
+      }, EXIT_ANIMATION_MS);
+      return;
+    }
+
+    // The candidate is the displayed notification itself — nothing to do. Cancel any
+    // dwell timer that may have been queued by an earlier run that has since become
+    // moot (e.g. the incoming notification was removed before its dwell expired).
+    if (candidate.id === displayedNotification.id) {
+      clearReplacementTimeout();
+      return;
+    }
+
+    const displayedInStore = notifications.some(
+      ({ id }) => id === displayedNotification.id,
+    );
+
+    // Swap routine shared by the immediate and dwell-deferred branches below. Captures
+    // `previousId` / `wasInStore` from the effect's closure so the exit timer can run
+    // the right cleanup even if state has moved on by the time it fires.
+    const startSwap = () => {
+      replacementTimeoutRef.current = null;
+      setTransitionState('exit');
+      const previousId = displayedNotification.id;
+      const wasInStore = displayedInStore;
+      exitTimeoutRef.current = window.setTimeout(() => {
+        exitTimeoutRef.current = null;
+        if (wasInStore) {
+          // Remove the previously displayed notification from the store so it does not
+          // re-appear, and so its NotificationManager auto-dismiss timer is cleared.
+          startedTimeoutIdsRef.current?.delete(previousId);
+          removeNotification(previousId);
+        }
+        // Read the latest candidate at the moment the exit animation actually completes —
+        // it may differ from the one decided when `startSwap` was queued because new
+        // notifications could have arrived during the 340ms exit window.
+        const next = candidateRef.current;
+        if (next && next.id !== previousId) {
+          displayedAtRef.current = Date.now();
+          setDisplayedNotification(next);
+          setTransitionState('enter');
+        } else {
+          displayedAtRef.current = null;
+          setDisplayedNotification(null);
+          setTransitionState('enter');
+        }
+      }, EXIT_ANIMATION_MS);
+    };
+
+    // External dismissal or auto-dismiss removed the displayed notification: swap right
+    // away (no dwell wait — the slot would otherwise stall empty for `minDisplayMs`).
+    if (!displayedInStore) {
+      clearReplacementTimeout();
+      startSwap();
+      return;
+    }
+
+    // Repeated triggers of the same snackbar replace the active one and reset the
+    // auto-dismiss timer immediately — feedback for the same condition should feel like
+    // a single, persistent thing being refreshed.
+    if (haveSameType(displayedNotification, candidate)) {
+      clearReplacementTimeout();
+      startSwap();
+      return;
+    }
+
+    // Default branch: enforce the dwell window. `displayedAtRef` is stamped synchronously
+    // every time we set `displayedNotification` (initial mount and swap completion), so it
+    // is in sync with what is on screen by the time this effect runs.
+    const elapsed = displayedAtRef.current ? Date.now() - displayedAtRef.current : 0;
+    const remaining = Math.max(0, minDisplayMs - elapsed);
+
+    if (remaining === 0) {
+      // Dwell already elapsed; swap right now.
+      clearReplacementTimeout();
+      startSwap();
+    } else if (replacementTimeoutRef.current === null) {
+      // A swap is pending but the dwell hasn't elapsed yet. Schedule the swap once —
+      // subsequent re-runs of this effect (e.g. as even newer notifications arrive)
+      // intentionally do NOT reschedule. `candidateRef` keeps tracking the freshest
+      // candidate, so when the timer fires `startSwap` → exit completes → the latest
+      // candidate is picked up automatically.
+      replacementTimeoutRef.current = window.setTimeout(startSwap, remaining);
+    }
+  }, [
+    clearReplacementTimeout,
+    displayedNotification,
+    minDisplayMs,
+    notifications,
+    pickNext,
+    removeNotification,
+    transitionState,
+  ]);
 
   const notification = displayedNotification;
   const notificationEnterFrom = getNotificationEnterFrom(notification, enterFrom);

--- a/src/components/Notifications/__tests__/NotificationList.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationList.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
-import { NotificationList } from '../NotificationList';
+import { NotificationList, pickNewest } from '../NotificationList';
 import { useNotificationApi } from '../hooks/useNotificationApi';
 import { useNotifications } from '../hooks/useNotifications';
 import { ComponentProvider } from '../../../context/ComponentContext';
@@ -55,23 +55,8 @@ const mockedUseNotifications = vi.mocked(useNotifications);
 const remove = vi.fn();
 const startTimeout = vi.fn();
 
-const notifications = [
-  {
-    createdAt: 1,
-    duration: 1000,
-    id: 'n-1',
-    message: 'First',
-    origin: { emitter: 'test' },
-    severity: 'info',
-  },
-  {
-    createdAt: 2,
-    id: 'n-2',
-    message: 'Second',
-    origin: { emitter: 'test' },
-    severity: 'info',
-  },
-] as Notification[];
+const EXIT_ANIMATION_MS = 340;
+const DEFAULT_MIN_DISPLAY_MS = 1000;
 
 type MockObserverEntry = {
   callback: IntersectionObserverCallback;
@@ -105,13 +90,32 @@ class IntersectionObserverMock {
   unobserve = vi.fn();
 }
 
+const triggerLatestIntersection = () => {
+  const last = observerEntries[observerEntries.length - 1];
+  last?.callback(
+    [{ isIntersecting: true } as IntersectionObserverEntry],
+    {} as IntersectionObserver,
+  );
+};
+
+const transientFixture = (overrides: Partial<Notification> = {}): Notification =>
+  ({
+    createdAt: 1,
+    duration: 3000,
+    id: 'n-1',
+    message: 'First',
+    origin: { emitter: 'test' },
+    severity: 'info',
+    ...overrides,
+  }) as Notification;
+
 describe('NotificationList', () => {
   let currentNotifications: Notification[];
 
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     observerEntries.splice(0, observerEntries.length);
-    currentNotifications = [...notifications];
+    currentNotifications = [];
     mockedUseNotificationApi.mockReturnValue({
       addNotification: vi.fn(),
       addSystemNotification: vi.fn(),
@@ -136,7 +140,9 @@ describe('NotificationList', () => {
     delete window['IntersectionObserver'];
   });
 
-  it('starts a timeout only when a notification first intersects the scroll container', () => {
+  it('starts a timeout only when the displayed notification first intersects', () => {
+    currentNotifications = [transientFixture()];
+
     render(<NotificationList />);
 
     expect(startTimeout).not.toHaveBeenCalled();
@@ -144,18 +150,12 @@ describe('NotificationList', () => {
     expect(screen.getByTestId('notification-list')).toHaveClass(
       'str-chat__notification-list--position-bottom',
     );
-
-    const listElement = screen.getByTestId('notification-list');
-    expect(observerEntries[0].options?.root).toBe(listElement);
-
-    observerEntries[0].callback(
-      [{ isIntersecting: true } as IntersectionObserverEntry],
-      {} as IntersectionObserver,
+    expect(observerEntries[0].options?.root).toBe(
+      screen.getByTestId('notification-list'),
     );
-    observerEntries[0].callback(
-      [{ isIntersecting: true } as IntersectionObserverEntry],
-      {} as IntersectionObserver,
-    );
+
+    triggerLatestIntersection();
+    triggerLatestIntersection();
 
     expect(startTimeout).toHaveBeenCalledTimes(1);
     expect(startTimeout).toHaveBeenCalledWith('n-1');
@@ -163,6 +163,7 @@ describe('NotificationList', () => {
 
   it('starts timeouts immediately when IntersectionObserver is not available', () => {
     delete window['IntersectionObserver'];
+    currentNotifications = [transientFixture()];
 
     render(<NotificationList />);
 
@@ -170,17 +171,94 @@ describe('NotificationList', () => {
     expect(startTimeout).toHaveBeenNthCalledWith(1, 'n-1');
   });
 
-  it('clears timeout and removes notification on dismiss', () => {
-    const { rerender } = render(<NotificationList />);
+  it('shows the oldest queued notification first (FIFO) when multiple are already queued at mount', () => {
+    currentNotifications = [
+      transientFixture({ createdAt: 1, id: 'n-1', message: 'Old' }),
+      transientFixture({ createdAt: 2, id: 'n-2', message: 'New' }),
+    ];
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Dismiss' })[0]);
+    render(<NotificationList />);
 
     expect(screen.getByTestId('notification-n-1')).toBeInTheDocument();
     expect(screen.queryByTestId('notification-n-2')).not.toBeInTheDocument();
+  });
+
+  it('uses a custom pickNext to override the default FIFO order', () => {
+    currentNotifications = [
+      transientFixture({ createdAt: 1, id: 'n-1', message: 'First' }),
+      transientFixture({ createdAt: 2, id: 'n-2', message: 'Second' }),
+      transientFixture({ createdAt: 3, id: 'n-3', message: 'Third' }),
+    ];
+
+    const { rerender } = render(
+      <NotificationList minDisplayMs={500} pickNext={pickNewest} />,
+    );
+
+    // With LIFO ordering the newest queued notification is shown first.
+    expect(screen.getByTestId('notification-n-3')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    rerender(<NotificationList minDisplayMs={500} pickNext={pickNewest} />);
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+    rerender(<NotificationList minDisplayMs={500} pickNext={pickNewest} />);
+
+    // After dwell + exit, the next-newest replaces it.
+    expect(remove).toHaveBeenCalledWith('n-3');
+    expect(screen.getByTestId('notification-n-2')).toBeInTheDocument();
+  });
+
+  it('cycles through queued notifications in FIFO order after each dwell window', () => {
+    currentNotifications = [
+      transientFixture({ createdAt: 1, id: 'n-1', message: 'First' }),
+      transientFixture({ createdAt: 2, id: 'n-2', message: 'Second' }),
+      transientFixture({ createdAt: 3, id: 'n-3', message: 'Third' }),
+    ];
+
+    const { rerender } = render(<NotificationList minDisplayMs={500} />);
+    expect(screen.getByTestId('notification-n-1')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    rerender(<NotificationList minDisplayMs={500} />);
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+    rerender(<NotificationList minDisplayMs={500} />);
+    expect(remove).toHaveBeenCalledWith('n-1');
+    expect(screen.getByTestId('notification-n-2')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    rerender(<NotificationList minDisplayMs={500} />);
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+    rerender(<NotificationList minDisplayMs={500} />);
+    expect(remove).toHaveBeenCalledWith('n-2');
+    expect(screen.getByTestId('notification-n-3')).toBeInTheDocument();
+  });
+
+  it('removes the displayed notification and shows the next one on dismiss', () => {
+    currentNotifications = [
+      transientFixture({ createdAt: 1, id: 'n-1', message: 'First' }),
+      transientFixture({ createdAt: 2, id: 'n-2', message: 'Second' }),
+    ];
+
+    const { rerender } = render(<NotificationList />);
+
+    expect(screen.getByTestId('notification-n-1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Dismiss' })[0]);
 
     rerender(<NotificationList />);
     act(() => {
-      vi.advanceTimersByTime(340);
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
     });
     rerender(<NotificationList />);
 
@@ -188,7 +266,243 @@ describe('NotificationList', () => {
     expect(screen.getByTestId('notification-n-2')).toBeInTheDocument();
   });
 
+  it('keeps the active snackbar for at least minDisplayMs before a queued one replaces it', () => {
+    currentNotifications = [transientFixture({ createdAt: 1, id: 'n-1' })];
+
+    const { rerender } = render(<NotificationList minDisplayMs={500} />);
+    expect(screen.getByTestId('notification-n-1')).toBeInTheDocument();
+
+    // Queue a second transient shortly after.
+    act(() => {
+      vi.advanceTimersByTime(100);
+      currentNotifications = [
+        ...currentNotifications,
+        transientFixture({ createdAt: 200, id: 'n-2', message: 'Second' }),
+      ];
+    });
+    rerender(<NotificationList minDisplayMs={500} />);
+
+    // Mid-dwell: still showing the first one.
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    rerender(<NotificationList minDisplayMs={500} />);
+    expect(screen.getByTestId('notification-n-1')).toBeInTheDocument();
+
+    // After the dwell window the replacement begins exiting then entering.
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    rerender(<NotificationList minDisplayMs={500} />);
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+    rerender(<NotificationList minDisplayMs={500} />);
+
+    expect(remove).toHaveBeenCalledWith('n-1');
+    expect(screen.getByTestId('notification-n-2')).toBeInTheDocument();
+  });
+
+  it('replaces immediately when the new arrival lands after the dwell window', () => {
+    currentNotifications = [transientFixture({ createdAt: 1, id: 'n-1' })];
+
+    const { rerender } = render(<NotificationList minDisplayMs={500} />);
+
+    act(() => {
+      vi.advanceTimersByTime(600);
+      currentNotifications = [
+        ...currentNotifications,
+        transientFixture({ createdAt: 700, id: 'n-2', message: 'Second' }),
+      ];
+    });
+    rerender(<NotificationList minDisplayMs={500} />);
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+    rerender(<NotificationList minDisplayMs={500} />);
+
+    expect(remove).toHaveBeenCalledWith('n-1');
+    expect(screen.getByTestId('notification-n-2')).toBeInTheDocument();
+  });
+
+  it('immediately replaces the active snackbar when a same-type trigger repeats', () => {
+    currentNotifications = [
+      transientFixture({ createdAt: 1, id: 'n-1', type: 'poll:create:failed' }),
+    ];
+
+    const { rerender } = render(<NotificationList minDisplayMs={5000} />);
+    expect(screen.getByTestId('notification-n-1')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+      currentNotifications = [
+        ...currentNotifications,
+        transientFixture({
+          createdAt: 60,
+          id: 'n-2',
+          message: 'Retry',
+          type: 'poll:create:failed',
+        }),
+      ];
+    });
+    rerender(<NotificationList minDisplayMs={5000} />);
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+    rerender(<NotificationList minDisplayMs={5000} />);
+
+    expect(remove).toHaveBeenCalledWith('n-1');
+    expect(screen.getByTestId('notification-n-2')).toBeInTheDocument();
+  });
+
+  it('does not replace a persistent notification with a transient one', () => {
+    currentNotifications = [
+      transientFixture({
+        createdAt: 1,
+        duration: undefined,
+        id: 'n-persistent',
+        message: 'Persistent error',
+      }),
+    ];
+
+    const { rerender } = render(<NotificationList minDisplayMs={100} />);
+    expect(screen.getByTestId('notification-n-persistent')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+      currentNotifications = [
+        ...currentNotifications,
+        transientFixture({ createdAt: 200, id: 'n-transient', message: 'Saved' }),
+      ];
+    });
+    rerender(<NotificationList minDisplayMs={100} />);
+
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_MIN_DISPLAY_MS + EXIT_ANIMATION_MS);
+    });
+    rerender(<NotificationList minDisplayMs={100} />);
+
+    expect(remove).not.toHaveBeenCalled();
+    expect(screen.getByTestId('notification-n-persistent')).toBeInTheDocument();
+    expect(screen.queryByTestId('notification-n-transient')).not.toBeInTheDocument();
+  });
+
+  it('replaces a persistent notification with a newer persistent one', () => {
+    currentNotifications = [
+      transientFixture({
+        createdAt: 1,
+        duration: undefined,
+        id: 'n-old',
+        message: 'Old persistent',
+      }),
+    ];
+
+    const { rerender } = render(<NotificationList minDisplayMs={100} />);
+    expect(screen.getByTestId('notification-n-old')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+      currentNotifications = [
+        ...currentNotifications,
+        transientFixture({
+          createdAt: 200,
+          duration: undefined,
+          id: 'n-new',
+          message: 'New persistent',
+        }),
+      ];
+    });
+    rerender(<NotificationList minDisplayMs={100} />);
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+    rerender(<NotificationList minDisplayMs={100} />);
+
+    expect(remove).toHaveBeenCalledWith('n-old');
+    expect(screen.getByTestId('notification-n-new')).toBeInTheDocument();
+  });
+
+  it('unmounts the list after exit animation when the store becomes empty', () => {
+    currentNotifications = [transientFixture({ id: 'n-1', message: 'Solo' })];
+
+    const { rerender } = render(<NotificationList minDisplayMs={100} />);
+    expect(screen.getByTestId('notification-n-1')).toBeInTheDocument();
+
+    // Externally drain the store (simulates auto-dismiss or a `clear()` call).
+    act(() => {
+      currentNotifications = [];
+    });
+    rerender(<NotificationList minDisplayMs={100} />);
+
+    // Mid exit animation: the notification is still mounted but flagged exiting.
+    expect(screen.getByTestId('notification-n-1')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+    rerender(<NotificationList minDisplayMs={100} />);
+
+    expect(screen.queryByTestId('notification-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('notification-n-1')).not.toBeInTheDocument();
+  });
+
+  it('mounts a freshly-added notification after the slot had been emptied', () => {
+    currentNotifications = [transientFixture({ id: 'n-1', message: 'Solo' })];
+
+    const { rerender } = render(<NotificationList minDisplayMs={100} />);
+
+    act(() => {
+      currentNotifications = [];
+    });
+    rerender(<NotificationList minDisplayMs={100} />);
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+    rerender(<NotificationList minDisplayMs={100} />);
+    expect(screen.queryByTestId('notification-list')).not.toBeInTheDocument();
+
+    act(() => {
+      currentNotifications = [
+        transientFixture({ createdAt: 100, id: 'n-2', message: 'Later' }),
+      ];
+    });
+    rerender(<NotificationList minDisplayMs={100} />);
+
+    expect(screen.getByTestId('notification-n-2')).toBeInTheDocument();
+  });
+
+  it('shows a queued transient once the persistent one is dismissed', () => {
+    currentNotifications = [
+      transientFixture({
+        createdAt: 1,
+        duration: undefined,
+        id: 'n-persistent',
+        message: 'Persistent',
+      }),
+      transientFixture({ createdAt: 2, id: 'n-transient', message: 'Saved' }),
+    ];
+
+    const { rerender } = render(<NotificationList minDisplayMs={100} />);
+    expect(screen.getByTestId('notification-n-persistent')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Dismiss' })[0]);
+    rerender(<NotificationList minDisplayMs={100} />);
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+    rerender(<NotificationList minDisplayMs={100} />);
+
+    expect(remove).toHaveBeenCalledWith('n-persistent');
+    expect(screen.getByTestId('notification-n-transient')).toBeInTheDocument();
+  });
+
   it('supports bottom alignment', () => {
+    currentNotifications = [transientFixture()];
     render(<NotificationList verticalAlignment='bottom' />);
 
     expect(screen.getByTestId('notification-list')).toHaveClass(
@@ -197,12 +511,7 @@ describe('NotificationList', () => {
   });
 
   it('prefers per-notification entry direction over the list fallback', () => {
-    currentNotifications = [
-      {
-        ...notifications[0],
-        metadata: { entryDirection: 'left' },
-      },
-    ];
+    currentNotifications = [transientFixture({ metadata: { entryDirection: 'left' } })];
 
     render(<NotificationList enterFrom='bottom' />);
 
@@ -217,13 +526,12 @@ describe('NotificationList', () => {
 
   it('uses origin.context.entryDirection when metadata is absent', () => {
     currentNotifications = [
-      {
-        ...notifications[0],
+      transientFixture({
         origin: {
           context: { entryDirection: 'right' },
           emitter: 'test',
         },
-      },
+      }),
     ];
 
     render(<NotificationList enterFrom='bottom' />);
@@ -238,6 +546,7 @@ describe('NotificationList', () => {
   });
 
   it('supports top vertical alignment', () => {
+    currentNotifications = [transientFixture()];
     render(<NotificationList verticalAlignment='top' />);
 
     expect(screen.getByTestId('notification-list')).toHaveClass(
@@ -246,6 +555,7 @@ describe('NotificationList', () => {
   });
 
   it('uses custom Notification component from ComponentContext', () => {
+    currentNotifications = [transientFixture()];
     const CustomNotification = React.forwardRef<
       HTMLDivElement,
       {

--- a/src/components/Notifications/__tests__/NotificationList.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationList.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
-import { NotificationList, pickNewest } from '../NotificationList';
+import { createDefaultPickNext, NotificationList, pickNewest } from '../NotificationList';
 import { useNotificationApi } from '../hooks/useNotificationApi';
 import { useNotifications } from '../hooks/useNotifications';
 import { ComponentProvider } from '../../../context/ComponentContext';
@@ -183,15 +183,16 @@ describe('NotificationList', () => {
     expect(screen.queryByTestId('notification-n-2')).not.toBeInTheDocument();
   });
 
-  it('uses a custom pickNext to override the default FIFO order', () => {
+  it('uses createDefaultPickNext to switch the default selector to LIFO', () => {
     currentNotifications = [
       transientFixture({ createdAt: 1, id: 'n-1', message: 'First' }),
       transientFixture({ createdAt: 2, id: 'n-2', message: 'Second' }),
       transientFixture({ createdAt: 3, id: 'n-3', message: 'Third' }),
     ];
 
+    const pickNextLifo = createDefaultPickNext(pickNewest);
     const { rerender } = render(
-      <NotificationList minDisplayMs={500} pickNext={pickNewest} />,
+      <NotificationList minDisplayMs={500} pickNext={pickNextLifo} />,
     );
 
     // With LIFO ordering the newest queued notification is shown first.
@@ -200,11 +201,11 @@ describe('NotificationList', () => {
     act(() => {
       vi.advanceTimersByTime(500);
     });
-    rerender(<NotificationList minDisplayMs={500} pickNext={pickNewest} />);
+    rerender(<NotificationList minDisplayMs={500} pickNext={pickNextLifo} />);
     act(() => {
       vi.advanceTimersByTime(EXIT_ANIMATION_MS);
     });
-    rerender(<NotificationList minDisplayMs={500} pickNext={pickNewest} />);
+    rerender(<NotificationList minDisplayMs={500} pickNext={pickNextLifo} />);
 
     // After dwell + exit, the next-newest replaces it.
     expect(remove).toHaveBeenCalledWith('n-3');


### PR DESCRIPTION
### 🎯 Goal

Closes REACT-984

Introduces:

- min display time for a snackbar notification to prevent waiting too long to display concurrent notifications (swaps faster by default if the queue is not empty)
- possibility to introduce custom policy for notification retrieval from the queue

The reduction of display time is introduced according to the design requirements:

```
Concurrency
- Repeated triggers of the same snackbar replace the active one and reset the auto-dismiss timer.
- A new snackbar replaces the current one rather than queueing behind it.
- Persistent variants (with an action like "Retry") are not replaced by transient feedback. They stay until dismissed or acted on.
- Snackbars do not stack visually.
```

Documented changes:

https://github.com/GetStream/docs-content/pull/1295

