### PR TITLE
chore(ci): run lint and test jobs on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    if: ${{ github.ref_name != 'master' }}
     name: ESLint & Prettier
     steps:
       - uses: actions/checkout@v6
@@ -47,7 +46,6 @@ jobs:
           key: '${{ env.BUILD_CACHE_KEY }}'
 
   test:
-    if: ${{ github.ref_name != 'master' }}
     runs-on: ubuntu-latest
     name: Test
     steps:


### PR DESCRIPTION
### 🎯 Goal

Previously the `lint` and `test` jobs were skipped on `master` (they only ran on pull requests), so anything reaching `master` outside the normal PR flow had no lint/test validation. Running them on `master` pushes adds a safety net.

### 🛠 Implementation details

Removed the `if: ${{ github.ref_name != 'master' }}` condition from the `lint` and `test` jobs in `.github/workflows/ci.yml`. Both jobs now run on every trigger (pull requests and pushes to `master`). The `build` job already ran unconditionally.

### 🎨 UI Changes

N/A — CI configuration only.