### PR TITLE
fix(interop): unwrap CJS default exports (react-player, @emoji-mart/react)

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -1,6 +1,15 @@
 import { useComponentContext } from '../../context';
-import ReactPlayer from 'react-player';
+import ReactPlayerImport from 'react-player';
 import React from 'react';
+
+// react-player ships as CJS with the component on `exports.default`. Some
+// bundler/interop setups (e.g. Vite serving our built ESM as a linked workspace
+// dependency) hand back the module namespace `{ default }` instead of the
+// component itself, which makes React throw "Element type is invalid ... got:
+// object". Unwrap the default defensively so it works regardless of interop.
+const ReactPlayer =
+  (ReactPlayerImport as unknown as { default?: typeof ReactPlayerImport }).default ??
+  ReactPlayerImport;
 
 export type VideoPlayerProps = {
   isPlaying?: boolean;

--- a/src/plugins/Emojis/EmojiPicker.tsx
+++ b/src/plugins/Emojis/EmojiPicker.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import Picker from '@emoji-mart/react';
+import PickerImport from '@emoji-mart/react';
 
 import { useMessageComposerContext, useTranslationContext } from '../../context';
 import {
@@ -10,6 +10,14 @@ import {
 } from '../../components';
 import { usePopoverPosition } from '../../components/Dialog/hooks/usePopoverPosition';
 import { useIsCooldownActive } from '../../components/MessageComposer/hooks/useIsCooldownActive';
+
+// @emoji-mart/react ships as CJS with the component on `exports.default`. Under
+// spec-strict ESM interop (e.g. Vite 8 / Rolldown, native Node ESM) a default
+// import yields the module namespace `{ default }` instead of the component,
+// which makes React throw "Element type is invalid ... got: object". Unwrap the
+// default defensively so it works regardless of interop.
+const Picker =
+  (PickerImport as unknown as { default?: typeof PickerImport }).default ?? PickerImport;
 
 const isShadowRoot = (node: Node): node is ShadowRoot => !!(node as ShadowRoot).host;
 


### PR DESCRIPTION
### 🎯 Goal

Fix a runtime crash — `Uncaught Error: Element type is invalid: expected a string ... but got: object` — when components backed by externalized **CommonJS** dependencies are rendered under spec-strict ESM↔CJS interop. Two components are affected:

- `VideoPlayer` → `react-player`
- `EmojiPicker` → `@emoji-mart/react`

This first surfaced in the Vite example, which consumes the SDK's built ESM (`dist/es`) as a linked workspace dependency. **Vite 8 swapped its dependency optimizer from esbuild to Rolldown.** esbuild honored the Babel `__esModule` marker and unwrapped `.default`; Rolldown follows spec-strict interop where a CJS module's ESM default export is `module.exports` itself. So `import ReactPlayer from 'react-player'` (and `import Picker from '@emoji-mart/react'`) now resolve to the module namespace `{ default, __esModule }` — an object — and rendering it throws. Native Node ESM behaves identically, so this was never spec-portable; it only worked under bundlers that honored `__esModule`.

### 🛠 Implementation details

Both packages ship as CJS with the real export on `exports.default`. We unwrap the interop default defensively at each import site:

```ts
import ReactPlayerImport from 'react-player';
const ReactPlayer =
  (ReactPlayerImport as unknown as { default?: typeof ReactPlayerImport }).default ??
  ReactPlayerImport;
```

```ts
import PickerImport from '@emoji-mart/react';
const Picker =
  (PickerImport as unknown as { default?: typeof PickerImport }).default ?? PickerImport;
```

When the bundler already provides the component (the normal case — esbuild, webpack, pre-Vite-8), `.default` is `undefined` and it falls back to the import unchanged. So this is a **no-op for existing consumers** and resolves the `got: object` crash only where the namespace leaks through.

**Audit.** Every default-imported externalized dependency in `src/` was checked against native-Node-ESM (≡ Rolldown strict) interop. Only `react-player` and `@emoji-mart/react` exhibit the hazard signature (object default carrying `{ __esModule, default }`). All others are safe:

- **Classic CJS** exporting the value on `module.exports`: `clsx`, `dayjs` + all `dayjs/plugin/*`, `lodash.debounce/mergewith/throttle/uniqby`, `emoji-regex`, `fix-webm-duration`, `react-fast-compare`, `moment-timezone`
- **Real ESM**: `react-markdown`, `remark-gfm`
- **Legitimately object-valued defaults** used correctly (member access / valid React element type): `react` (namespace), `i18next` (instance), `react-textarea-autosize` (`forwardRef`)

Files changed: `src/components/VideoPlayer/VideoPlayer.tsx`, `src/plugins/Emojis/EmojiPicker.tsx`. `tsc`, eslint, and prettier are clean; existing `VideoAttachment` tests pass.

### 🎨 UI Changes

No visual changes. Restores `VideoPlayer` and `EmojiPicker` rendering in environments where they previously crashed (Vite 8 / Rolldown, native Node ESM, strict-interop SSR). No screenshots applicable.
