### PR TITLE
fix: general performance and bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "react-textarea-autosize": "^8.5.9",
     "react-virtuoso": "^2.19.1",
     "remark-gfm": "^4.0.1",
-    "ts-pattern": "^5.9.0",
     "unist-builder": "^4.0.0",
     "unist-util-visit": "^5.1.0",
     "use-sync-external-store": "^1.6.0"

--- a/src/components/Badge/MediaBadge.tsx
+++ b/src/components/Badge/MediaBadge.tsx
@@ -24,7 +24,7 @@ export const MediaBadge = ({ attachment, variant }: MediaBadgeProps) => {
       })}
     >
       {Icon && <Icon />}
-      {attachment.duration && <div>{attachment.duration}</div>}
+      {attachment.duration ? <div>{attachment.duration}</div> : null}
     </div>
   );
 };

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -279,13 +279,13 @@ const ChannelInner = (
 
   const channelCapabilitiesArray = channel.data?.own_capabilities as string[];
 
-  const throttledCopyStateFromChannel = throttle(
-    () => dispatch({ channel, type: 'copyStateFromChannelOnEvent' }),
-    500,
-    {
-      leading: true,
-      trailing: true,
-    },
+  const throttledCopyStateFromChannel = useMemo(
+    () =>
+      throttle(() => dispatch({ channel, type: 'copyStateFromChannelOnEvent' }), 500, {
+        leading: true,
+        trailing: true,
+      }),
+    [channel],
   );
 
   const setChannelUnreadUiState = useMemo(

--- a/src/components/ChatView/ChatView.tsx
+++ b/src/components/ChatView/ChatView.tsx
@@ -167,7 +167,7 @@ export const useActiveThread = ({ activeThread }: { activeThread?: Thread }) => 
     window.addEventListener('blur', handleVisibilityChange);
     return () => {
       activeThread.deactivate();
-      window.addEventListener('blur', handleVisibilityChange);
+      window.removeEventListener('blur', handleVisibilityChange);
       window.removeEventListener('focus', handleVisibilityChange);
     };
   }, [activeThread]);

--- a/src/components/Dialog/hooks/usePopoverPosition.ts
+++ b/src/components/Dialog/hooks/usePopoverPosition.ts
@@ -1,5 +1,6 @@
 import {
   autoPlacement,
+  type AutoPlacementOptions,
   autoUpdate,
   flip as flipMw,
   offset as offsetMw,
@@ -8,7 +9,6 @@ import {
   size as sizeMw,
   useFloating,
 } from '@floating-ui/react';
-import type { AutoPlacementOptions } from '@floating-ui/core';
 
 const hasResizeObserver = typeof window !== 'undefined' && 'ResizeObserver' in window;
 

--- a/src/components/MessageActions/DownloadSubmenu.tsx
+++ b/src/components/MessageActions/DownloadSubmenu.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { useMessageContext, useTranslationContext } from '../../context';
+import {
+  ContextMenuBackButton,
+  ContextMenuButton,
+  ContextMenuHeader,
+  useContextMenuContext,
+} from '../Dialog';
+import { IconChevronLeft, IconDownload } from '../Icons';
+import {
+  downloadAllAttachments,
+  downloadAttachment,
+  isDownloadableAttachment,
+} from './downloadUtils';
+
+const msgActionsBoxButtonClassName =
+  'str-chat__message-actions-list-item-button' as const;
+
+export const DownloadSubmenuHeader = () => {
+  const { returnToParentMenu: goBack } = useContextMenuContext();
+  const { t } = useTranslationContext();
+  return (
+    <ContextMenuHeader>
+      <ContextMenuBackButton onClick={goBack}>
+        <IconChevronLeft />
+        <span>{t('Download Attachment')}</span>
+      </ContextMenuBackButton>
+    </ContextMenuHeader>
+  );
+};
+
+export const DownloadSubmenu = () => {
+  const { closeMenu } = useContextMenuContext();
+  const { message } = useMessageContext();
+  const { t } = useTranslationContext();
+
+  const downloadableAttachments = (message.attachments ?? []).filter(
+    isDownloadableAttachment,
+  );
+
+  return (
+    <div
+      aria-label={t('aria/Download attachment')}
+      className='str-chat__message-actions-box__submenu str-chat__message-actions-box__submenu--download-attachments'
+      role='menu'
+    >
+      {downloadableAttachments.map((attachment, index) => {
+        const fileName =
+          attachment.localMetadata?.file?.name ??
+          attachment.title ??
+          t('Download Attachment');
+
+        return (
+          <ContextMenuButton
+            className={msgActionsBoxButtonClassName}
+            Icon={IconDownload}
+            key={
+              attachment.localMetadata?.id ??
+              attachment.asset_url ??
+              attachment.image_url ??
+              `${fileName}-${index}`
+            }
+            onClick={() => {
+              void downloadAttachment(attachment);
+              closeMenu();
+            }}
+          >
+            {`Download ${fileName}`}
+          </ContextMenuButton>
+        );
+      })}
+      <ContextMenuButton
+        className={msgActionsBoxButtonClassName}
+        Icon={IconDownload}
+        onClick={() => {
+          void downloadAllAttachments(downloadableAttachments);
+          closeMenu();
+        }}
+      >
+        {t('Download All')}
+      </ContextMenuButton>
+    </div>
+  );
+};

--- a/src/components/MessageActions/MessageActions.defaults.tsx
+++ b/src/components/MessageActions/MessageActions.defaults.tsx
@@ -8,7 +8,6 @@ import {
   IconBellOff,
   IconBookmark,
   IconBookmarkRemove,
-  IconChevronLeft,
   IconCopy,
   IconDelete,
   IconDownload,
@@ -41,10 +40,9 @@ import {
   useTranslationContext,
 } from '../../context';
 import { RemindMeSubmenu, RemindMeSubmenuHeader } from './RemindMeSubmenu';
+import { DownloadSubmenu, DownloadSubmenuHeader } from './DownloadSubmenu';
 import {
-  ContextMenuBackButton,
   ContextMenuButton,
-  ContextMenuHeader,
   DialogAnchor,
   useContextMenuContext,
   useDialogIsOpen,
@@ -54,11 +52,7 @@ import { MessageActions, type MessageActionSetItem } from './MessageActions';
 import { QuickMessageActionsButton } from './QuickMessageActionButton';
 import clsx from 'clsx';
 import { DeleteMessageAlert } from './DeleteMessageAlert';
-import {
-  downloadAllAttachments,
-  downloadAttachment,
-  isDownloadableAttachment,
-} from './downloadUtils';
+import { downloadAttachment, isDownloadableAttachment } from './downloadUtils';
 
 const msgActionsBoxButtonClassName =
   'str-chat__message-actions-list-item-button' as const;
@@ -200,63 +194,6 @@ const DefaultMessageActionComponents = {
       );
 
       if (!downloadableAttachments.length) return null;
-
-      const DownloadSubmenuHeader = () => {
-        const { returnToParentMenu: goBack } = useContextMenuContext();
-        const { t: translate } = useTranslationContext();
-        return (
-          <ContextMenuHeader>
-            <ContextMenuBackButton onClick={goBack}>
-              <IconChevronLeft />
-              <span>{translate('Download Attachment')}</span>
-            </ContextMenuBackButton>
-          </ContextMenuHeader>
-        );
-      };
-
-      const DownloadSubmenu = () => (
-        <div
-          aria-label={t('aria/Download attachment')}
-          className='str-chat__message-actions-box__submenu str-chat__message-actions-box__submenu--download-attachments'
-          role='menu'
-        >
-          {downloadableAttachments.map((attachment, index) => {
-            const fileName =
-              attachment.localMetadata?.file?.name ??
-              attachment.title ??
-              t('Download Attachment');
-
-            return (
-              <MessageActionsMenuItemButton
-                className={msgActionsBoxButtonClassName}
-                Icon={IconDownload}
-                key={
-                  attachment.localMetadata?.id ??
-                  attachment.asset_url ??
-                  attachment.image_url ??
-                  `${fileName}-${index}`
-                }
-                onClick={() => {
-                  void downloadAttachment(attachment);
-                  closeMenu();
-                }}
-              >
-                {`Download ${fileName}`}
-              </MessageActionsMenuItemButton>
-            );
-          })}
-          <MessageActionsMenuItemButton
-            className={msgActionsBoxButtonClassName}
-            Icon={IconDownload}
-            onClick={() => {
-              void downloadAllAttachments(downloadableAttachments);
-              closeMenu();
-            }}
-          >
-            {t('Download All')}
-          </MessageActionsMenuItemButton>
-        </div>
-      );
 
       return (
         <MessageActionsMenuItemButton

--- a/src/components/MessageList/utils.ts
+++ b/src/components/MessageList/utils.ts
@@ -249,6 +249,15 @@ export const insertIntro = (messages: RenderedMessage[], headerPosition?: number
 
 export type GroupStyle = '' | 'middle' | 'top' | 'bottom' | 'single';
 
+// Allocation-free, early-exiting emptiness check. Avoids the throwaway array
+// that `Object.keys(obj).length > 0` allocates per message inside getGroupStyles.
+const isNonEmptyRecord = (record: Record<string, unknown>) => {
+  for (const key in record) {
+    if (Object.prototype.hasOwnProperty.call(record, key)) return true;
+  }
+  return false;
+};
+
 export const getGroupStyles = (
   message: RenderedMessage,
   previousMessage: RenderedMessage,
@@ -268,7 +277,7 @@ export const getGroupStyles = (
     previousMessage.type === 'error' ||
     previousMessage.attachments?.length !== 0 ||
     message.user?.id !== previousMessage.user?.id ||
-    (message.reaction_groups && Object.keys(message.reaction_groups).length > 0) ||
+    (message.reaction_groups && isNonEmptyRecord(message.reaction_groups)) ||
     isMessageEdited(previousMessage) ||
     (maxTimeBetweenGroupedMessages !== undefined &&
       previousMessage.created_at &&
@@ -285,8 +294,7 @@ export const getGroupStyles = (
     nextMessage.type === 'error' ||
     nextMessage.attachments?.length !== 0 ||
     message.user?.id !== nextMessage.user?.id ||
-    (nextMessage.reaction_groups &&
-      Object.keys(nextMessage.reaction_groups).length > 0) ||
+    (nextMessage.reaction_groups && isNonEmptyRecord(nextMessage.reaction_groups)) ||
     isMessageEdited(message) ||
     (maxTimeBetweenGroupedMessages !== undefined &&
       nextMessage.created_at &&

--- a/src/components/Reactions/hooks/useProcessReactions.tsx
+++ b/src/components/Reactions/hooks/useProcessReactions.tsx
@@ -90,17 +90,28 @@ export const useProcessReactions = (params: UseProcessReactionsParams) => {
     ).length;
   }, [isSupportedReaction, reactionGroups]);
 
-  const getLatestReactedUserNames = useCallback(
-    (reactionType?: string) =>
-      latestReactions?.flatMap((reaction) => {
-        if (reactionType && reactionType === reaction.type) {
-          const username = reaction.user?.name || reaction.user?.id;
-          return username ? [username] : [];
-        }
-        return [];
-      }) ?? [],
-    [latestReactions],
-  );
+  // Group the reacting user names by reaction type in a single pass, so each
+  // reaction group can look its names up in O(1) instead of re-scanning the
+  // whole `latestReactions` array per type (previously O(types × reactions)).
+  const latestReactedUserNamesByType = useMemo(() => {
+    const namesByType = new Map<string, string[]>();
+    if (!latestReactions) return namesByType;
+
+    for (const reaction of latestReactions) {
+      if (!reaction.type) continue;
+      const username = reaction.user?.name || reaction.user?.id;
+      if (!username) continue;
+
+      const existing = namesByType.get(reaction.type);
+      if (existing) {
+        existing.push(username);
+      } else {
+        namesByType.set(reaction.type, [username]);
+      }
+    }
+
+    return namesByType;
+  }, [latestReactions]);
 
   const existingReactions: ReactionSummary[] = useMemo(() => {
     if (!reactionGroups) {
@@ -113,7 +124,8 @@ export const useProcessReactions = (params: UseProcessReactionsParams) => {
           return [];
         }
 
-        const latestReactedUserNames = getLatestReactedUserNames(reactionType);
+        const latestReactedUserNames =
+          latestReactedUserNamesByType.get(reactionType) ?? [];
 
         return [
           {
@@ -133,7 +145,7 @@ export const useProcessReactions = (params: UseProcessReactionsParams) => {
     return unsortedReactions.sort(sortReactions);
   }, [
     getEmojiByReactionType,
-    getLatestReactedUserNames,
+    latestReactedUserNamesByType,
     isOwnReaction,
     isSupportedReaction,
     reactionGroups,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10085,7 +10085,6 @@ __metadata:
     sass: "npm:^1.100.0"
     semantic-release: "npm:^25.0.3"
     stream-chat: "npm:^9.44.2"
-    ts-pattern: "npm:^5.9.0"
     typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.59.4"
     unist-builder: "npm:^4.0.0"
@@ -10654,13 +10653,6 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10c0/767849383c114e7f1971fa976b20e73ac28fd0c70d8d65c0004790bf4d8f89888c7e4cf6d5949f9c1beae9bc3c64835bef77bbe27fddf45a3c7b60cebcf85c8c
-  languageName: node
-  linkType: hard
-
-"ts-pattern@npm:^5.9.0":
-  version: 5.9.0
-  resolution: "ts-pattern@npm:5.9.0"
-  checksum: 10c0/7640db25c39d29b287471b2b82d4f7b4674a02098c6ba4d10fed180adfb07d0e0c71930d9e59dc0d90654145e02fd320af63cf0df3c41e100d4154658a612a0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 🎯 Goal

Apply the low-risk, high-confidence findings from the Vercel React best-practices audit (`PERFORMANCE_AUDIT.md`) as isolated, behavior-preserving changes. These are the "quick wins" — one real bug fix plus several allocation/re-render/dependency-hygiene cleanups — that don't touch the public API and are safe to land without a profiler-backed investigation.

### 🛠 Implementation details

Each item is a separate commit:

- **`fix(ChatView)`**  `useActiveThread` cleanup re-added the `blur` listener instead of removing it, leaking a handler (operating on stale thread refs) on every `activeThread` change/unmount. Now calls `removeEventListener`.
- **`fix(Badge)`** `MediaBadge` used `{duration && …}`, which renders a literal `0` text node for a zero-duration attachment. Switched to a ternary.
- **`perf(Reactions)`** `useProcessReactions` scanned the whole `latest_reactions` array once per reaction type (O(types × reactions)). Replaced with a single-pass `Map<reactionType, string[]>` + O(1) lookups.
- **`perf(MessageActions)`** the `Download` action defined `DownloadSubmenu`/`DownloadSubmenuHeader` inside its render (new component types each render → remount). Moved them to a module-scope `MessageActions/DownloadSubmenu.tsx`, reading from context, mirroring the existing `RemindMeSubmenu` pattern.
- **`perf(Channel)`** `throttledCopyStateFromChannel` was re-allocated every render; wrapped in `useMemo([channel])` to match the sibling `markRead`/`setChannelUnreadUiState` memos. The `handleEvent` stale-closure ref-refactor is **deferred** — it rewires WebSocket subscription semantics in a race-condition-sensitive file and needs dedicated event-ordering tests.
- **`perf(MessageList)`** `getGroupStyles` used `Object.keys(reaction_groups).length > 0` (throwaway array) per message. Replaced with an allocation-free, early-exiting `isNonEmptyRecord` helper. Semantics unchanged (key-present, not count>0).
- **`refactor(Dialog)`** `usePopoverPosition` imported `AutoPlacementOptions` from the undeclared (transitive) `@floating-ui/core`. `@floating-ui/react` re-exports the type, so the import now points there. Type-only; zero runtime impact.
- **`chore(deps)`** removed the unused `ts-pattern` dependency (no import anywhere in `src/`) and synced `yarn.lock`.


