### PR TITLE
docs(examples/tutorial): update theming tokens to --str-chat__ prefix

### DIFF
--- a/examples/tutorial/src/3-channel-list/layout.css
+++ b/examples/tutorial/src/3-channel-list/layout.css
@@ -4,29 +4,29 @@
 @layer stream-overrides {
   .custom-theme {
     /* Accent */
-    --accent-primary: #0d47a1;
+    --str-chat__accent-primary: #0d47a1;
 
     /* Message bubble colors */
-    --chat-bg-outgoing: #1e3a8a;
-    --chat-bg-attachment-outgoing: #0d47a1;
-    --chat-bg-incoming: #dbeafe;
-    --chat-text-outgoing: #ffffff;
-    --chat-reply-indicator-outgoing: #93c5fd;
+    --str-chat__chat-bg-outgoing: #1e3a8a;
+    --str-chat__chat-bg-attachment-outgoing: #0d47a1;
+    --str-chat__chat-bg-incoming: #dbeafe;
+    --str-chat__chat-text-outgoing: #ffffff;
+    --str-chat__chat-reply-indicator-outgoing: #93c5fd;
 
     /* Links */
-    --text-link: #1e40af;
-    --chat-text-link: #93c5fd;
+    --str-chat__text-link: #1e40af;
+    --str-chat__chat-text-link: #93c5fd;
 
     /* Panel backgrounds */
-    --background-core-elevation-1: #dbeafe; /* channel list, surrounding panels */
-    --background-core-app: #c7dafc;         /* message list background */
+    --str-chat__background-core-elevation-1: #dbeafe; /* channel list, surrounding panels */
+    --str-chat__background-core-app: #c7dafc;         /* message list background */
 
     /* Focus ring */
-    --border-utility-focused: #1e40af;
+    --str-chat__border-utility-focused: #1e40af;
 
     /* Radii */
-    --radius-max: 8px;
-    --button-radius-full: 6px;
+    --str-chat__radius-max: 8px;
+    --str-chat__button-radius-full: 6px;
   }
 }
 

--- a/examples/tutorial/src/4-custom-ui-components/layout.css
+++ b/examples/tutorial/src/4-custom-ui-components/layout.css
@@ -4,29 +4,29 @@
 @layer stream-overrides {
   .custom-theme {
     /* Accent */
-    --accent-primary: #0d47a1;
+    --str-chat__accent-primary: #0d47a1;
 
     /* Message bubble colors */
-    --chat-bg-outgoing: #1e3a8a;
-    --chat-bg-attachment-outgoing: #0d47a1;
-    --chat-bg-incoming: #dbeafe;
-    --chat-text-outgoing: #ffffff;
-    --chat-reply-indicator-outgoing: #93c5fd;
+    --str-chat__chat-bg-outgoing: #1e3a8a;
+    --str-chat__chat-bg-attachment-outgoing: #0d47a1;
+    --str-chat__chat-bg-incoming: #dbeafe;
+    --str-chat__chat-text-outgoing: #ffffff;
+    --str-chat__chat-reply-indicator-outgoing: #93c5fd;
 
     /* Links */
-    --text-link: #1e40af;
-    --chat-text-link: #93c5fd;
+    --str-chat__text-link: #1e40af;
+    --str-chat__chat-text-link: #93c5fd;
 
     /* Panel backgrounds */
-    --background-core-elevation-1: #dbeafe; /* channel list, surrounding panels */
-    --background-core-app: #c7dafc;         /* message list background */
+    --str-chat__background-core-elevation-1: #dbeafe; /* channel list, surrounding panels */
+    --str-chat__background-core-app: #c7dafc;         /* message list background */
 
     /* Focus ring */
-    --border-utility-focused: #1e40af;
+    --str-chat__border-utility-focused: #1e40af;
 
     /* Radii */
-    --radius-max: 8px;
-    --button-radius-full: 6px;
+    --str-chat__radius-max: 8px;
+    --str-chat__button-radius-full: 6px;
   }
 }
 

--- a/examples/tutorial/src/5-custom-attachment-type/layout.css
+++ b/examples/tutorial/src/5-custom-attachment-type/layout.css
@@ -4,29 +4,29 @@
 @layer stream-overrides {
   .custom-theme {
     /* Accent */
-    --accent-primary: #0d47a1;
+    --str-chat__accent-primary: #0d47a1;
 
     /* Message bubble colors */
-    --chat-bg-outgoing: #1e3a8a;
-    --chat-bg-attachment-outgoing: #0d47a1;
-    --chat-bg-incoming: #dbeafe;
-    --chat-text-outgoing: #ffffff;
-    --chat-reply-indicator-outgoing: #93c5fd;
+    --str-chat__chat-bg-outgoing: #1e3a8a;
+    --str-chat__chat-bg-attachment-outgoing: #0d47a1;
+    --str-chat__chat-bg-incoming: #dbeafe;
+    --str-chat__chat-text-outgoing: #ffffff;
+    --str-chat__chat-reply-indicator-outgoing: #93c5fd;
 
     /* Links */
-    --text-link: #1e40af;
-    --chat-text-link: #93c5fd;
+    --str-chat__text-link: #1e40af;
+    --str-chat__chat-text-link: #93c5fd;
 
     /* Panel backgrounds */
-    --background-core-elevation-1: #dbeafe; /* channel list, surrounding panels */
-    --background-core-app: #c7dafc;         /* message list background */
+    --str-chat__background-core-elevation-1: #dbeafe; /* channel list, surrounding panels */
+    --str-chat__background-core-app: #c7dafc;         /* message list background */
 
     /* Focus ring */
-    --border-utility-focused: #1e40af;
+    --str-chat__border-utility-focused: #1e40af;
 
     /* Radii */
-    --radius-max: 8px;
-    --button-radius-full: 6px;
+    --str-chat__radius-max: 8px;
+    --str-chat__button-radius-full: 6px;
   }
 }
 

--- a/examples/tutorial/src/6-emoji-picker/layout.css
+++ b/examples/tutorial/src/6-emoji-picker/layout.css
@@ -4,29 +4,29 @@
 @layer stream-overrides {
   .custom-theme {
     /* Accent */
-    --accent-primary: #0d47a1;
+    --str-chat__accent-primary: #0d47a1;
 
     /* Message bubble colors */
-    --chat-bg-outgoing: #1e3a8a;
-    --chat-bg-attachment-outgoing: #0d47a1;
-    --chat-bg-incoming: #dbeafe;
-    --chat-text-outgoing: #ffffff;
-    --chat-reply-indicator-outgoing: #93c5fd;
+    --str-chat__chat-bg-outgoing: #1e3a8a;
+    --str-chat__chat-bg-attachment-outgoing: #0d47a1;
+    --str-chat__chat-bg-incoming: #dbeafe;
+    --str-chat__chat-text-outgoing: #ffffff;
+    --str-chat__chat-reply-indicator-outgoing: #93c5fd;
 
     /* Links */
-    --text-link: #1e40af;
-    --chat-text-link: #93c5fd;
+    --str-chat__text-link: #1e40af;
+    --str-chat__chat-text-link: #93c5fd;
 
     /* Panel backgrounds */
-    --background-core-elevation-1: #dbeafe; /* channel list, surrounding panels */
-    --background-core-app: #c7dafc;         /* message list background */
+    --str-chat__background-core-elevation-1: #dbeafe; /* channel list, surrounding panels */
+    --str-chat__background-core-app: #c7dafc;         /* message list background */
 
     /* Focus ring */
-    --border-utility-focused: #1e40af;
+    --str-chat__border-utility-focused: #1e40af;
 
     /* Radii */
-    --radius-max: 8px;
-    --button-radius-full: 6px;
+    --str-chat__radius-max: 8px;
+    --str-chat__button-radius-full: 6px;
   }
 }
 

--- a/examples/tutorial/src/7-livestream/layout.css
+++ b/examples/tutorial/src/7-livestream/layout.css
@@ -4,29 +4,29 @@
 @layer stream-overrides {
   .custom-theme {
     /* Accent */
-    --accent-primary: #0d47a1;
+    --str-chat__accent-primary: #0d47a1;
 
     /* Message bubble colors */
-    --chat-bg-outgoing: #1e3a8a;
-    --chat-bg-attachment-outgoing: #0d47a1;
-    --chat-bg-incoming: #dbeafe;
-    --chat-text-outgoing: #ffffff;
-    --chat-reply-indicator-outgoing: #93c5fd;
+    --str-chat__chat-bg-outgoing: #1e3a8a;
+    --str-chat__chat-bg-attachment-outgoing: #0d47a1;
+    --str-chat__chat-bg-incoming: #dbeafe;
+    --str-chat__chat-text-outgoing: #ffffff;
+    --str-chat__chat-reply-indicator-outgoing: #93c5fd;
 
     /* Links */
-    --text-link: #1e40af;
-    --chat-text-link: #93c5fd;
+    --str-chat__text-link: #1e40af;
+    --str-chat__chat-text-link: #93c5fd;
 
     /* Panel backgrounds */
-    --background-core-elevation-1: #dbeafe; /* channel list, surrounding panels */
-    --background-core-app: #c7dafc;         /* message list background */
+    --str-chat__background-core-elevation-1: #dbeafe; /* channel list, surrounding panels */
+    --str-chat__background-core-app: #c7dafc;         /* message list background */
 
     /* Focus ring */
-    --border-utility-focused: #1e40af;
+    --str-chat__border-utility-focused: #1e40af;
 
     /* Radii */
-    --radius-max: 8px;
-    --button-radius-full: 6px;
+    --str-chat__radius-max: 8px;
+    --str-chat__button-radius-full: 6px;
   }
 }
 


### PR DESCRIPTION
PR #3128 renamed all SDK CSS custom properties with a --str-chat__ prefix immediately after PR #3133 synced the tutorial examples to the semantic token names. Update all five tutorial layout.css files accordingly.

### 🎯 Goal

PR #3128 added the `--str-chat__` prefix to all SDK CSS custom properties, but the tutorial examples (steps 3–7) were not updated at the same time. As a result, the `stream-overrides` layer in each tutorial's `layout.css` sets properties that no longer exist, making the custom blue theme have no visible effect.

### 🛠 Implementation details

Renamed all 13 CSS custom properties in the `.custom-theme` block across the five byte-identical `layout.css` files (tutorial steps 3–7) to match the current `--str-chat__` prefix convention (e.g. `--chat-bg-outgoing` → `--str-chat__chat-bg-outgoing`).

### 🎨 UI Changes

CSS-only rename — no visual change intended. The theming was already broken before this fix; after the fix it renders as originally designed (navy outgoing bubbles, light-blue incoming bubbles, pale-blue panel backgrounds).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tutorial example files across multiple sections to use standardized CSS variable naming conventions for theming and styling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->