### PR TITLE
chore(demo): support api_key query param in vite example

### DIFF
--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -74,15 +74,21 @@ const PUBLIC_VITE_EXAMPLE_API_KEY = 'xzwhhgtazy6h';
 
 init({ data });
 
-const parseUserIdFromToken = (token: string) => {
-  const [, payload] = token.split('.');
+const parseUserIdFromToken = (token: string): string | undefined => {
+  try {
+    const [, payload] = token.split('.');
 
-  if (!payload) throw new Error('Token is missing');
+    if (!payload) return undefined;
 
-  return JSON.parse(atob(payload))?.user_id;
+    return JSON.parse(atob(payload))?.user_id;
+  } catch {
+    return undefined;
+  }
 };
 
-const apiKey = import.meta.env.VITE_STREAM_API_KEY;
+const apiKey =
+  new URLSearchParams(window.location.search).get('api_key') ||
+  import.meta.env.VITE_STREAM_API_KEY;
 const token =
   new URLSearchParams(window.location.search).get('token') ||
   import.meta.env.VITE_USER_TOKEN;
@@ -107,6 +113,7 @@ const useUser = () => {
   const userId = useMemo(
     () =>
       searchParams.get('user_id') ||
+      (token ? parseUserIdFromToken(token) : undefined) ||
       import.meta.env.VITE_USER_ID ||
       localStorage.getItem('user_id') ||
       humanId({ separator: '_', capitalize: false }),


### PR DESCRIPTION
### 🎯 Goal

The vite example could only take the Stream API key from the `VITE_STREAM_API_KEY` env var, while the user `token` was already overridable via a query param. This makes it awkward to point the running example at a different Stream app without editing `.env` and restarting. This lets you pass `?api_key=…` (and combine it with `?token=…`) directly in the URL, matching how `token` already works.

### 🛠 Implementation details

- `apiKey` now reads from the `api_key` query param first, falling back to `VITE_STREAM_API_KEY` — mirroring the existing `token` resolution.
- `userId` now derives from the provided `token` (via `parseUserIdFromToken`) when present, slotted just below the explicit `user_id` query param and above the env/localStorage/random fallbacks. This makes `?api_key=…&token=…` self-sufficient: previously the pronto token generator was only skipped when the resolved `userId` matched the token's embedded `user_id`, so omitting `user_id` silently fell back to pronto with the wrong environment/app.
- `parseUserIdFromToken` now returns `undefined` instead of throwing on a malformed/empty token, since it now runs during render; this also hardens the existing `tokenProvider` call site.

User-id precedence: `?user_id=` → token-derived → `VITE_USER_ID` → `localStorage` → random. The explicit `user_id` param still wins, preserving the "connect as someone else, regenerate via pronto" path.

### 🎨 UI Changes

No visual changes — this only affects how the example app sources its credentials. Verified by driving the running example with Playwright:
- `?api_key=test_key_AAA&token=<jwt for "bob">` → Stream WS connects with `api_key=test_key_AAA` and `user_id=bob`; pronto skipped.
- `?api_key=test_key_BBB` (no token) → pronto `create-token` called (fallback intact).
- `?api_key=xzwhhgtazy6h` (public key) → real connection succeeds, chat UI renders, zero console errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key can now be optionally specified via query parameter, with fallback to environment configuration
  * Enhanced token parsing with improved error handling that gracefully manages malformed tokens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->