### PR TITLE
fix: only run husky in a git checkout so npm consumers don't break

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "start:css": "node scripts/watch-styling.mjs",
     "start:tutorial": "yarn workspace @stream-io/stream-chat-react-tutorial dev",
     "start:vite": "yarn workspace @stream-io/stream-chat-react-vite dev",
-    "postinstall": "husky",
+    "postinstall": "node -e \"require('fs').existsSync('scripts/install-husky.mjs') && import('./scripts/install-husky.mjs')\"",
     "test": "vitest run",
     "test:watch": "vitest",
     "types": "tsc --emitDeclarationOnly false --noEmit",

--- a/scripts/install-husky.mjs
+++ b/scripts/install-husky.mjs
@@ -1,0 +1,11 @@
+import { existsSync } from 'node:fs';
+
+// husky installs this repo's local git hooks and is a dev-only dependency. It is
+// invoked from a presence-guarded postinstall (see package.json) so it never runs
+// for consumers — this file is intentionally not published. The .git check is a
+// secondary guard for non-checkout environments; husky's own default() already
+// no-ops gracefully on a missing .git or HUSKY=0, and any genuine setup error is
+// left to surface rather than be swallowed. See GetStream/stream-chat-js#1763.
+if (existsSync('.git')) {
+  (await import('husky')).default();
+}


### PR DESCRIPTION
### 🎯 Goal

`postinstall` ran `husky` unconditionally. npm executes a dependency's `postinstall` for every consumer, but `husky` is a `devDependency` and isn't installed in a consumer's tree, so `npm install stream-chat-react` failed:

```
npm error code 127
npm error sh: husky: command not found
```

This ports the same fix already merged for the JS SDK in [GetStream/stream-chat-js#1764](https://github.com/GetStream/stream-chat-js/pull/1764) — `stream-chat-react` had the identical `"postinstall": "husky"`.

### 🛠 Implementation details

**Why husky has to stay in `postinstall`:** Yarn Berry (this repo's package manager) runs the **root workspace's `postinstall`** on `yarn install` but **not** its `prepare`. Moving husky to `prepare` would silently stop installing contributors' git hooks. husky must stay in `postinstall`; the fix is to stop *running* it for consumers.

- `postinstall` now invokes a dev-only `scripts/install-husky.mjs` **only when it is present** — and that file is intentionally **not** in `package.json#files` (which publishes only `dist`, `package.json`, `README.md`, `AI.md`), so consumers never receive it and the guard short-circuits to a no-op.
- The invocation runs via `node` (not a shell `|| true`) so it's cross-platform — npm runs consumer postinstalls through `cmd.exe` on Windows, where `||`/`true` aren't valid.
- `scripts/install-husky.mjs` runs husky only inside a git checkout, and lets genuine husky setup errors **surface** (not swallowed) so contributors learn if hook installation actually fails.

> Note: unlike the JS SDK PR (which left `prepare: yarn run build` untouched), this repo uses `prepack: yarn build` and has no `prepare` script, so nothing there needed changing — the husky fix is independent of it.

**Verified locally:**

| Scenario | Result |
| --- | --- |
| Consumer (no `scripts/install-husky.mjs`) | exit 0 · husky never executed |
| Contributor (`.git` + script present) | `core.hooksPath=.husky/_` · hooks installed · exit 0 |

`yarn prettier` and `yarn eslint` clean on both changed files.

### 🎨 UI Changes

None — build/install tooling only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved post-install script configuration to make Git hook initialization more reliable and conditional based on repository presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->