### PR TITLE
refactor(tutorial): use isProductAttachment type guard instead of inline predicate

### DIFF
--- a/examples/tutorial/src/5-custom-attachment-type/App.tsx
+++ b/examples/tutorial/src/5-custom-attachment-type/App.tsx
@@ -93,9 +93,7 @@ const App = () => {
       await channel.watch();
 
       const hasProductMessage = channel.state.messages.some((message) =>
-        message.attachments?.some(
-          (attachment) => 'type' in attachment && attachment.type === 'product',
-        ),
+        message.attachments?.some(isProductAttachment),
       );
 
       if (!hasProductMessage) {


### PR DESCRIPTION
## Summary

- In `5-custom-attachment-type/App.tsx`, `hasProductMessage` used an inline predicate `(attachment) => 'type' in attachment && attachment.type === 'product'` that duplicated the existing `isProductAttachment` type guard defined earlier in the same file.
- Replaced the inline predicate with a direct reference to `isProductAttachment`.

## Test plan

- [ ] No behaviour change — purely a refactor to reuse the existing type guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Examples**: Updated tutorial to demonstrate improved patterns for detecting and handling custom attachment types in message processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->