### PR TITLE
fix(MediaRecorder): guard pause/resume against inactive recorder to prevent InvalidStateError

### DIFF
--- a/src/components/MediaRecorder/classes/MediaRecorderController.ts
+++ b/src/components/MediaRecorder/classes/MediaRecorderController.ts
@@ -310,6 +310,10 @@ export class MediaRecorderController {
 
   pause = () => {
     if (this.recordingState.value !== MediaRecordingState.RECORDING) return;
+    // The native recorder can transition to 'inactive' on its own (e.g. iOS Safari
+    // interruptions or a preceding stop) while recordingState still reads RECORDING.
+    // Calling pause() on a non-recording recorder throws InvalidStateError.
+    if (this.mediaRecorder?.state !== 'recording') return;
     if (this.startTime) {
       this.recordedChunkDurations.push(new Date().getTime() - this.startTime);
       this.startTime = undefined;
@@ -321,6 +325,9 @@ export class MediaRecorderController {
 
   resume = () => {
     if (this.recordingState.value !== MediaRecordingState.PAUSED) return;
+    // resume() is only valid on a 'paused' recorder; the native recorder may have gone
+    // inactive while recordingState still reads PAUSED, which would throw InvalidStateError.
+    if (this.mediaRecorder?.state !== 'paused') return;
     this.startTime = new Date().getTime();
     this.mediaRecorder?.resume();
     this.amplitudeRecorder?.start();

--- a/src/components/MediaRecorder/classes/__tests__/MediaRecorderController.test.js
+++ b/src/components/MediaRecorder/classes/__tests__/MediaRecorderController.test.js
@@ -353,6 +353,32 @@ describe('MediaRecorderController', () => {
         expect(controller.recordingState.value).toBe(recordingState);
       },
     );
+
+    // Reproduces the iOS Safari crash reported in production: tapping stop and then
+    // immediately pause leaves the native MediaRecorder in the 'inactive' state while
+    // the controller's recordingState subject can still read RECORDING. Calling
+    // pause() then throws "InvalidStateError: The MediaRecorder's state cannot be
+    // inactive".
+    it('does not pause the native recorder when its state is inactive', async () => {
+      const controller = new MediaRecorderController();
+      await controller.start();
+      const recorder = controller.mediaRecorder;
+      // The native recorder went inactive (e.g. the stop button's native stop() or an
+      // interruption) without the controller's recordingState subject transitioning.
+      recorder.state = 'inactive';
+      recorder.pause.mockImplementation(() => {
+        if (recorder.state === 'inactive') {
+          throw new DOMException(
+            "The MediaRecorder's state cannot be inactive",
+            'InvalidStateError',
+          );
+        }
+        recorder.state = 'paused';
+      });
+
+      expect(() => controller.pause()).not.toThrow();
+      expect(recorder.pause).not.toHaveBeenCalled();
+    });
   });
 
   describe('resume', () => {
@@ -379,6 +405,29 @@ describe('MediaRecorderController', () => {
         expect(controller.recordingState.value).toBe(recordingState);
       },
     );
+
+    // Symmetric to the pause() crash: resuming a recorder that has gone inactive
+    // throws "InvalidStateError" because resume() is only valid in the 'paused' state.
+    it('does not resume the native recorder when its state is inactive', async () => {
+      const controller = new MediaRecorderController();
+      await controller.start();
+      controller.pause();
+      const recorder = controller.mediaRecorder;
+      controller.recordingState.next(MediaRecordingState.PAUSED);
+      recorder.state = 'inactive';
+      recorder.resume.mockImplementation(() => {
+        if (recorder.state !== 'paused') {
+          throw new DOMException(
+            "The MediaRecorder's state cannot be inactive",
+            'InvalidStateError',
+          );
+        }
+        recorder.state = 'recording';
+      });
+
+      expect(() => controller.resume()).not.toThrow();
+      expect(recorder.resume).not.toHaveBeenCalled();
+    });
   });
 
   describe('stop', () => {

--- a/src/mock-builders/browser/MediaRecorder.js
+++ b/src/mock-builders/browser/MediaRecorder.js
@@ -3,10 +3,19 @@ import { EventEmitterMock } from './EventEmitter';
 export class MediaRecorderMock extends EventEmitterMock {
   constructor() {
     super();
-    this.start = jest.fn();
-    this.pause = jest.fn();
-    this.resume = jest.fn();
-    this.stop = jest.fn();
+    this.state = 'inactive';
+    this.start = jest.fn(() => {
+      this.state = 'recording';
+    });
+    this.pause = jest.fn(() => {
+      this.state = 'paused';
+    });
+    this.resume = jest.fn(() => {
+      this.state = 'recording';
+    });
+    this.stop = jest.fn(() => {
+      this.state = 'inactive';
+    });
   }
 
   static isTypeSupported = jest.fn().mockReturnValue(true);


### PR DESCRIPTION
### 🎯 Goal

Closes REACT-789

### 🛠 Implementation details

Root cause
In `MediaRecorderController`, `pause()` guards only against the controller's internal state subject, then calls the native API unconditionally:

```js
pause = () => {
  if (this.recordingState.value !== MediaRecordingState.RECORDING) return;
  ...
  this.mediaRecorder?.pause();   // ← throws if native state is 'inactive'
  ...
};
```

The internal recordingState `BehaviorSubject` can drift out of sync with the native `mediaRecorder.state`. On iOS Safari the native MediaRecorder can transition to inactive on its own (interruptions, the stop button's native `stop()`, track ending) while the React-driven recordingState subject still reads RECORDING. When the user taps stop then immediately pause, `pause()` passes its internal-state guard but `this.mediaRecorder.pause()` hits an inactive recorder → InvalidStateError: The MediaRecorder's state cannot be inactive.

Note the inconsistency: `stop()` already guards against the native `this.mediaRecorder?.state`, but `pause()`/`resume()` guard only against the internal subject. That asymmetry is the bug.