### PR TITLE
fix: use client mandated composer queue

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -17,3 +17,6 @@ npmMinimalAgeGate: 3d
 npmPublishProvenance: true
 
 yarnPath: .yarn/releases/yarn-4.15.0.cjs
+
+npmPreapprovedPackages:
+  - stream-chat

--- a/examples/tutorial/package.json
+++ b/examples/tutorial/package.json
@@ -16,7 +16,7 @@
     "emoji-mart": "^5.6.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "stream-chat": "^9.44.2",
+    "stream-chat": "^9.45.6",
     "stream-chat-react": "workspace:^"
   },
   "devDependencies": {

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -16,7 +16,7 @@
     "modern-normalize": "^3.0.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "stream-chat": "^9.44.2",
+    "stream-chat": "^9.45.6",
     "stream-chat-react": "workspace:^"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "react-dom": "^19.2.6",
     "sass": "^1.100.0",
     "semantic-release": "^25.0.3",
-    "stream-chat": "^9.44.2",
+    "stream-chat": "^9.45.6",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4",
     "vite": "^8.0.14",

--- a/src/components/MessageComposer/__tests__/MessageInput.test.tsx
+++ b/src/components/MessageComposer/__tests__/MessageInput.test.tsx
@@ -1244,11 +1244,13 @@ describe(`MessageInputFlat`, () => {
       });
     });
 
+    // stream-chat >= 9.45 prepends the built-in `@channel` and `@here` special
+    // mentions to the suggestion list, on top of the channel members.
+    const builtInMentionsCount = 2;
+    const memberMentionsCount = Object.keys(customChannel.state.members).length - 1; // remove own user
     await waitFor(() => {
       const usernameList = document.querySelectorAll('.str-chat__suggestion-list-item');
-      expect(usernameList).toHaveLength(
-        Object.keys(customChannel.state.members).length - 1, // remove own user
-      );
+      expect(usernameList).toHaveLength(memberMentionsCount + builtInMentionsCount);
     });
     Element.prototype.scrollIntoView = scrollIntoView;
   });
@@ -1280,9 +1282,12 @@ describe(`MessageInputFlat`, () => {
         document.querySelectorAll('.str-chat__suggestion-list-item').length,
       ).toBeGreaterThan(0);
     });
-    const firstItem = document.querySelectorAll('.str-chat__suggestion-list-item')[0];
+    // The suggestion list also contains the built-in `@channel` / `@here` special
+    // mentions (stream-chat >= 9.45), so select the user's suggestion explicitly
+    // instead of relying on it being the first item.
+    const userItem = screen.getByText(mentionName);
     await act(async () => {
-      await fireEvent.click(firstItem);
+      await fireEvent.click(userItem);
     });
 
     await act(() => submit());

--- a/src/components/MessageComposer/hooks/useMessageComposerController.ts
+++ b/src/components/MessageComposer/hooks/useMessageComposerController.ts
@@ -1,16 +1,12 @@
 import { useEffect, useMemo } from 'react';
-import {
-  FixedSizeQueueCache,
-  MessageComposer as MessageComposerController,
-} from 'stream-chat';
+import { MessageComposer as MessageComposerController } from 'stream-chat';
 import { useThreadContext } from '../../Threads';
 import { useChannelStateContext, useChatContext } from '../../../context';
 import { useLegacyThreadContext } from '../../Thread';
 
-const queueCache = new FixedSizeQueueCache<string, MessageComposerController>(64);
-
 export const useMessageComposerController = () => {
   const { client } = useChatContext();
+  const { messageComposerFixedSizeQueue: queueCache } = client;
   const { channel } = useChannelStateContext();
   const { legacyThread: parentMessage } = useLegacyThreadContext();
   const threadInstance = useThreadContext();
@@ -46,7 +42,7 @@ export const useMessageComposerController = () => {
     } else {
       return channel.messageComposer;
     }
-  }, [cachedParentMessage, channel, client, threadInstance]);
+  }, [cachedParentMessage, channel.messageComposer, client, queueCache, threadInstance]);
 
   if (
     (['legacy_thread', 'message'] as MessageComposerController['contextType'][]).includes(

--- a/src/components/MessageComposer/hooks/useMessageComposerController.ts
+++ b/src/components/MessageComposer/hooks/useMessageComposerController.ts
@@ -6,7 +6,7 @@ import { useLegacyThreadContext } from '../../Thread';
 
 export const useMessageComposerController = () => {
   const { client } = useChatContext();
-  const { messageComposerFixedSizeQueue: queueCache } = client;
+  const { messageComposerCache: queueCache } = client;
   const { channel } = useChannelStateContext();
   const { legacyThread: parentMessage } = useLegacyThreadContext();
   const threadInstance = useThreadContext();

--- a/src/components/MessageComposer/hooks/useMessageComposerController.ts
+++ b/src/components/MessageComposer/hooks/useMessageComposerController.ts
@@ -42,7 +42,7 @@ export const useMessageComposerController = () => {
     } else {
       return channel.messageComposer;
     }
-  }, [cachedParentMessage, channel.messageComposer, client, queueCache, threadInstance]);
+  }, [cachedParentMessage, channel, client, threadInstance]);
 
   if (
     (['legacy_thread', 'message'] as MessageComposerController['contextType'][]).includes(

--- a/src/components/MessageComposer/hooks/useMessageComposerController.ts
+++ b/src/components/MessageComposer/hooks/useMessageComposerController.ts
@@ -42,7 +42,7 @@ export const useMessageComposerController = () => {
     } else {
       return channel.messageComposer;
     }
-  }, [cachedParentMessage, channel, client, threadInstance]);
+  }, [cachedParentMessage, channel, client, queueCache, threadInstance]);
 
   if (
     (['legacy_thread', 'message'] as MessageComposerController['contextType'][]).includes(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,7 +2079,7 @@ __metadata:
     emoji-mart: "npm:^5.6.0"
     react: "npm:^19.2.6"
     react-dom: "npm:^19.2.6"
-    stream-chat: "npm:^9.44.2"
+    stream-chat: "npm:^9.45.6"
     stream-chat-react: "workspace:^"
     typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
@@ -2105,7 +2105,7 @@ __metadata:
     react: "npm:^19.2.6"
     react-dom: "npm:^19.2.6"
     sass: "npm:^1.100.0"
-    stream-chat: "npm:^9.44.2"
+    stream-chat: "npm:^9.45.6"
     stream-chat-react: "workspace:^"
     typescript: "npm:^6.0.3"
     vite: "npm:^8.0.14"
@@ -2584,7 +2584,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8.5.14":
+"@types/ws@npm:^8.18.1":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
   dependencies:
@@ -2933,6 +2933,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 10c0/c9c52697227661b68d0debaf972222d4f622aa06b185824164e153438afa7b08273432ca43ea792cadb24dada1d46f6f6bb1ef8de9956979288cc1b96bf9914e
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:6":
+  version: 6.0.2
+  resolution: "agent-base@npm:6.0.2"
+  dependencies:
+    debug: "npm:4"
+  checksum: 10c0/dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
   languageName: node
   linkType: hard
 
@@ -3285,14 +3294,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.1":
-  version: 1.16.0
-  resolution: "axios@npm:1.16.0"
+"axios@npm:^1.16.1":
+  version: 1.17.0
+  resolution: "axios@npm:1.17.0"
   dependencies:
     follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
+    https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/1c91a5221b77b76072026b4cc95ecdf38f7c3e33e63423abec09a85e6e9a12279637dcc9ac2ba1fc333e0c447fb3b0f46d7965acb5d7cea02d188e9c6d425c0b
+  checksum: 10c0/c4fa19ff3a3a63bde48beec03ad816b133b9a6385cccffffe172577ab18c6a70e299280d57f12c80c867fe25df41f92cb91d3a8258708a6d2be3e9e085f92650
   languageName: node
   linkType: hard
 
@@ -5037,7 +5047,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.4, form-data@npm:^4.0.5":
+"form-data@npm:^4.0.5":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
   dependencies:
@@ -5576,6 +5586,16 @@ __metadata:
     agent-base: "npm:9.0.0"
     debug: "npm:^4.3.4"
   checksum: 10c0/9ffd12ee9c827c0ec681c5066f0a1739c0e5b948c54ced9fc53313861b757f3bb3a2bdab2b8089d47757c1246aaea13bf4b4c304ef7b1e9f9d4bfe5dc87344e2
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "https-proxy-agent@npm:5.0.1"
+  dependencies:
+    agent-base: "npm:6"
+    debug: "npm:4"
+  checksum: 10c0/6dd639f03434003577c62b27cafdb864784ef19b2de430d8ae2a1d45e31c4fd60719e5637b44db1a88a046934307da7089e03d6089ec3ddacc1189d8de8897d1
   languageName: node
   linkType: hard
 
@@ -6849,7 +6869,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"linkifyjs@npm:^4.3.2, linkifyjs@npm:^4.3.3":
+"linkifyjs@npm:^4.3.3":
   version: 4.3.3
   resolution: "linkifyjs@npm:4.3.3"
   checksum: 10c0/0eac293927f1465d13625c8c67c83c50d7fda9137c255a4a2ff5970ea4e9ba57de4846b170326e54b9e4e82be24f3705572bc50773737be9b13af5f1e4577798
@@ -10084,7 +10104,7 @@ __metadata:
     remark-gfm: "npm:^4.0.1"
     sass: "npm:^1.100.0"
     semantic-release: "npm:^25.0.3"
-    stream-chat: "npm:^9.44.2"
+    stream-chat: "npm:^9.45.6"
     typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.59.4"
     unist-builder: "npm:^4.0.0"
@@ -10127,20 +10147,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"stream-chat@npm:^9.44.2":
-  version: 9.44.2
-  resolution: "stream-chat@npm:9.44.2"
+"stream-chat@npm:^9.45.6":
+  version: 9.45.6
+  resolution: "stream-chat@npm:9.45.6"
   dependencies:
     "@types/jsonwebtoken": "npm:^9.0.8"
-    "@types/ws": "npm:^8.5.14"
-    axios: "npm:^1.15.1"
+    "@types/ws": "npm:^8.18.1"
+    axios: "npm:^1.16.1"
     base64-js: "npm:^1.5.1"
-    form-data: "npm:^4.0.4"
+    form-data: "npm:^4.0.5"
     isomorphic-ws: "npm:^5.0.0"
     jsonwebtoken: "npm:^9.0.3"
-    linkifyjs: "npm:^4.3.2"
-    ws: "npm:^8.18.1"
-  checksum: 10c0/2657a6fdf21f54833df230fa2f8261a3ff9648ae627ca394639dd4baf27c244257bd380544d45073915b7af64943e471e021c780c90426875662925048133895
+    linkifyjs: "npm:^4.3.3"
+    ws: "npm:^8.20.1"
+  dependenciesMeta:
+    esbuild:
+      built: true
+    husky:
+      built: true
+  checksum: 10c0/b121144eb7aef34c989bb1702e0bc09a98bb4089f785d530c26721377d308eea9c8e7b11e387f66dd42a663dbeca76e2a8ba54b43ddb93496b4251bcc8c2df48
   languageName: node
   linkType: hard
 
@@ -11470,9 +11495,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.18.1":
-  version: 8.20.0
-  resolution: "ws@npm:8.20.0"
+"ws@npm:^8.20.1":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -11481,7 +11506,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/956ac5f11738c914089b65878b9223692ace77337ba55379ae68e1ecbeae9b47a0c6eb9403688f609999a58c80d83d99865fe0029b229d308b08c1ef93d4ea14
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 🎯 Goal

A mirror of [this PR](https://github.com/GetStream/stream-chat-react-native/pull/3648) from the React Native SDK.

### 🛠 Implementation details

_Provide a description of the implementation_

### 🎨 UI Changes

_Add relevant screenshots_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The message composer now uses the shared client-side cache provided by the chat client, improving consistency across views and avoiding duplicate cache setup.

* **Chores**
  * Bumped `stream-chat` to a newer patch version in the main project and example packages.
  * Updated package manager configuration to explicitly allow `stream-chat`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->