### PR TITLE
fix(renderText): recognize uppercase URL schemes

### DIFF
--- a/src/components/Message/renderText/__tests__/renderText.test.tsx
+++ b/src/components/Message/renderText/__tests__/renderText.test.tsx
@@ -28,6 +28,14 @@ describe(`renderText`, () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('linkifies a URL with an uppercase scheme like a lowercase one', () => {
+    const Markdown = renderText('see HTTPS://en.wikipedia.org/wiki/Apple');
+    render(Markdown);
+    const link = screen.getByRole('link', { name: 'en.wikipedia.org/wiki/Apple' });
+    expect(link).toHaveClass('str-chat__message-url-link');
+    expect(link).toHaveAttribute('href', 'HTTPS://en.wikipedia.org/wiki/Apple');
+  });
+
   it('handles the special case where user name matches to an e-mail pattern - 1', () => {
     const Markdown = renderText(
       'Hello @username@email.com, is username@email.com your @primary e-mail?',

--- a/src/components/Message/renderText/componentRenderers/Anchor.tsx
+++ b/src/components/Message/renderText/componentRenderers/Anchor.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 export const Anchor = ({ children, href }: ComponentProps<'a'>) => {
   const isEmail = href?.startsWith('mailto:');
-  const isUrl = href?.startsWith('http');
+  const isUrl = href?.toLowerCase().startsWith('http');
 
   if (!href || (!isEmail && !isUrl)) return <>{children}</>;
 

--- a/src/components/Message/renderText/regex.ts
+++ b/src/components/Message/renderText/regex.ts
@@ -2,7 +2,7 @@ export function escapeRegExp(text: string) {
   return text.replace(/[-[\]{}()*+?.,/\\^$|#]/g, '\\$&');
 }
 
-export const detectHttp = /(http(s?):\/\/)?(www\.)?/;
+export const detectHttp = /(http(s?):\/\/)?(www\.)?/i;
 
 // Regexes are hoisted to module scope so they are compiled once rather than on
 // every call. `codeRegex`/`regexMdLinks` are only used with `String#match`


### PR DESCRIPTION
## Summary

URLs written with an uppercase scheme (e.g. `HTTPS://example.com`) were rendered incorrectly in message text:

- The anchor was emitted **without** the `str-chat__message-url-link` class, so the link looked like plain, unstyled text (effectively "not recognized as a link").
- The scheme was **not stripped** from the displayed text, so users saw `HTTPS://example.com` instead of `example.com`.

The lowercase equivalent (`https://example.com`) renders correctly, so the bug is purely about case sensitivity in two helpers.

## Root cause

Two case-sensitive helpers in the `renderText` pipeline:

1. **`componentRenderers/Anchor.tsx`** decided whether to apply the link class with `href?.startsWith('http')`. An `HTTPS://` href fails this check, so `isUrl` was `false` and the `str-chat__message-url-link` class was dropped.
2. **`regex.ts`** strips the scheme for display text via `detectHttp = /(http(s?):\/\/)?(www\.)?/`. Without the `i` flag it doesn't match `HTTPS://`, so the scheme stayed in the display text.

`linkifyjs` (which detects the URL) and `react-markdown` (which renders it) are both already case-insensitive, so they are not at fault — they correctly identify and preserve the uppercase-scheme URL. The display/styling layer was the only case-sensitive part.

## The fix

```diff
- const isUrl = href?.startsWith('http');
+ const isUrl = href?.toLowerCase().startsWith('http');
```

```diff
- export const detectHttp = /(http(s?):\/\/)?(www\.)?/;
+ export const detectHttp = /(http(s?):\/\/)?(www\.)?/i;
```

Both changes are minimal and preserve the existing behavior for lowercase schemes.

## Reproduction

Before the fix:

- `https://en.wikipedia.org/wiki/Apple` -> styled link, display text `en.wikipedia.org/wiki/Apple`
- `HTTPS://en.wikipedia.org/wiki/Apple` -> unstyled `<a>` (no `str-chat__message-url-link`), display text `HTTPS://en.wikipedia.org/wiki/Apple`

After the fix, the uppercase variant renders identically to the lowercase one: a styled link with the scheme stripped from the display text, while the `href` keeps its original casing.

## Tests

Added a regression test in `renderText.test.tsx` asserting that `"see HTTPS://en.wikipedia.org/wiki/Apple"` produces an anchor with:

- class `str-chat__message-url-link`
- `href="HTTPS://en.wikipedia.org/wiki/Apple"` (original casing preserved)
- link text `en.wikipedia.org/wiki/Apple` (scheme stripped)

The test fails on `master` (the input renders as plain text with no anchor) and passes with this change. The full `renderText` suite (61 tests) passes; no existing snapshots changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URLs with uppercase or mixed-case schemes are now detected and linked correctly.
  * Link rendering now treats URL schemes case-insensitively, improving consistency for pasted links.
  * Added test coverage for uppercase URL matching and link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->