### PR TITLE
fix(MessageList): don't count thread replies toward channel unread UI state

### DIFF
--- a/src/components/MessageList/hooks/__tests__/useMarkRead.test.tsx
+++ b/src/components/MessageList/hooks/__tests__/useMarkRead.test.tsx
@@ -504,6 +504,87 @@ describe('useMarkRead', () => {
       expect(setChannelUnreadUiState).not.toHaveBeenCalled();
     });
 
+    it.each([
+      [
+        'message list is not scrolled to the bottom',
+        { isMessageListScrolledToBottom: false },
+      ],
+      ['channel was marked unread', { wasMarkedUnread: true }],
+    ])(
+      'should not increase channel unread UI count for thread messages when %s',
+      async (_, paramsOverride) => {
+        const {
+          channels: [channel],
+          client,
+        } = await initClientWithChannels();
+
+        await render({
+          channel,
+          client,
+          params: { ...shouldMarkReadParams, ...paramsOverride },
+        });
+
+        await act(() => {
+          dispatchMessageNewEvent(client, generateMessage({ parent_id: 'X' }), channel);
+        });
+
+        expect(setChannelUnreadUiState).not.toHaveBeenCalled();
+        expect(markRead).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should not increase channel unread UI count for thread messages when document is hidden', async () => {
+      const {
+        channels: [channel],
+        client,
+      } = await initClientWithChannels();
+
+      await render({
+        channel,
+        client,
+        params: shouldMarkReadParams,
+      });
+
+      const docHiddenSpy = vi.spyOn(document, 'hidden', 'get').mockReturnValueOnce(true);
+      await act(() => {
+        dispatchMessageNewEvent(client, generateMessage({ parent_id: 'X' }), channel);
+      });
+
+      expect(setChannelUnreadUiState).not.toHaveBeenCalled();
+      expect(markRead).not.toHaveBeenCalled();
+      docHiddenSpy.mockRestore();
+    });
+
+    it('should increase channel unread UI count for thread messages with show_in_channel enabled when not scrolled to the bottom', async () => {
+      let channelUnreadUiStateCb: (prev?: ChannelUnreadUiState) => ChannelUnreadUiState;
+      setChannelUnreadUiState.mockImplementationOnce(
+        (cb) => (channelUnreadUiStateCb = cb),
+      );
+      const {
+        channels: [channel],
+        client,
+      } = await initClientWithChannels();
+
+      await render({
+        channel,
+        client,
+        params: { ...shouldMarkReadParams, isMessageListScrolledToBottom: false },
+      });
+
+      await act(() => {
+        dispatchMessageNewEvent(
+          client,
+          generateMessage({ parent_id: 'X', show_in_channel: true }),
+          channel,
+        );
+      });
+
+      expect(setChannelUnreadUiState).toHaveBeenCalledTimes(1);
+      const channelUnreadUiState = channelUnreadUiStateCb();
+      expect(channelUnreadUiState.unread_messages).toBe(1);
+      expect(markRead).not.toHaveBeenCalled();
+    });
+
     it('should mark channel read for thread messages with event.show_in_channel enabled', async () => {
       const {
         channels: [channel],

--- a/src/components/MessageList/hooks/useMarkRead.ts
+++ b/src/components/MessageList/hooks/useMarkRead.ts
@@ -54,6 +54,10 @@ export const useMarkRead = ({
       const mainChannelUpdated =
         !event.message?.parent_id || event.message?.show_in_channel;
 
+      // Thread replies that are not shown in the channel must not affect the
+      // main channel's unread UI state (count / notification).
+      if (!mainChannelUpdated) return;
+
       if (!isMessageListScrolledToBottom || wasMarkedUnread || document.hidden) {
         setChannelUnreadUiState((prev) => {
           const previousUnreadCount = prev?.unread_messages ?? 0;
@@ -71,7 +75,7 @@ export const useMarkRead = ({
             unread_messages: previousUnreadCount + 1,
           };
         });
-      } else if (mainChannelUpdated && shouldMarkRead()) {
+      } else if (shouldMarkRead()) {
         markRead();
       }
     };


### PR DESCRIPTION
### Problem
Posting a reply into a thread could surface the `UnreadMessagesNotification` in the **main** `MessageList`. `handleMessageNew` incremented `channelUnreadUiState.unread_messages` for every `message.new` event when the list was scrolled up, marked unread, or the tab was hidden — including pure thread replies that don't render in the main list. With no `UnreadMessagesSeparator` present, the notification then popped.

### Fix
Early-return from `handleMessageNew` when the event doesn't update the main channel (`parent_id` set and not `show_in_channel`), so thread-only replies never touch the channel's unread UI state. Replies with `show_in_channel: true` still increment correctly.

Thread unread indicators are unaffected — they come from stream-chat's separate `ThreadState` store, and the notification is `!threadList`-gated.

### Tests
Added regression coverage for the three increment triggers (scrolled-up, marked-unread, document-hidden) with a thread reply, plus a positive `show_in_channel` case. Verified the new tests fail without the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread count handling for thread replies so messages that aren’t shown in the channel no longer incorrectly increase unread counts or trigger read updates.
  * Hidden tabs and non-bottom scroll states now behave more consistently, avoiding unexpected read status changes.
  * Thread replies shown in the channel now update unread state correctly when the list isn’t at the bottom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->