### PR TITLE
chore: add release-v15 rc prerelease branch to semantic-release config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,6 +3,10 @@
     {
       "name": "master",
       "channel": "latest"
+    },
+    {
+      "name": "release-v15",
+      "prerelease": "rc"
     }
   ],
   "plugins": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for a new pre-release release line so version 15 builds can be published as release candidates.
  * Kept the existing stable release path unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->