### PR TITLE
fix(ChannelList): make channel list and thread list width app-driven

### DIFF
--- a/src/components/ChannelList/styling/ChannelList.scss
+++ b/src/components/ChannelList/styling/ChannelList.scss
@@ -11,7 +11,7 @@
   --str-chat__channel-list-transition-offset: 8px;
 
   /* Default desktop width of the channel list. Override to match custom layouts. */
-  --str-chat__channel-list-width: 30%;
+  --str-chat__channel-list-width: 100%;
 
   /* Default mobile overlay width of the channel list. Override to match custom layouts. */
   --str-chat__channel-list-mobile-width: 100%;

--- a/src/components/Threads/ThreadList/styling/ThreadList.scss
+++ b/src/components/Threads/ThreadList/styling/ThreadList.scss
@@ -10,8 +10,11 @@
   --str-chat__thread-list-transition-offset: var(
     --str-chat__channel-list-transition-offset
   );
-  --str-chat__thread-list-width: var(--str-chat__channel-list-width);
-  --str-chat__thread-list-mobile-width: var(--str-chat__channel-list-mobile-width);
+  /* Default desktop width of the thread list. Override to match custom layouts. */
+  --str-chat__thread-list-width: 100%;
+
+  /* Default mobile overlay width of the thread list. Override to match custom layouts. */
+  --str-chat__thread-list-mobile-width: 100%;
 }
 
 .str-chat__thread-list-container {


### PR DESCRIPTION
### 🎯 Goal

The SDK shouldn't hold strict opinions about how wide the channel list (and thread list) sidebars are — that's a layout decision the parent app owns. Previously `--str-chat__channel-list-width` defaulted to `30%`, effectively dictating a desktop two-pane ratio out of the box. This makes the sidebar width app-driven: the SDK defaults to filling available space, and the app constrains it via the CSS variable (as the vite example already does with its own layout token).

### 🛠 Implementation details

- **`ChannelList.scss`** — change the default `--str-chat__channel-list-width` from `30%` → `100%`. The channel list is `flex: 0 0 var(--str-chat__channel-list-width)`, so apps drive the width by overriding the variable (not the `width` property, since a non-`auto` `flex-basis` wins in a flex row).
- **`ThreadList.scss`** — decouple `--str-chat__thread-list-width` and `--str-chat__thread-list-mobile-width` from the channel-list tokens. They previously resolved to `var(--str-chat__channel-list-width)` / `var(--str-chat__channel-list-mobile-width)`, which meant sizing the channel list silently resized the thread list too. They now have their own independent `100%` defaults, so each sidebar is sized independently.
- Transition tokens (`duration`/`easing`/`offset`) remain shared — those are animation consistency, not width, and are unchanged.

**Notes / compatibility**

- Behavioral default change: an app relying on the old built-in `30%` desktop sidebar will now see a full-width channel list until it sets `--str-chat__channel-list-width` itself.
- Mobile is unaffected — the mobile breakpoint already forces a `100%` absolutely-positioned overlay with `min-width: 0`.
- Examples that already override the variable (`examples/vite`, tutorial shell) are unaffected. `yarn build-styling` compiles cleanly.

### 🎨 UI Changes

No screenshots attached — this is a CSS custom-property default change with no markup changes. Visible effect: without an app-provided width override, the desktop channel list renders full-width (fills its flex container) instead of the previous `30%` sidebar. Apps set `--str-chat__channel-list-width` (and now optionally `--str-chat__thread-list-width` independently) to restore a fixed/percentage sidebar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated default chat channel list sizing on desktop to use the full available width.
  * Adjusted thread list sizing defaults so both desktop and mobile views now start at full width, making custom layouts easier to override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->