### PR TITLE
ci: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ env:
   BUILD_CACHE_KEY: ${{ github.sha }}-dist
 
 permissions:
-  actions: write
   contents: read
   pull-requests: read
 
@@ -31,6 +30,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     name: Build & Validate
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ on:
 
 env:
   BUILD_CACHE_KEY: ${{ github.sha }}-dist
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pr-title:
     name: Validate PR Title

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -12,7 +12,7 @@ env:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   compressed-size:

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -10,6 +10,10 @@ on:
 env:
   NODE_OPTIONS: --max_old_space_size=4096
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   compressed-size:
     name: Compressed Size


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **6** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to use clearer, scoped permission settings.
  * Restricted automation to read-only access for pull request checks where possible, while preserving required write access for CI tasks.
  * Improved consistency and security across repository automation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->