### PR TITLE
fix: custom doUploadRequest permission adjustments

### DIFF
--- a/examples/tutorial/package.json
+++ b/examples/tutorial/package.json
@@ -16,7 +16,7 @@
     "emoji-mart": "^5.6.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "stream-chat": "^9.49.0",
+    "stream-chat": "^9.50.2",
     "stream-chat-react": "workspace:^"
   },
   "devDependencies": {

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -16,7 +16,7 @@
     "modern-normalize": "^3.0.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "stream-chat": "^9.49.0",
+    "stream-chat": "^9.50.2",
     "stream-chat-react": "workspace:^"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "modern-normalize": "^3.0.1",
     "react": "^19.0.0 || ^18.0.0 || ^17.0.0",
     "react-dom": "^19.0.0 || ^18.0.0 || ^17.0.0",
-    "stream-chat": "^9.49.0"
+    "stream-chat": "^9.50.2"
   },
   "peerDependenciesMeta": {
     "@breezystack/lamejs": {
@@ -184,7 +184,7 @@
     "react-dom": "^19.2.6",
     "sass": "^1.100.0",
     "semantic-release": "^25.0.3",
-    "stream-chat": "^9.49.0",
+    "stream-chat": "^9.50.2",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4",
     "vite": "^8.1.3",

--- a/src/components/MessageComposer/AttachmentSelector/AttachmentSelector.tsx
+++ b/src/components/MessageComposer/AttachmentSelector/AttachmentSelector.tsx
@@ -343,7 +343,6 @@ export const AttachmentSelector = ({
   const { t } = useTranslationContext();
   const { ContextMenu: ContextMenuComponent = ContextMenu, Modal = GlobalModal } =
     useComponentContext();
-  const { channelCapabilities } = useChannelStateContext();
   const messageComposer = useMessageComposerController();
   const isCooldownActive = useIsCooldownActive();
   const { command } = useStateStore(
@@ -434,7 +433,7 @@ export const AttachmentSelector = ({
   return (
     <AttachmentSelectorContextProvider value={{ fileInput }}>
       <div className='str-chat__attachment-selector' {...inertProps}>
-        {channelCapabilities['upload-file'] && <UploadFileInput ref={setFileInput} />}
+        <UploadFileInput ref={setFileInput} />
         <AttachmentSelectorButton
           {...buttonProps}
           aria-expanded={menuDialogIsOpen}

--- a/src/components/MessageComposer/hooks/useAttachmentManagerState.ts
+++ b/src/components/MessageComposer/hooks/useAttachmentManagerState.ts
@@ -14,6 +14,8 @@ export const useAttachmentManagerState = () => {
     availableUploadSlots: attachmentManager.availableUploadSlots,
     blockedUploadsCount: attachmentManager.blockedUploadsCount,
     failedUploadsCount: attachmentManager.failedUploadsCount,
+    hasAvailableUploadSlots: attachmentManager.hasAvailableUploadSlots,
+    hasCustomDoUploadRequest: attachmentManager.hasCustomDoUploadRequest,
     isUploadEnabled: attachmentManager.isUploadEnabled,
     pendingUploadsCount: attachmentManager.pendingUploadsCount,
     successfulUploadsCount: attachmentManager.successfulUploadsCount,

--- a/src/components/ReactFileUtilities/UploadButton.tsx
+++ b/src/components/ReactFileUtilities/UploadButton.tsx
@@ -6,8 +6,6 @@ import React, { forwardRef, useCallback, useMemo } from 'react';
 import { useHandleFileChangeWrapper } from './utils';
 import { useMessageComposerContext, useTranslationContext } from '../../context';
 import { useMessageComposerController } from '../MessageComposer/hooks/useMessageComposerController';
-import { useAttachmentManagerState } from '../MessageComposer/hooks/useAttachmentManagerState';
-import { useIsCooldownActive } from '../MessageComposer/hooks/useIsCooldownActive';
 import { useStateStore } from '../../store';
 import type { MessageComposerConfig } from 'stream-chat';
 import type { PartialSelected } from '../../types/types';
@@ -43,12 +41,10 @@ export const UploadFileInput = forwardRef(function UploadFileInput(
   const { textareaRef } = useMessageComposerContext();
   const messageComposer = useMessageComposerController();
   const { attachmentManager } = messageComposer;
-  const { isUploadEnabled } = useAttachmentManagerState();
   const { acceptedFiles, maxNumberOfFilesPerMessage } = useStateStore(
     messageComposer.configState,
     attachmentManagerConfigStateSelector,
   );
-  const isCooldownActive = useIsCooldownActive();
   const id = useMemo(() => nanoid(), []);
 
   const onFileChange = useCallback(
@@ -65,7 +61,6 @@ export const UploadFileInput = forwardRef(function UploadFileInput(
       accept={acceptedFiles?.join(',')}
       aria-label={t('aria/File upload')}
       data-testid='file-input'
-      disabled={!isUploadEnabled || isCooldownActive}
       id={id}
       multiple={maxNumberOfFilesPerMessage > 1}
       {...props}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,7 +2079,7 @@ __metadata:
     emoji-mart: "npm:^5.6.0"
     react: "npm:^19.2.6"
     react-dom: "npm:^19.2.6"
-    stream-chat: "npm:^9.49.0"
+    stream-chat: "npm:^9.50.2"
     stream-chat-react: "workspace:^"
     typescript: "npm:^6.0.3"
     vite: "npm:^8.1.3"
@@ -2105,7 +2105,7 @@ __metadata:
     react: "npm:^19.2.6"
     react-dom: "npm:^19.2.6"
     sass: "npm:^1.100.0"
-    stream-chat: "npm:^9.49.0"
+    stream-chat: "npm:^9.50.2"
     stream-chat-react: "workspace:^"
     typescript: "npm:^6.0.3"
     vite: "npm:^8.1.3"
@@ -10106,7 +10106,7 @@ __metadata:
     remark-parse: "npm:^11.0.0"
     sass: "npm:^1.100.0"
     semantic-release: "npm:^25.0.3"
-    stream-chat: "npm:^9.49.0"
+    stream-chat: "npm:^9.50.2"
     typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.59.4"
     unified: "npm:^11.0.5"
@@ -10124,7 +10124,7 @@ __metadata:
     modern-normalize: ^3.0.1
     react: ^19.0.0 || ^18.0.0 || ^17.0.0
     react-dom: ^19.0.0 || ^18.0.0 || ^17.0.0
-    stream-chat: ^9.49.0
+    stream-chat: ^9.50.2
   dependenciesMeta:
     "@parcel/watcher":
       built: true
@@ -10150,9 +10150,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"stream-chat@npm:^9.49.0":
-  version: 9.49.0
-  resolution: "stream-chat@npm:9.49.0"
+"stream-chat@npm:^9.50.2":
+  version: 9.50.2
+  resolution: "stream-chat@npm:9.50.2"
   dependencies:
     "@types/jsonwebtoken": "npm:^9.0.8"
     "@types/ws": "npm:^8.18.1"
@@ -10168,7 +10168,7 @@ __metadata:
       built: true
     husky:
       built: true
-  checksum: 10c0/2fceb2434d69523b09b9c6419ab46f2c181aa2ef0b269ed388ce53254f8a4c618eb14ead46d2ae5245c2070c33ab35d33ac1c3671610774503da8a160d71e985
+  checksum: 10c0/5ddd07124f74538f8fc3f9b875e928e60b854d8c85736d0af0692e7fbae58d27f6d1683f36c274b2ff7c78ad5980e28d3bf050f482e670d7fbf3886e01bcca4d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 🎯 Goal

Ref: https://getstream.slack.com/archives/C02R5UCGN6N/p1784023573649669
Relies on: GetStream/stream-chat-js#1800


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-upload availability by basing upload enablement on the message composer’s configured file limits.
  * Made the multi-action attachment UI consistently display the file upload option, even when channel capability details are unavailable.
  * Updated upload control behavior to better reflect current attachment slot availability and upload-request handling.
* **Chores**
  * Updated the underlying `stream-chat` dependency version (main and example apps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->