### PR TITLE
feat: localized unread count

### DIFF
--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -302,7 +302,20 @@ const ChannelInner = (
       throttle(
         async (options?: MarkReadWrapperOptions) => {
           const { updateChannelUiUnreadState = true } = options ?? {};
-          if (channel.disconnected || !channelConfig?.read_events) {
+          if (channel.disconnected) return;
+
+          if (!channelConfig?.read_events && client.options.isLocalUnreadCountEnabled) {
+            const event = channel.markReadLocally();
+
+            if (updateChannelUiUnreadState && event) {
+              lastRead.current = new Date();
+              _setChannelUnreadUiState({
+                last_read: lastRead.current,
+                last_read_message_id: event.last_read_message_id,
+                unread_messages: 0,
+              });
+            }
+
             return;
           }
 
@@ -316,7 +329,7 @@ const ChannelInner = (
               );
             } else {
               const markReadResponse = await channel.markRead();
-              //  markReadResponse.event can be null in case of a user that is not a member of a channel being marked read
+              // markReadResponse.event can be null in case of a user that is not a member of a channel being marked read
               // in that case event is null and we should not set unread UI
               if (updateChannelUiUnreadState && markReadResponse?.event) {
                 _setChannelUnreadUiState({
@@ -343,6 +356,7 @@ const ChannelInner = (
       activeUnreadHandler,
       channel,
       channelConfig,
+      client,
       doMarkReadRequest,
       setChannelUnreadUiState,
       t,
@@ -381,7 +395,7 @@ const ChannelInner = (
       if (mainChannelUpdated) {
         if (
           document.hidden &&
-          channelConfig?.read_events &&
+          (channelConfig?.read_events || client.options.isLocalUnreadCountEnabled) &&
           !channel.muteStatus().muted
         ) {
           const unread = channel.countUnread(lastRead.current);

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -315,13 +315,9 @@ const ChannelInner = (
                 unread_messages: 0,
               });
             }
+          } else if (channelConfig?.read_events) {
+            lastRead.current = new Date();
 
-            return;
-          }
-
-          lastRead.current = new Date();
-
-          try {
             if (doMarkReadRequest) {
               doMarkReadRequest(
                 channel,
@@ -339,14 +335,12 @@ const ChannelInner = (
                 });
               }
             }
+          }
 
-            if (activeUnreadHandler) {
-              activeUnreadHandler(0, originalTitle.current);
-            } else if (originalTitle.current) {
-              document.title = originalTitle.current;
-            }
-          } catch (e) {
-            console.error(t('Failed to mark channel as read'));
+          if (activeUnreadHandler) {
+            activeUnreadHandler(0, originalTitle.current);
+          } else if (originalTitle.current) {
+            document.title = originalTitle.current;
           }
         },
         500,
@@ -359,7 +353,6 @@ const ChannelInner = (
       client,
       doMarkReadRequest,
       setChannelUnreadUiState,
-      t,
     ],
   );
 
@@ -438,6 +431,10 @@ const ChannelInner = (
       });
     }
 
+    if (event.type === 'message.read_locally') {
+      return;
+    }
+
     if (event.type === 'notification.mark_unread')
       _setChannelUnreadUiState((prev) => {
         if (!(event.last_read_at && event.user)) return prev;
@@ -504,7 +501,11 @@ const ChannelInner = (
         if (client.user?.id && channel.state.read[client.user.id]) {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { user, ...ownReadState } = channel.state.read[client.user.id];
-          _setChannelUnreadUiState(ownReadState);
+          _setChannelUnreadUiState((existingState) => {
+            // only set the initial state here, do not override existing
+            if (existingState) return existingState;
+            return ownReadState;
+          });
         }
         /**
          * TODO: maybe pass last_read to the countUnread method to get proper value

--- a/src/components/ChannelListItem/ChannelListItem.tsx
+++ b/src/components/ChannelListItem/ChannelListItem.tsx
@@ -119,23 +119,18 @@ export const ChannelListItem = (props: ChannelListItemProps) => {
 
   useEffect(() => {
     const handleEvent = (event: Event) => {
-      if (!event.cid) return setUnread(0);
-      if (channel.cid === event.cid) setUnread(0);
-    };
-
-    client.on('notification.mark_read', handleEvent);
-    return () => client.off('notification.mark_read', handleEvent);
-  }, [channel, client]);
-
-  useEffect(() => {
-    const handleEvent = (event: Event) => {
       if (channel.cid !== event.cid) return;
       if (event.user?.id !== client.user?.id) return;
       setUnread(channel.countUnread());
     };
+
+    client.on('notification.mark_read', handleEvent);
     channel.on('notification.mark_unread', handleEvent);
+    channel.on('message.read_locally', handleEvent);
     return () => {
+      client.off('notification.mark_read', handleEvent);
       channel.off('notification.mark_unread', handleEvent);
+      channel.off('message.read_locally', handleEvent);
     };
   }, [channel, client]);
 

--- a/src/components/ChannelListItem/hooks/useMessageDeliveryStatus.ts
+++ b/src/components/ChannelListItem/hooks/useMessageDeliveryStatus.ts
@@ -92,10 +92,12 @@ export const useMessageDeliveryStatus = ({
 
     channel.on('message.delivered', handleMessageDelivered);
     channel.on('message.read', handleMarkRead);
+    channel.on('message.read_locally', handleMarkRead);
 
     return () => {
       channel.off('message.delivered', handleMessageDelivered);
       channel.off('message.read', handleMarkRead);
+      channel.off('message.read_locally', handleMarkRead);
     };
   }, [channel, client, isOwnMessage, lastMessage]);
 

--- a/src/components/MessageList/hooks/useMarkRead.ts
+++ b/src/components/MessageList/hooks/useMarkRead.ts
@@ -37,7 +37,11 @@ export const useMarkRead = ({
   const { channel } = useChannelStateContext('useMarkRead');
 
   useEffect(() => {
-    if (!channel.getConfig()?.read_events) return;
+    const unreadNotificationSupported =
+      channel.getConfig()?.read_events || client.options.isLocalUnreadCountEnabled;
+
+    if (!unreadNotificationSupported) return;
+
     const shouldMarkRead = () =>
       !document.hidden &&
       !wasMarkedUnread &&


### PR DESCRIPTION
### 🎯 Goal

Ref: GetStream/stream-chat-react-native#3679


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread-count accuracy for channels using local unread tracking.
  * Marking messages as read now updates channel lists and delivery indicators consistently.
  * Read-state updates no longer incorrectly reset unread counts.
  * Hidden-tab unread indicators now stay synchronized with local unread activity.
  * Read actions continue to work when server read events are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->