### PR TITLE
perf(build): emit ESM per source module so consumers can tree-shake

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,7 +422,8 @@ See `examples/vite/src/index.scss` for the reference layer setup.
 - `stream-chat-react/emojis` — Emoji picker plugin (`src/plugins/Emojis/`)
 - `stream-chat-react/mp3-encoder` — MP3 encoding for voice messages (`src/plugins/encoders/mp3.ts`)
 
-Vite config: no minification, sourcemaps enabled, all deps externalized. Target: ES2020.
+Vite config: no minification, sourcemaps enabled, all deps externalized. Target: ES2022
+(inherited from `tsconfig.lib.json`'s `compilerOptions.target`, so the two never drift).
 
 ### i18n System
 

--- a/package.json
+++ b/package.json
@@ -259,11 +259,6 @@
       "built": true
     }
   },
-  "browserslist": [
-    ">0.2%",
-    "not ie <= 11",
-    "not op_mini all"
-  ],
   "packageManager": "yarn@4.15.0",
   "workspaces": [
     "examples/*"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
         'slot-layout': resolve(__dirname, './src/plugins/SlotLayout/index.tsx'),
       },
     },
+    // `yarn build` already wipes dist up front via `yarn clean`
     emptyOutDir: false,
     outDir: 'dist',
     minify: false,
@@ -45,6 +46,11 @@ export default defineConfig({
           chunkFileNames: `${dir}/[name].[hash].${extension}`,
           entryFileNames: `${dir}/[name].${extension}`,
           hashCharacters: 'hex',
+          // Emit the ESM build as one file per source module. Consumer bundlers
+          // drop whole modules (guided by our package.json `sideEffects`) before
+          // they attempt statement-level elimination. The CJS build stays chunked,
+          // as CJS is not tree-shaken by consumers either way.
+          preserveModules: format === 'es',
         };
       }),
     },


### PR DESCRIPTION
### Goal

The ESM build collapsed the whole source tree into a single chunk, which defeats tree-shaking in consumer apps: importing only `Chat` pulled 405kB.

### Implementation details

- `preserveModules` on the ESM output only, so `dist/es` mirrors `src` one file per module (11 files -> 516). Consumer bundlers drop unused modules first, guided by our `sideEffects` field, and only then attempt statement-level elimination -- a merged chunk leaves nothing to drop. CJS stays chunked, since consumers do not tree-shake CJS.
- Entry filenames and the `package.json` exports map are unchanged.
- Measured consumer bundles: `import { Chat }` 405.1 -> 33.1 kB, `Chat + Channel + MessageList` 451.7 -> 332.6 kB, `stream-chat-react/slot-layout` 426.1 -> 160.4 kB. Whole-SDK import unchanged. Published package grows ~199kB raw.
- Dropped the `browserslist` field: nothing in the repo reads it and its query contradicted the ES2022 output floor. Fixed the stale ES2020 target note in CLAUDE.md and recorded why `emptyOutDir` must stay `false`.

Verified: `yarn build` green, 231 test files / 2825 tests pass, ESM and CJS entries both load with 611 exports and a single shared `ChatContext`.

### UI Changes

None, build output only.
